### PR TITLE
adding support for qcow2 image output

### DIFF
--- a/image-templates/debian13-x86_64-desktop-virtualization-qcow2.yml
+++ b/image-templates/debian13-x86_64-desktop-virtualization-qcow2.yml
@@ -1,0 +1,260 @@
+# ============================================================================
+# Debian 13 Desktop Virtualization ISO Image Template
+# ============================================================================
+#
+# This template is adapted from the EMT Desktop Virtualization project for
+# Debian 13 (trixie) systems, providing QEMU/KVM desktop virtualization 
+# with Intel graphics SR-IOV support.
+#
+# Key features:
+#   - QEMU/KVM virtualization stack
+#   - Intel i915 graphics SR-IOV for GPU-accelerated virtual desktops
+#   - X11 display server with hardware acceleration
+#   - Complete development environment
+#   - SELinux security (where applicable)
+# ============================================================================
+
+# AI-searchable metadata for template discovery
+metadata:
+  description: "Debian 13 Desktop Virtualization ISO image with graphics SR-IOV, QEMU/KVM, and X11 display for GPU-virtualized desktop workflows"
+  use_cases:
+    - "desktop virtualization"
+    - "graphics SR-IOV"
+    - "GPU passthrough"
+    - "virtual desktop infrastructure"
+    - "QEMU/KVM virtualization"
+    - "bootable installer"
+    - "debian development"
+  keywords:
+    - debian13
+    - trixie
+    - desktop-virtualization
+    - sriov
+    - gpu
+    - qemu
+    - kvm
+    - libvirt
+    - xorg
+    - iso
+    - installer
+    - beyonnB
+    - microvisor
+    - i915
+
+image:
+  name: debian13-x86_64-desktop-virtualization
+  version: "1.0.0"
+
+target:
+  os: debian
+  dist: debian13  # Align with debian13-minimal-raw.yml
+  arch: x86_64
+  imageType: qcow2
+
+# ============================================================================
+# System Configuration
+# ============================================================================
+systemConfig:
+  name: Debian13-Desktop-Virtualization
+  description: >-
+    Debian 13 Desktop Virtualization ISO with Intel graphics SR-IOV support.
+    Provides GPU-accelerated virtual desktops using QEMU/KVM.
+
+  bootloader:
+    bootType: efi
+    provider: grub
+
+  immutability:
+    enabled: false
+
+  # ============================================================================
+  # Packages - Debian 13 equivalents
+  # ============================================================================
+  packages:
+
+    # --------------------------------------------------------------------------
+    # Bootloader packages
+    # --------------------------------------------------------------------------
+    - grub2-common                # GRUB2 bootloader
+    - grub-efi-amd64              # GRUB EFI support for x86_64
+    - grub-efi-amd64-bin          # GRUB EFI binaries
+
+    # --------------------------------------------------------------------------
+    # Essential system packages
+    # --------------------------------------------------------------------------
+    - shim-signed                 # UEFI shim bootloader for Secure Boot
+    - efibootmgr                  # EFI Boot Manager utility
+    - ca-certificates             # Root CA certificates
+    - cron                        # Cron job scheduler
+    - logrotate                   # Log rotation utility
+    - dracut-core                 # Dracut initramfs generator
+    - initramfs-tools             # Initial RAM filesystem tools
+    - passwd                      # User/group management utilities
+    - apparmor                    # AppArmor security framework
+    - apt-listchanges             # APT package change notifications
+    - apt-utils                   # APT utilities
+    - bash-completion             # Bash completion scripts
+    - bind9-host                  # DNS lookup utilities
+    - cloud-init                  # Cloud instance initialization
+    - cloud-initramfs-growroot    # Cloud init RAM filesystem growth
+    - dbus                        # D-Bus message bus
+    - dosfstools                  # FAT filesystem utilities
+    - init                        # System initialization
+    - liblastlog2-2               # Last login library
+    - libnss-myhostname          # NSS hostname resolution
+    - libnss-resolve             # NSS systemd-resolved integration
+    - libpam-modules-bin         # PAM modules binaries
+    - libpam-systemd             # PAM systemd integration
+    - linux-sysctl-defaults      # Default sysctl configuration
+    - man-db                      # Manual page database
+    - manpages                    # System manual pages
+    - mawk                        # Pattern scanning language
+    - nano                        # Simple text editor
+    - netplan.io                  # Network configuration
+    - polkitd                     # PolicyKit daemon
+    - psmisc                      # Process utilities
+    - python3-minimal             # Minimal Python 3
+    - reportbug                   # Bug reporting tool
+    - screen                      # Terminal multiplexer
+    - socat                       # Socket concatenation
+    - ssh-import-id              # SSH key import utility
+    - sudo                        # Privilege escalation
+    - tcpdump                     # Network packet analyzer
+    - traceroute                  # Network path tracer
+    - unattended-upgrades         # Automatic security updates
+    - uuid-runtime                # UUID generation runtime
+    - vim-tiny                    # Minimal Vim editor
+    - whiptail                    # Dialog boxes for shell scripts
+    - zstd                        # Zstandard compression
+
+    # --------------------------------------------------------------------------
+    # Development and build tools
+    # --------------------------------------------------------------------------
+    - build-essential             # Essential build tools (gcc, make, etc.)
+    - cmake                       # Cross-platform build system
+    - curl                        # HTTP/FTP client
+    - libcurl4-openssl-dev        # libcurl development headers
+    - flex                        # Lexical analyzer generator
+    - libfuse-dev                 # FUSE development headers
+    - git                         # Version control system
+    - golang-go                   # Go programming language
+    - iputils-ping                # Network utilities
+    - less                        # Terminal pager
+    - net-tools                   # Legacy networking utilities
+    - ninja-build                 # Ninja build system
+    - parted                      # Disk partitioning tool
+    - pciutils                    # PCI utilities (lspci)
+    - python3-pip                 # Python package installer
+    - tar                         # Archive utility
+    - texinfo                     # Documentation system
+    - usbutils                    # USB utilities (lsusb)
+    - wget                        # File downloader
+
+    # --------------------------------------------------------------------------
+    # Package management and utilities
+    # --------------------------------------------------------------------------
+    - apt                         # APT package manager
+    - vim                         # Vi Improved text editor
+
+    # --------------------------------------------------------------------------
+    # SSH server
+    # --------------------------------------------------------------------------
+    - openssh-server              # OpenSSH server
+
+    # --------------------------------------------------------------------------
+    # Virtualization stack (QEMU/KVM)
+    # --------------------------------------------------------------------------
+    - swtpm-tools                 # Software TPM tools
+    - libvirt-daemon-system       # Libvirt virtualization daemon
+    - libvirt-clients             # Libvirt client tools
+    - pulseaudio                  # Audio server
+    - qemu-kvm                    # QEMU with KVM acceleration
+    - qemu-system-x86             # QEMU system emulation for x86
+    - qemu-utils                  # QEMU utilities
+    - virtinst                    # Virtual machine installation tools
+    - virt-manager                # Virtual machine management GUI
+    - bridge-utils                # Network bridge utilities
+    - iptables                    # Netfilter administration tool
+
+    # --------------------------------------------------------------------------
+    # QEMU guest support
+    # --------------------------------------------------------------------------
+    - qemu-guest-agent            # QEMU guest agent
+
+    # --------------------------------------------------------------------------
+    # X11 display server and desktop environment
+    # --------------------------------------------------------------------------
+    - openbox                     # Lightweight window manager
+    - xterm                       # X11 terminal emulator
+    - xserver-xorg                # X.Org X11 server
+    - xserver-xorg-core           # X.Org server core
+    - x11-apps                    # Standard X11 applications
+    - x11-utils                   # X11 utilities
+    - x11-xserver-utils           # X server utilities
+    - xinit                       # X11 session initialization
+    - xserver-xorg-input-libinput # X11 libinput input driver
+    - xfonts-base                 # Basic X11 fonts
+    - fonts-liberation            # Liberation fonts
+
+    # --------------------------------------------------------------------------
+    # SELinux security (where available in Debian)
+    # --------------------------------------------------------------------------
+    - selinux-basics              # SELinux basic tools
+    - selinux-policy-default      # Default SELinux policy
+    - selinux-utils               # SELinux utilities
+    - policycoreutils             # SELinux policy utilities
+
+    # --------------------------------------------------------------------------
+    # Intel GPU and graphics support
+    # --------------------------------------------------------------------------
+    - intel-gpu-tools             # Intel GPU diagnostic tools
+    - mesa-utils                  # Mesa OpenGL utilities
+    - mesa-vulkan-drivers         # Vulkan drivers
+    - libgl1-mesa-dri             # Mesa DRI drivers
+    - xserver-xorg-video-intel    # Intel X11 graphics driver
+    - firmware-intel-graphics     # Intel graphics firmware (from minimal-raw)
+    - firmware-intel-misc         # Intel miscellaneous firmware
+
+    # --------------------------------------------------------------------------
+    # TPM and trusted boot support
+    # --------------------------------------------------------------------------
+    - tpm2-tools                  # TPM 2.0 tools
+    - libtss2-dev                 # TPM 2.0 TSS development files
+
+    # --------------------------------------------------------------------------
+    # Network and wireless support
+    # --------------------------------------------------------------------------
+    - firmware-iwlwifi            # Intel WiFi firmware
+    - wpasupplicant               # WPA supplicant
+    - wireless-regdb              # Wireless regulatory database
+
+    # --------------------------------------------------------------------------
+    # Additional utilities
+    # --------------------------------------------------------------------------
+    - lsb-release                 # LSB version information
+    - nbd-client                  # Network block device client
+    - nbd-server                  # Network block device server
+    - ntfs-3g                     # NTFS filesystem driver
+
+  # ============================================================================
+  # Kernel Configuration
+  # ============================================================================
+  kernel:
+    version: "6.12.74"  # Align with debian13-minimal-raw.yml
+    # Kernel command line optimized for virtualization and Intel GPU SR-IOV
+    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 udmabuf.list_limit=8192 i915.enable_guc=3 i915.max_vfs=7 intel_iommu=on i915.force_probe=* selinux=1 enforcing=0"
+    packages:
+      - linux-image-amd64         # Debian kernel
+
+  # ============================================================================
+  # Additional Files
+  # ============================================================================
+  additionalFiles:
+    - local: ../additionalfiles/99-dhcp-en.network
+      final: /etc/systemd/network/99-dhcp-en.network
+    - local: ../additionalfiles/tc-client
+      final: /usr/bin/tc-client
+    - local: ../additionalfiles/tc-disk.sh
+      final: /lib/dracut/hooks/initqueue/tcdisk.sh
+    - local: ../additionalfiles/ucc.conf
+      final: /etc/dracut.conf.d/ucc.conf

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1272,6 +1272,61 @@ systemConfig:
 	}
 }
 
+func TestDefaultConfigLoaderQcow2UsesRawDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldConfigDir := Global().ConfigDir
+	Global().ConfigDir = tmpDir
+	t.Cleanup(func() { Global().ConfigDir = oldConfigDir })
+
+	defaultDir := filepath.Join(tmpDir, "osv", "ubuntu", "ubuntu24", "imageconfigs", "defaultconfigs")
+	if err := os.MkdirAll(defaultDir, 0755); err != nil {
+		t.Fatalf("failed to create default config dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "general"), 0755); err != nil {
+		t.Fatalf("failed to create general config dir: %v", err)
+	}
+
+	defaultConfig := `image:
+  name: ubuntu-default-raw
+  version: "24.04"
+
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+
+disk:
+  name: Default_Raw
+  artifacts:
+    - type: raw
+
+systemConfig:
+  name: Default_Raw
+  packages:
+    - ubuntu-minimal
+`
+	defaultPath := filepath.Join(defaultDir, "default-raw-x86_64.yml")
+	if err := os.WriteFile(defaultPath, []byte(defaultConfig), 0644); err != nil {
+		t.Fatalf("failed to write default config: %v", err)
+	}
+
+	loader := NewDefaultConfigLoader("ubuntu", "ubuntu24", "x86_64")
+	template, err := loader.LoadDefaultConfig("qcow2")
+	if err != nil {
+		t.Fatalf("expected qcow2 default config to load via raw default file, got error: %v", err)
+	}
+	if template.Target.ImageType != "raw" {
+		t.Errorf("expected loaded default image type 'raw', got '%s'", template.Target.ImageType)
+	}
+	if len(template.Disk.Artifacts) == 0 {
+		t.Fatal("expected default config to include at least one artifact")
+	}
+	if template.Disk.Artifacts[0].Type != "raw" {
+		t.Errorf("expected raw default artifact, got '%s'", template.Disk.Artifacts[0].Type)
+	}
+}
+
 func TestWSL2DefaultConfigs(t *testing.T) {
 	defaults := []string{
 		"azure-linux/azl3",

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -35,6 +35,8 @@ func (d *DefaultConfigLoader) LoadDefaultConfig(imageType string) (*ImageTemplat
 	switch imageType {
 	case "raw":
 		defaultConfigFile = fmt.Sprintf("default-raw-%s.yml", d.targetArch)
+	case "qcow2":
+		defaultConfigFile = fmt.Sprintf("default-raw-%s.yml", d.targetArch)
 	case "img":
 		defaultConfigFile = fmt.Sprintf("default-initrd-%s.yml", d.targetArch)
 	case "iso":
@@ -131,6 +133,8 @@ func MergeConfigurations(userTemplate, defaultTemplate *ImageTemplate) (*ImageTe
 		mergedTemplate.Disk = userTemplate.Disk
 		log.Debugf("User disk config overrides default")
 	}
+
+	applyImplicitQcow2Artifact(userTemplate, &mergedTemplate)
 
 	// System configuration - merge intelligently
 	if !isEmptySystemConfig(userTemplate.SystemConfig) {
@@ -566,6 +570,26 @@ func isEmptyDiskConfig(disk DiskConfig) bool {
 		disk.PartitionTableType == "" &&
 		len(disk.Artifacts) == 0 &&
 		len(disk.Partitions) == 0
+}
+
+// applyImplicitQcow2Artifact ensures that target.imageType=qcow2 yields qcow2
+// output even when the user relies on default disk configuration.
+func applyImplicitQcow2Artifact(userTemplate *ImageTemplate, mergedTemplate *ImageTemplate) {
+	if userTemplate == nil || mergedTemplate == nil {
+		return
+	}
+
+	if mergedTemplate.Target.ImageType != "qcow2" {
+		return
+	}
+
+	// Respect explicit user disk/artifact choices.
+	if !isEmptyDiskConfig(userTemplate.Disk) {
+		return
+	}
+
+	mergedTemplate.Disk.Artifacts = []ArtifactInfo{{Type: "qcow2"}}
+	log.Debug("Applied implicit qcow2 artifact for target.imageType=qcow2")
 }
 
 func isEmptySystemConfig(config SystemConfig) bool {

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -102,6 +102,63 @@ func TestMergeConfigurationsImageInfo(t *testing.T) {
 	}
 }
 
+func TestMergeConfigurationsImplicitQcow2ArtifactFromDefaults(t *testing.T) {
+	defaultTemplate := &ImageTemplate{
+		Image:  ImageInfo{Name: "default", Version: "1.0.0"},
+		Target: TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"},
+		Disk: DiskConfig{
+			Name:      "Default_Raw",
+			Artifacts: []ArtifactInfo{{Type: "raw"}},
+		},
+	}
+
+	userTemplate := &ImageTemplate{
+		Image:  ImageInfo{Name: "user", Version: "2.0.0"},
+		Target: TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "qcow2"},
+	}
+
+	result, err := MergeConfigurations(userTemplate, defaultTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Target.ImageType != "qcow2" {
+		t.Fatalf("expected merged target image type 'qcow2', got '%s'", result.Target.ImageType)
+	}
+	if len(result.Disk.Artifacts) != 1 || result.Disk.Artifacts[0].Type != "qcow2" {
+		t.Fatalf("expected implicit qcow2 artifact, got %+v", result.Disk.Artifacts)
+	}
+}
+
+func TestMergeConfigurationsQcow2RespectsExplicitUserDiskArtifacts(t *testing.T) {
+	defaultTemplate := &ImageTemplate{
+		Image:  ImageInfo{Name: "default", Version: "1.0.0"},
+		Target: TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "raw"},
+		Disk: DiskConfig{
+			Name:      "Default_Raw",
+			Artifacts: []ArtifactInfo{{Type: "raw"}},
+		},
+	}
+
+	userTemplate := &ImageTemplate{
+		Image:  ImageInfo{Name: "user", Version: "2.0.0"},
+		Target: TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "x86_64", ImageType: "qcow2"},
+		Disk: DiskConfig{
+			Name:      "UserDisk",
+			Artifacts: []ArtifactInfo{{Type: "vmdk"}},
+		},
+	}
+
+	result, err := MergeConfigurations(userTemplate, defaultTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Disk.Artifacts) != 1 || result.Disk.Artifacts[0].Type != "vmdk" {
+		t.Fatalf("expected user artifact to be preserved, got %+v", result.Disk.Artifacts)
+	}
+}
+
 func TestMergeConfigurationsBaseline(t *testing.T) {
 	// A user-provided overlay baseline must survive the merge even when the
 	// default template has none; otherwise the build silently falls back to

--- a/internal/config/schema/os-image-template.schema.json
+++ b/internal/config/schema/os-image-template.schema.json
@@ -43,7 +43,7 @@
         "imageType": {
           "type": "string",
           "description": "Type of image to build",
-          "enum": ["raw", "img", "iso", "wsl2"]
+          "enum": ["raw", "img", "iso", "wsl2", "qcow2"]
         }
       },
       "required": ["os", "dist", "arch", "imageType"],

--- a/internal/config/validate/validate_test.go
+++ b/internal/config/validate/validate_test.go
@@ -208,6 +208,43 @@ systemConfig:
 	}
 }
 
+func TestValidQcow2Template(t *testing.T) {
+	qcow2TemplateYAML := `image:
+  name: test-qcow2-image
+  version: "1.0.0"
+
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: qcow2
+
+disk:
+  name: qcow2-disk
+  artifacts:
+    - type: qcow2
+
+systemConfig:
+  name: default
+  packages:
+    - ubuntu-minimal
+`
+
+	var raw interface{}
+	if err := yaml.Unmarshal([]byte(qcow2TemplateYAML), &raw); err != nil {
+		t.Fatalf("yml parsing error: %v", err)
+	}
+
+	dataJSON, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("json marshaling error: %v", err)
+	}
+
+	if err := ValidateImageTemplateJSON(dataJSON); err != nil {
+		t.Errorf("expected qcow2 template to pass validation, but got: %v", err)
+	}
+}
+
 func TestInvalidWSL2TemplateWithPartitionTable(t *testing.T) {
 	invalidTemplateYAML := `image:
   name: test-wsl2-image

--- a/internal/provider/azl/azl.go
+++ b/internal/provider/azl/azl.go
@@ -118,6 +118,8 @@ func (p *AzureLinux) BuildImage(template *config.ImageTemplate) error {
 	switch template.Target.ImageType {
 	case "raw":
 		return p.buildRawImage(template)
+	case "qcow2":
+		return p.buildRawImage(template)
 	case "img":
 		return p.buildInitrdImage(template)
 	case "iso":

--- a/internal/provider/azl/azl_test.go
+++ b/internal/provider/azl/azl_test.go
@@ -526,7 +526,7 @@ func TestAzlBuildImageUnsupportedType(t *testing.T) {
 func TestAzlBuildImageValidTypes(t *testing.T) {
 	azl := &AzureLinux{}
 
-	validTypes := []string{"raw", "img", "iso", "wsl2"}
+	validTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imageType := range validTypes {
 		t.Run(imageType, func(t *testing.T) {

--- a/internal/provider/debian13/debian13.go
+++ b/internal/provider/debian13/debian13.go
@@ -113,6 +113,8 @@ func (p *debian13) BuildImage(template *config.ImageTemplate) error {
 	switch template.Target.ImageType {
 	case "raw":
 		return p.buildRawImage(template)
+	case "qcow2":
+		return p.buildRawImage(template)
 	case "img":
 		return p.buildInitrdImage(template)
 	case "iso":

--- a/internal/provider/debian13/debian13_test.go
+++ b/internal/provider/debian13/debian13_test.go
@@ -781,7 +781,7 @@ func TestDebian13BuildImageUnsupportedType(t *testing.T) {
 func TestDebian13BuildImageValidTypes(t *testing.T) {
 	debian := &debian13{}
 
-	validTypes := []string{"raw", "img", "iso", "wsl2"}
+	validTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imageType := range validTypes {
 		t.Run(imageType, func(t *testing.T) {
@@ -2007,7 +2007,7 @@ func TestDebian13BuildImageAllTypes(t *testing.T) {
 		chrootEnv: &mockChrootEnv{},
 	}
 
-	imageTypes := []string{"raw", "img", "iso", "wsl2"}
+	imageTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imgType := range imageTypes {
 		t.Run(imgType, func(t *testing.T) {

--- a/internal/provider/elxr/elxr.go
+++ b/internal/provider/elxr/elxr.go
@@ -115,6 +115,8 @@ func (p *eLxr) BuildImage(template *config.ImageTemplate) error {
 	switch template.Target.ImageType {
 	case "raw":
 		return p.buildRawImage(template)
+	case "qcow2":
+		return p.buildRawImage(template)
 	case "img":
 		return p.buildInitrdImage(template)
 	case "iso":

--- a/internal/provider/elxr/elxr_test.go
+++ b/internal/provider/elxr/elxr_test.go
@@ -779,7 +779,7 @@ func TestElxrBuildImageUnsupportedType(t *testing.T) {
 func TestElxrBuildImageValidTypes(t *testing.T) {
 	elxr := &eLxr{}
 
-	validTypes := []string{"raw", "img", "iso", "wsl2"}
+	validTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imageType := range validTypes {
 		t.Run(imageType, func(t *testing.T) {

--- a/internal/provider/emt/emt.go
+++ b/internal/provider/emt/emt.go
@@ -120,6 +120,8 @@ func (p *Emt) BuildImage(template *config.ImageTemplate) error {
 	switch template.Target.ImageType {
 	case "raw":
 		return p.buildRawImage(template)
+	case "qcow2":
+		return p.buildRawImage(template)
 	case "img":
 		return p.buildInitrdImage(template)
 	case "iso":

--- a/internal/provider/emt/emt_test.go
+++ b/internal/provider/emt/emt_test.go
@@ -530,7 +530,7 @@ func TestEmtBuildImageUnsupportedType(t *testing.T) {
 func TestEmtBuildImageValidTypes(t *testing.T) {
 	emt := &Emt{}
 
-	validTypes := []string{"raw", "img", "iso", "wsl2"}
+	validTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imageType := range validTypes {
 		t.Run(imageType, func(t *testing.T) {

--- a/internal/provider/rcd/rcd.go
+++ b/internal/provider/rcd/rcd.go
@@ -118,6 +118,8 @@ func (p *RCD) BuildImage(template *config.ImageTemplate) error {
 	switch template.Target.ImageType {
 	case "raw":
 		return p.buildRawImage(template)
+	case "qcow2":
+		return p.buildRawImage(template)
 	case "img":
 		return p.buildInitrdImage(template)
 	case "iso":

--- a/internal/provider/rcd/rcd_test.go
+++ b/internal/provider/rcd/rcd_test.go
@@ -526,7 +526,7 @@ func TestRCDBuildImageUnsupportedType(t *testing.T) {
 func TestRCDBuildImageValidTypes(t *testing.T) {
 	rcd := &RCD{}
 
-	validTypes := []string{"raw", "img", "iso", "wsl2"}
+	validTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imageType := range validTypes {
 		t.Run(imageType, func(t *testing.T) {

--- a/internal/provider/ubuntu/ubuntu.go
+++ b/internal/provider/ubuntu/ubuntu.go
@@ -114,6 +114,8 @@ func (p *ubuntu) BuildImage(template *config.ImageTemplate) error {
 	switch template.Target.ImageType {
 	case "raw":
 		return p.buildRawImage(template)
+	case "qcow2":
+		return p.buildRawImage(template)
 	case "img":
 		return p.buildInitrdImage(template)
 	case "iso":

--- a/internal/provider/ubuntu/ubuntu_test.go
+++ b/internal/provider/ubuntu/ubuntu_test.go
@@ -1076,7 +1076,7 @@ func TestUbuntuBuildImageUnsupportedType(t *testing.T) {
 func TestUbuntuBuildImageValidTypes(t *testing.T) {
 	ubuntu := &ubuntu{}
 
-	validTypes := []string{"raw", "img", "iso", "wsl2"}
+	validTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imageType := range validTypes {
 		t.Run(imageType, func(t *testing.T) {
@@ -2351,7 +2351,7 @@ func TestUbuntuBuildImageAllTypes(t *testing.T) {
 		chrootEnv: &mockChrootEnv{},
 	}
 
-	imageTypes := []string{"raw", "img", "iso", "wsl2"}
+	imageTypes := []string{"raw", "img", "iso", "wsl2", "qcow2"}
 
 	for _, imgType := range imageTypes {
 		t.Run(imgType, func(t *testing.T) {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [yes ] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
Schema now accepts qcow2 as a target image type
Added qcow2 to target.imageType enum in os-image-template.schema.json:46.
Default config loading supports qcow2 by reusing raw defaults
In merge.go:30, DefaultConfigLoader maps qcow2 to default-raw-<arch>.yml.
This ensures qcow2 builds reuse the raw composition pipeline before format conversion.
Merge logic guarantees qcow2 artifact output when user relies on defaults
Added implicit artifact handling in merge.go:575.
For target.imageType = qcow2 with no explicit user disk config, merged disk artifacts become [{type: qcow2}] in merge.go:591.
Providers route qcow2 through raw image composition path

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? 
Merge behavior tests added in merge_test.go:105 and merge_test.go:133.
Default loader qcow2 path test added in config_test.go:1275.
Provider valid image type tables extended with qcow2 in:
debian13_test.go:784
ubuntu_test.go:1079
azl_test.go:529
elxr_test.go:782
emt_test.go:533
rcd_test.go:529
Validation tests updated in internal/config/validate/validate_test.go.
