### PR TITLE
feat(config): add extends chain resolution algorithm

### DIFF
--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -674,6 +674,13 @@ func resolveExtendsChain(templatePath string) ([]*ImageTemplate, error) {
 			return nil, fmt.Errorf("invalid extends path: %w", err)
 		}
 
+		// The lexical guard in resolveExtendsParentPath cannot see through directory
+		// symlinks inside the child directory. Re-check containment against the fully
+		// symlink-resolved paths so a symlink like child/link -> /outside cannot escape.
+		if err := verifyResolvedContainment(currentPath, parentPath); err != nil {
+			return nil, err
+		}
+
 		if cycleStart, exists := visited[canonicalPath(parentPath)]; exists {
 			cyclePaths := append([]string{}, displayPaths[cycleStart:]...)
 			cyclePaths = append(cyclePaths, parentPath)
@@ -725,6 +732,32 @@ func resolveExtendsParentPath(childTemplatePath, extendsRef string) (string, err
 	}
 
 	return parentPath, nil
+}
+
+// verifyResolvedContainment ensures that, after resolving all symlinks, the parent
+// template still lives within the child template's directory. This defends against
+// directory symlinks inside the child directory that the lexical check in
+// resolveExtendsParentPath cannot detect. Both paths must already exist.
+func verifyResolvedContainment(childTemplatePath, parentPath string) error {
+	resolvedChildDir, err := filepath.EvalSymlinks(filepath.Dir(childTemplatePath))
+	if err != nil {
+		return fmt.Errorf("failed to resolve child template directory: %w", err)
+	}
+
+	resolvedParent, err := filepath.EvalSymlinks(parentPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve extends path %s: %w", parentPath, err)
+	}
+
+	rel, err := filepath.Rel(resolvedChildDir, resolvedParent)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate resolved extends path %s: %w", parentPath, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("extends path escapes child template's directory: %s", parentPath)
+	}
+
+	return nil
 }
 
 // canonicalPath returns a symlink-resolved absolute path for use as a stable

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/security"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/slice"
 )
 
@@ -613,6 +614,150 @@ func validateAndFixImmutabilityConfig(template *ImageTemplate) {
 		template.SystemConfig.Immutability.Enabled = false
 		log.Infof("Immutability has been disabled due to missing hash partition.")
 	}
+}
+
+func resolveExtendsChain(templatePath string) ([]*ImageTemplate, error) {
+	startPath, err := filepath.Abs(filepath.Clean(templatePath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve template path: %w", err)
+	}
+
+	leafToRoot := make([]*ImageTemplate, 0)
+	displayPaths := make([]string, 0)
+	// visited maps a canonicalized (symlink-resolved) path to its position in the
+	// chain. Canonicalizing guards against directory symlinks aliasing two distinct
+	// textual paths to the same file, which would otherwise evade cycle detection.
+	visited := make(map[string]int)
+	currentPath := startPath
+
+	var leafTarget TargetInfo
+
+	for {
+		tmpl, err := LoadTemplate(currentPath, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load template in extends chain: %w", err)
+		}
+
+		if len(leafToRoot) == 0 {
+			leafTarget = tmpl.Target
+		} else if !targetsMatch(leafTarget, tmpl.Target) {
+			level := len(leafToRoot)
+			return nil, fmt.Errorf(
+				"extends target mismatch at level %d: child targets %s but parent targets %s",
+				level,
+				formatTarget(leafTarget),
+				formatTarget(tmpl.Target),
+			)
+		}
+
+		visited[canonicalPath(currentPath)] = len(displayPaths)
+		leafToRoot = append(leafToRoot, tmpl)
+		displayPaths = append(displayPaths, currentPath)
+
+		if strings.TrimSpace(tmpl.Extends) == "" {
+			break
+		}
+
+		parentPath, err := resolveExtendsParentPath(currentPath, tmpl.Extends)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := os.Stat(parentPath); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("extends path not found: %s", parentPath)
+			}
+			return nil, fmt.Errorf("failed to access extends path %s: %w", parentPath, err)
+		}
+
+		if _, err := security.CheckSymlink(parentPath, security.RejectSymlinks); err != nil {
+			return nil, fmt.Errorf("invalid extends path: %w", err)
+		}
+
+		if cycleStart, exists := visited[canonicalPath(parentPath)]; exists {
+			cyclePaths := append([]string{}, displayPaths[cycleStart:]...)
+			cyclePaths = append(cyclePaths, parentPath)
+			return nil, fmt.Errorf("circular extends detected: %s", formatCyclePath(cyclePaths))
+		}
+
+		currentPath = parentPath
+	}
+
+	depth := len(leafToRoot) - 1
+	if depth > 4 {
+		log.Warnf("extends chain depth %d exceeds recommended maximum of 4", depth)
+	}
+
+	rootToLeaf := make([]*ImageTemplate, len(leafToRoot))
+	for i := range leafToRoot {
+		rootToLeaf[len(leafToRoot)-1-i] = leafToRoot[i]
+	}
+
+	return rootToLeaf, nil
+}
+
+func resolveExtendsParentPath(childTemplatePath, extendsRef string) (string, error) {
+	childPath, err := filepath.Abs(filepath.Clean(childTemplatePath))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve child template path: %w", err)
+	}
+
+	childDir := filepath.Dir(childPath)
+
+	var parentCandidate string
+	if filepath.IsAbs(extendsRef) {
+		parentCandidate = filepath.Clean(extendsRef)
+	} else {
+		parentCandidate = filepath.Clean(filepath.Join(childDir, extendsRef))
+	}
+
+	parentPath, err := filepath.Abs(parentCandidate)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve extends path %q: %w", extendsRef, err)
+	}
+
+	rel, err := filepath.Rel(childDir, parentPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate extends path %q: %w", extendsRef, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("extends path escapes child template's directory: %s", parentPath)
+	}
+
+	return parentPath, nil
+}
+
+// canonicalPath returns a symlink-resolved absolute path for use as a stable
+// cycle-detection key. It falls back to the cleaned absolute path when the file
+// cannot be resolved (e.g. it does not exist yet), so callers always receive a
+// deterministic key.
+func canonicalPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	if abs, err := filepath.Abs(filepath.Clean(path)); err == nil {
+		return abs
+	}
+	return filepath.Clean(path)
+}
+
+func targetsMatch(a, b TargetInfo) bool {
+	return a.OS == b.OS &&
+		a.Dist == b.Dist &&
+		a.Arch == b.Arch &&
+		a.ImageType == b.ImageType
+}
+
+func formatTarget(target TargetInfo) string {
+	return fmt.Sprintf("%s/%s/%s/%s", target.OS, target.Dist, target.Arch, target.ImageType)
+}
+
+func formatCyclePath(paths []string) string {
+	names := make([]string, 0, len(paths))
+	for _, p := range paths {
+		names = append(names, filepath.Base(p))
+	}
+	return strings.Join(names, " -> ")
 }
 
 // LoadAndMergeTemplate loads a user template and merges it with the appropriate default config

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -1094,6 +1094,42 @@ func TestResolveExtendsChainPathTraversalAttack(t *testing.T) {
 	}
 }
 
+func TestResolveExtendsChainDirectorySymlinkEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	childDir := filepath.Join(tmpDir, "child")
+	outsideDir := filepath.Join(tmpDir, "outside")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("failed to create child directory: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("failed to create outside directory: %v", err)
+	}
+
+	// Parent template lives outside the child directory.
+	writeChainTemplate(t, filepath.Join(outsideDir, "parent.yml"), "parent", "", target)
+
+	// A directory symlink inside the child directory points outside it. The lexical
+	// guard sees "link/parent.yml" (no ".."), so only the symlink-resolved
+	// containment check can catch this escape.
+	if err := os.Symlink(outsideDir, filepath.Join(childDir, "link")); err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+
+	leafPath := filepath.Join(childDir, "leaf.yml")
+	writeChainTemplate(t, leafPath, "leaf", "link/parent.yml", target)
+
+	_, err := resolveExtendsChain(leafPath)
+	if err == nil {
+		t.Fatalf("resolveExtendsChain() expected directory-symlink escape rejection")
+	}
+
+	if !strings.Contains(err.Error(), "extends path escapes child template's directory") {
+		t.Errorf("error = %q, want contains path escape message", err.Error())
+	}
+}
+
 func TestResolveExtendsChainDepthWarning(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 )
 
 func TestNewDefaultConfigLoader(t *testing.T) {
@@ -911,5 +915,254 @@ func TestLoadProviderRepoConfigArchVariants(t *testing.T) {
 				t.Logf("Expected error for arch %s: %v", arch, err)
 			}
 		})
+	}
+}
+
+func TestResolveExtendsChainSingleExtends(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	basePath := filepath.Join(tmpDir, "base.yml")
+	leafPath := filepath.Join(tmpDir, "leaf.yml")
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	writeChainTemplate(t, basePath, "base", "", target)
+	writeChainTemplate(t, leafPath, "leaf", "base.yml", target)
+
+	chain, err := resolveExtendsChain(leafPath)
+	if err != nil {
+		t.Fatalf("resolveExtendsChain() err = %v", err)
+	}
+
+	if len(chain) != 2 {
+		t.Fatalf("len(chain) = %d, want 2", len(chain))
+	}
+	if chain[0].Image.Name != "base" {
+		t.Errorf("chain[0].Image.Name = %q, want %q", chain[0].Image.Name, "base")
+	}
+	if chain[1].Image.Name != "leaf" {
+		t.Errorf("chain[1].Image.Name = %q, want %q", chain[1].Image.Name, "leaf")
+	}
+}
+
+func TestResolveExtendsChainMultiLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	rootPath := filepath.Join(tmpDir, "root.yml")
+	level1Path := filepath.Join(tmpDir, "level1.yml")
+	level2Path := filepath.Join(tmpDir, "level2.yml")
+	leafPath := filepath.Join(tmpDir, "leaf.yml")
+
+	writeChainTemplate(t, rootPath, "root", "", target)
+	writeChainTemplate(t, level1Path, "level1", "root.yml", target)
+	writeChainTemplate(t, level2Path, "level2", "level1.yml", target)
+	writeChainTemplate(t, leafPath, "leaf", "level2.yml", target)
+
+	chain, err := resolveExtendsChain(leafPath)
+	if err != nil {
+		t.Fatalf("resolveExtendsChain() err = %v", err)
+	}
+
+	if len(chain) != 4 {
+		t.Fatalf("len(chain) = %d, want 4", len(chain))
+	}
+
+	wantOrder := []string{"root", "level1", "level2", "leaf"}
+	for i, want := range wantOrder {
+		if chain[i].Image.Name != want {
+			t.Errorf("chain[%d].Image.Name = %q, want %q", i, chain[i].Image.Name, want)
+		}
+	}
+}
+
+func TestResolveExtendsChainCycleDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	aPath := filepath.Join(tmpDir, "a.yml")
+	bPath := filepath.Join(tmpDir, "b.yml")
+
+	writeChainTemplate(t, aPath, "a", "b.yml", target)
+	writeChainTemplate(t, bPath, "b", "a.yml", target)
+
+	_, err := resolveExtendsChain(aPath)
+	if err == nil {
+		t.Fatalf("resolveExtendsChain() expected cycle error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "circular extends detected") {
+		t.Errorf("error = %q, want contains %q", errMsg, "circular extends detected")
+	}
+	if !strings.Contains(errMsg, "a.yml -> b.yml -> a.yml") {
+		t.Errorf("error = %q, want contains %q", errMsg, "a.yml -> b.yml -> a.yml")
+	}
+}
+
+func TestResolveExtendsChainCycleViaDirectorySymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	realDir := filepath.Join(tmpDir, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("failed to create real directory: %v", err)
+	}
+
+	// A directory symlink that lives inside the child directory and points back to
+	// it. Reaching a.yml through "self/" yields a different textual path for the
+	// same file. Without canonicalization the self-extends cycle would go
+	// undetected; the traversal guard still permits it because it stays within the
+	// child directory.
+	if err := os.Symlink(realDir, filepath.Join(realDir, "self")); err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+
+	aReal := filepath.Join(realDir, "a.yml")
+	writeChainTemplate(t, aReal, "a", "self/a.yml", target)
+
+	_, err := resolveExtendsChain(aReal)
+	if err == nil {
+		t.Fatalf("resolveExtendsChain() expected cycle error via directory symlink")
+	}
+
+	if !strings.Contains(err.Error(), "circular extends detected") {
+		t.Errorf("error = %q, want contains %q", err.Error(), "circular extends detected")
+	}
+}
+
+func TestResolveExtendsChainTargetMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent.yml")
+	leafPath := filepath.Join(tmpDir, "leaf.yml")
+
+	parentTarget := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "aarch64", ImageType: "raw"}
+	leafTarget := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	writeChainTemplate(t, parentPath, "parent", "", parentTarget)
+	writeChainTemplate(t, leafPath, "leaf", "parent.yml", leafTarget)
+
+	_, err := resolveExtendsChain(leafPath)
+	if err == nil {
+		t.Fatalf("resolveExtendsChain() expected target mismatch error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "extends target mismatch at level") {
+		t.Errorf("error = %q, want contains %q", errMsg, "extends target mismatch at level")
+	}
+}
+
+func TestResolveExtendsChainMissingParent(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	leafPath := filepath.Join(tmpDir, "leaf.yml")
+	writeChainTemplate(t, leafPath, "leaf", "missing.yml", target)
+
+	_, err := resolveExtendsChain(leafPath)
+	if err == nil {
+		t.Fatalf("resolveExtendsChain() expected missing parent error")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "extends path not found:") {
+		t.Errorf("error = %q, want contains %q", errMsg, "extends path not found:")
+	}
+}
+
+func TestResolveExtendsChainPathTraversalAttack(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	childDir := filepath.Join(tmpDir, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("failed to create child directory: %v", err)
+	}
+
+	leafPath := filepath.Join(childDir, "leaf.yml")
+	writeChainTemplate(t, leafPath, "leaf", "../parent.yml", target)
+
+	_, err := resolveExtendsChain(leafPath)
+	if err == nil {
+		t.Fatalf("resolveExtendsChain() expected traversal rejection")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "extends path escapes child template's directory") {
+		t.Errorf("error = %q, want contains path escape message", errMsg)
+	}
+}
+
+func TestResolveExtendsChainDepthWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"}
+
+	fileNames := []string{"root.yml", "l1.yml", "l2.yml", "l3.yml", "l4.yml", "leaf.yml"}
+	for i := range fileNames {
+		path := filepath.Join(tmpDir, fileNames[i])
+		extends := ""
+		if i > 0 {
+			extends = fileNames[i-1]
+		}
+		writeChainTemplate(t, path, strings.TrimSuffix(fileNames[i], ".yml"), extends, target)
+	}
+
+	var buf bytes.Buffer
+	prevWriter := logger.ReplaceStderrWriter(&buf)
+	t.Cleanup(func() {
+		logger.ReplaceStderrWriter(prevWriter)
+	})
+
+	chain, err := resolveExtendsChain(filepath.Join(tmpDir, "leaf.yml"))
+	if err != nil {
+		t.Fatalf("resolveExtendsChain() err = %v", err)
+	}
+
+	if len(chain) != 6 {
+		t.Fatalf("len(chain) = %d, want 6", len(chain))
+	}
+
+	if !strings.Contains(buf.String(), "extends chain depth 5 exceeds recommended maximum of 4") {
+		t.Errorf("log output did not contain depth warning, got %q", buf.String())
+	}
+}
+
+func writeChainTemplate(t *testing.T, path, imageName, extends string, target TargetInfo) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create template directory: %v", err)
+	}
+
+	var builder strings.Builder
+	if extends != "" {
+		builder.WriteString("extends: ")
+		builder.WriteString("\"")
+		builder.WriteString(extends)
+		builder.WriteString("\"\n")
+	}
+
+	builder.WriteString("image:\n")
+	builder.WriteString("  name: ")
+	builder.WriteString(imageName)
+	builder.WriteString("\n")
+	builder.WriteString("  version: \"1.0.0\"\n")
+	builder.WriteString("target:\n")
+	builder.WriteString("  os: ")
+	builder.WriteString(target.OS)
+	builder.WriteString("\n")
+	builder.WriteString("  dist: ")
+	builder.WriteString(target.Dist)
+	builder.WriteString("\n")
+	builder.WriteString("  arch: ")
+	builder.WriteString(target.Arch)
+	builder.WriteString("\n")
+	builder.WriteString("  imageType: ")
+	builder.WriteString(target.ImageType)
+	builder.WriteString("\n")
+
+	if err := os.WriteFile(path, []byte(builder.String()), 0o644); err != nil {
+		t.Fatalf("failed to write template file %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
#### Merge Checklist

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description

Implements the extends chain resolution algorithm from `docs/architecture/adr-template-extends.md`. Adds `resolveExtendsChain(templatePath string) ([]*ImageTemplate, error)` in `internal/config/merge.go`, which walks `extends` references from leaf to root, loads every template, and validates the chain.

Behavior:
- Resolves `extends` paths relative to each child template's directory
- Returns an ordered slice `[root, level1, ..., leaf]`
- **Cycle detection** via a visited-set keyed on canonicalized (symlink-resolved) paths; rejects `A -> B -> A` with `circular extends detected: a.yml -> b.yml -> a.yml`
- **Target match validation**: all templates must share OS/dist/arch/imageType; mismatch returns `extends target mismatch at level N: ...`
- **Path safety**: `filepath.Clean`, symlink rejection via `security.RejectSymlinks`, and rejection of paths escaping the child template's directory
- **Missing parent**: returns `extends path not found: <resolved-path>`
- **Depth warning**: logs a warning when the chain exceeds 4 extends levels (no hard rejection, per ADR)

Note: `resolveExtendsChain` is not yet wired into `LoadAndMergeTemplate`  that integration is intentionally deferred to a follow-up PR.

- Cycle detection is keyed on `filepath.EvalSymlinks`-canonicalized paths, closing a gap where a directory symlink could alias two textual paths to the same file and evade detection. Covered by `TestResolveExtendsChainCycleViaDirectorySymlink`.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

Unit tests in `internal/config/merge_test.go`:
- Single extends
- Multi-level chain (3+ levels)
- Cycle detection
- Directory-symlink cycle aliasing (hardening)
- Target mismatch
- Missing parent
- Path traversal attack
- Depth warning (captured via logger output)

All resolver tests and the full `go test ./internal/config/` suite pass; `go vet ./internal/config/...` is clean.