### PR TITLE
Copy baseline to workspace and attach loop device

### DIFF
--- a/internal/config/baseline_test.go
+++ b/internal/config/baseline_test.go
@@ -67,12 +67,12 @@ func TestValidateBaseline(t *testing.T) {
 			wantNoErr: true,
 		},
 		{
-			name: "overlay accepts http URL source",
+			name: "overlay rejects plain http URL source",
 			baseline: &Baseline{
 				Mode:   BaselineModeOverlay,
 				Source: &BaselineSource{URL: "http://example.com/u.raw"},
 			},
-			wantNoErr: true,
+			wantErr: "must use https",
 		},
 		{
 			name: "overlay rejects URL written into path field",
@@ -91,12 +91,36 @@ func TestValidateBaseline(t *testing.T) {
 			wantErr: "use baseline.source.url for remote images",
 		},
 		{
-			name: "overlay rejects non-http URL scheme",
+			name: "overlay rejects non-https URL scheme",
 			baseline: &Baseline{
 				Mode:   BaselineModeOverlay,
 				Source: &BaselineSource{URL: "file:///tmp/u.raw"},
 			},
-			wantErr: "must use http or https",
+			wantErr: "must use https",
+		},
+		{
+			name: "overlay rejects https URL with no host",
+			baseline: &Baseline{
+				Mode:   BaselineModeOverlay,
+				Source: &BaselineSource{URL: "https://"},
+			},
+			wantErr: "must include a host",
+		},
+		{
+			name: "overlay rejects https URL with query but no host",
+			baseline: &Baseline{
+				Mode:   BaselineModeOverlay,
+				Source: &BaselineSource{URL: "https://?q=x"},
+			},
+			wantErr: "must include a host",
+		},
+		{
+			name: "overlay rejects https URL with fragment but no host",
+			baseline: &Baseline{
+				Mode:   BaselineModeOverlay,
+				Source: &BaselineSource{URL: "https://#frag"},
+			},
+			wantErr: "must include a host",
 		},
 		{
 			name: "overlay rejects source with neither path nor url",
@@ -179,6 +203,28 @@ func TestValidateBaseline(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBaselineSourceValidateNormalizesWhitespace(t *testing.T) {
+	t.Run("path is trimmed in place", func(t *testing.T) {
+		s := &BaselineSource{Path: "  /tmp/u.raw\n"}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.Path != "/tmp/u.raw" {
+			t.Errorf("Path = %q, want trimmed %q", s.Path, "/tmp/u.raw")
+		}
+	})
+
+	t.Run("url is trimmed in place", func(t *testing.T) {
+		s := &BaselineSource{URL: "  https://example.com/u.raw  "}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.URL != "https://example.com/u.raw" {
+			t.Errorf("URL = %q, want trimmed %q", s.URL, "https://example.com/u.raw")
+		}
+	})
 }
 
 func TestIsOverlayMode(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1134,7 +1134,7 @@ func (t *ImageTemplate) validateBaseline() error {
 		if t.Baseline.Source == nil {
 			return fmt.Errorf("baseline: source is required when mode is %q", BaselineModeOverlay)
 		}
-		if err := t.Baseline.Source.validate(); err != nil {
+		if err := t.Baseline.Source.Validate(); err != nil {
 			return err
 		}
 		format := t.Baseline.Source.Format
@@ -1156,13 +1156,21 @@ func (t *ImageTemplate) validateBaseline() error {
 	return nil
 }
 
-// validate enforces that exactly one of Path or URL is set, and that a URL
-// uses an http(s) scheme. Integrity verification of the downloaded image is
-// intentionally deferred. Local paths are taken from the host build system
-// as-is; URLs are downloaded (over TLS) before the overlay runs.
-func (s *BaselineSource) validate() error {
+// Validate enforces that exactly one of Path or URL is set, and that a URL uses
+// the https scheme. Plain http is rejected so the baseline is always fetched
+// over TLS, matching the https-only policy used for other remote downloads in
+// this tool (e.g. RPM packages). Integrity verification of the downloaded image
+// is intentionally deferred. Local paths are taken from the host build system
+// as-is; https URLs are downloaded before the overlay runs.
+func (s *BaselineSource) Validate() error {
+	// Normalize by trimming surrounding whitespace and persist it back onto the
+	// struct so callers (overlay ingestion) use the same value that was
+	// validated. Otherwise a padded path/URL could pass validation here but then
+	// fail with a confusing error during copy/download.
 	path := strings.TrimSpace(s.Path)
 	rawURL := strings.TrimSpace(s.URL)
+	s.Path = path
+	s.URL = rawURL
 
 	switch {
 	case path == "" && rawURL == "":
@@ -1180,8 +1188,17 @@ func (s *BaselineSource) validate() error {
 		if err != nil {
 			return fmt.Errorf("baseline.source.url is not a valid URL: %w", err)
 		}
-		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			return fmt.Errorf("baseline.source.url must use http or https (got %q)", parsed.Scheme)
+		// Require https so the baseline is always fetched over TLS. Plain http
+		// offers no integrity or authenticity guarantee for a whole-disk image
+		// and is rejected here, consistent with other remote downloads.
+		if parsed.Scheme != "https" {
+			return fmt.Errorf("baseline.source.url must use https (got %q)", parsed.Scheme)
+		}
+		// Reject a scheme-only URL like "https://" (no host): it passes the
+		// scheme check but would fail later with an opaque download error.
+		// Catching it here gives an immediate, clear message.
+		if parsed.Host == "" {
+			return fmt.Errorf("baseline.source.url must include a host (got %q)", rawURL)
 		}
 	}
 	return nil

--- a/internal/config/schema/os-image-template.schema.json
+++ b/internal/config/schema/os-image-template.schema.json
@@ -471,7 +471,7 @@
     },
     "BaselineSource": {
       "type": "object",
-      "description": "Baseline source. v1 supports a local RAW disk image, referenced by a local path or an http(s) URL. Exactly one of 'path' or 'url' must be set.",
+      "description": "Baseline source. v1 supports a local RAW disk image, referenced by a local path or an https URL. Exactly one of 'path' or 'url' must be set.",
       "properties": {
         "path": {
           "type": "string",
@@ -481,8 +481,9 @@
         },
         "url": {
           "type": "string",
-          "description": "http(s) URL of the baseline RAW disk image; downloaded over TLS before the overlay runs",
-          "minLength": 1
+          "description": "https URL of the baseline RAW disk image; downloaded over TLS before the overlay runs (plain http is rejected)",
+          "minLength": 1,
+          "pattern": "^https://[^/?#]"
         },
         "format": {
           "type": "string",

--- a/internal/image/imagedisc/loopdev.go
+++ b/internal/image/imagedisc/loopdev.go
@@ -2,6 +2,7 @@ package imagedisc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -14,16 +15,28 @@ import (
 type LoopDevInterface interface {
 	LoopSetupDelete(loopDevPath string) error
 	CreateRawImageLoopDev(filePath string, template *config.ImageTemplate) (string, map[string]string, error)
+	AttachImageToLoopDev(imagePath string) (string, []string, error)
 }
 
 type LoopDev struct{}
+
+// canonicalLoopDevPath matches a bare loop device path, e.g. "/dev/loop0" or
+// "/dev/loop12", with no trailing partition suffix or surrounding text. It is
+// used to validate losetup output before that value is interpolated into
+// privileged shell commands.
+var canonicalLoopDevPath = regexp.MustCompile(`^/dev/loop\d+$`)
 
 func NewLoopDev() *LoopDev {
 	return &LoopDev{}
 }
 
 func loopSetupCreate(imagePath string) (string, error) {
-	cmd := fmt.Sprintf("losetup --direct-io=on --show -f -P %s", imagePath)
+	// losetup runs with sudo through a bash -c string. Single-quote the path so
+	// bash performs no expansion on it: strconv.Quote uses double quotes, inside
+	// which $(...), ${...} and backticks still expand, so a crafted work-dir or
+	// image path could trigger command substitution. shell.QuoteArg neutralizes
+	// that by wrapping the value in single quotes.
+	cmd := fmt.Sprintf("losetup --direct-io=on --show -f -P %s", shell.QuoteArg(imagePath))
 	loopDevPath, err := shell.ExecCmd(cmd, true, shell.HostPath, nil)
 	if err != nil {
 		log.Errorf("Losetup failed for %s: %v", imagePath, err)
@@ -31,7 +44,12 @@ func loopSetupCreate(imagePath string) (string, error) {
 	}
 
 	loopDevPath = strings.TrimSpace(loopDevPath)
-	if strings.Contains(loopDevPath, "/dev/loop") {
+	// losetup output is interpolated into later privileged bash -c commands
+	// (partition scan, detach, lsblk, ...). Accept only a canonical loop device
+	// path ("/dev/loopN") via an anchored regex, so a malformed or unexpected
+	// output string can never be propagated into shell execution. A substring
+	// match would let arbitrary surrounding text through.
+	if canonicalLoopDevPath.MatchString(loopDevPath) {
 		log.Infof(fmt.Sprintf("Losetup %s created loopback device at %s\n", imagePath, loopDevPath))
 		return loopDevPath, nil
 	} else {
@@ -51,6 +69,66 @@ func loopSetupCreateEmptyRawDisk(filePath, fileSize string) (string, error) {
 	}
 	log.Errorf("Can't find %s after creating raw file", filePath)
 	return "", fmt.Errorf("can't find %s", filePath)
+}
+
+// AttachImageToLoopDev attaches an already-existing disk image to a loop device
+// with partition scanning enabled (losetup -fP) and returns the loop device path
+// along with its enumerated partition nodes. Unlike CreateRawImageLoopDev it does
+// not create or partition the backing file, so it is safe to use on a baseline
+// image that must not be modified. On partition-enumeration failure the loop
+// device is detached before returning so no loop device is leaked. If that
+// detach itself fails, the device is genuinely leaked: the returned path is the
+// leaked device (non-empty) and the error is annotated with it so the caller can
+// retain the backing file and operators can reclaim the device.
+func (loopDev *LoopDev) AttachImageToLoopDev(imagePath string) (string, []string, error) {
+	if _, err := os.Stat(imagePath); err != nil {
+		return "", nil, fmt.Errorf("cannot access baseline image at %s: %w", imagePath, err)
+	}
+
+	loopDevPath, err := loopSetupCreate(imagePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to attach loop device for %s: %w", imagePath, err)
+	}
+
+	partitions, err := loopDevPartitions(loopDevPath)
+	if err != nil {
+		if detachErr := loopDev.LoopSetupDelete(loopDevPath); detachErr != nil {
+			// Detach also failed: the loop device is leaked. Return the leaked
+			// device path (not "") together with both the enumeration error and
+			// the detach failure, wrapped with the path, so the caller can retain
+			// the backing file and operators can identify and reclaim the device.
+			log.Errorf("Failed to detach loop device %s after partition enumeration failure: %v", loopDevPath, detachErr)
+			return loopDevPath, nil, fmt.Errorf("leaked loop device %s: %w", loopDevPath, errors.Join(err, detachErr))
+		}
+		return "", nil, err
+	}
+
+	return loopDevPath, partitions, nil
+}
+
+// loopDevPartitions returns the partition device nodes of a loop device, e.g.
+// ["/dev/loop0p1", "/dev/loop0p2"]. The base loop device itself is excluded.
+func loopDevPartitions(loopDevPath string) ([]string, error) {
+	// loopDevPath originates from losetup output; single-quote it defensively so
+	// a malformed value is never reinterpreted by the bash -c shell. Single
+	// quotes (via shell.QuoteArg) suppress the $(...)/backtick expansion that
+	// double-quoting (strconv.Quote) would still allow.
+	cmd := fmt.Sprintf("lsblk -prno NAME %s", shell.QuoteArg(loopDevPath))
+	output, err := shell.ExecCmd(cmd, true, shell.HostPath, nil)
+	if err != nil {
+		log.Errorf("Failed to list partitions for loop device %s: %v", loopDevPath, err)
+		return nil, fmt.Errorf("failed to list partitions for loop device %s: %w", loopDevPath, err)
+	}
+
+	var partitions []string
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || name == loopDevPath {
+			continue
+		}
+		partitions = append(partitions, name)
+	}
+	return partitions, nil
 }
 
 func (loopDev *LoopDev) LoopSetupDelete(loopDevPath string) error {

--- a/internal/image/imagedisc/loopdev_test.go
+++ b/internal/image/imagedisc/loopdev_test.go
@@ -31,6 +31,12 @@ func TestLoopSetupCreate(t *testing.T) {
 		{name: "success", output: "/dev/loop7\n"},
 		{name: "command error", cmdErr: fmt.Errorf("losetup failed"), expectError: true, errorContains: "losetup failed"},
 		{name: "unexpected output", output: "not-a-loop-device", expectError: true, errorContains: "failed to create loopback device"},
+		// Substring-containing but non-canonical output must be rejected: the
+		// value is later interpolated into privileged shell commands, so only a
+		// bare "/dev/loopN" path is accepted.
+		{name: "loop path with trailing garbage", output: "/dev/loop7; rm -rf /", expectError: true, errorContains: "failed to create loopback device"},
+		{name: "loop path with partition suffix", output: "/dev/loop7p1", expectError: true, errorContains: "failed to create loopback device"},
+		{name: "loop substring inside other text", output: "prefix /dev/loop7", expectError: true, errorContains: "failed to create loopback device"},
 	}
 
 	for _, tt := range tests {
@@ -98,6 +104,120 @@ func TestLoopSetupDelete(t *testing.T) {
 		err := ld.LoopSetupDelete("/dev/loop8")
 		if err == nil || !strings.Contains(err.Error(), "failed to delete loop device") {
 			t.Fatalf("expected wrapped delete error, got %v", err)
+		}
+	})
+}
+
+func TestLoopDevPartitions(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	t.Run("excludes base device and blanks", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{
+			Pattern: `lsblk -prno NAME '/dev/loop0'`,
+			Output:  "/dev/loop0\n/dev/loop0p1\n/dev/loop0p2\n\n",
+		}})
+		got, err := loopDevPartitions("/dev/loop0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"/dev/loop0p1", "/dev/loop0p2"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("partitions = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("command error", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{
+			Pattern: `lsblk -prno NAME '/dev/loop1'`,
+			Error:   fmt.Errorf("lsblk failed"),
+		}})
+		if _, err := loopDevPartitions("/dev/loop1"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestAttachImageToLoopDev(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	makeImage := func(t *testing.T) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "baseline.raw")
+		if err := os.WriteFile(path, []byte("img"), 0644); err != nil {
+			t.Fatalf("write image: %v", err)
+		}
+		return path
+	}
+
+	t.Run("missing image", func(t *testing.T) {
+		ld := &LoopDev{}
+		if _, _, err := ld.AttachImageToLoopDev("/nonexistent/baseline.raw"); err == nil {
+			t.Fatal("expected error for missing image")
+		}
+	})
+
+	t.Run("success returns partitions", func(t *testing.T) {
+		img := makeImage(t)
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+			{Pattern: "losetup --direct-io=on --show -f -P", Output: "/dev/loop6\n"},
+			{Pattern: `lsblk -prno NAME '/dev/loop6'`, Output: "/dev/loop6\n/dev/loop6p1\n"},
+		})
+		ld := &LoopDev{}
+		dev, parts, err := ld.AttachImageToLoopDev(img)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dev != "/dev/loop6" {
+			t.Fatalf("dev = %q, want /dev/loop6", dev)
+		}
+		if len(parts) != 1 || parts[0] != "/dev/loop6p1" {
+			t.Fatalf("parts = %v, want [/dev/loop6p1]", parts)
+		}
+	})
+
+	t.Run("detaches on partition enumeration failure", func(t *testing.T) {
+		img := makeImage(t)
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+			{Pattern: "losetup --direct-io=on --show -f -P", Output: "/dev/loop5\n"},
+			{Pattern: `lsblk -prno NAME '/dev/loop5'`, Error: fmt.Errorf("lsblk failed")},
+			{Pattern: "losetup -d /dev/loop5", Output: ""}, // cleanup detach must run
+		})
+		ld := &LoopDev{}
+		if _, _, err := ld.AttachImageToLoopDev(img); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("surfaces detach failure alongside enumeration failure", func(t *testing.T) {
+		img := makeImage(t)
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+			{Pattern: "losetup --direct-io=on --show -f -P", Output: "/dev/loop2\n"},
+			{Pattern: `lsblk -prno NAME '/dev/loop2'`, Error: fmt.Errorf("lsblk failed")},
+			// swapoff scan during detach is best-effort; the detach itself fails.
+			{Pattern: "losetup -d /dev/loop2", Error: fmt.Errorf("detach failed")},
+		})
+		ld := &LoopDev{}
+		dev, _, err := ld.AttachImageToLoopDev(img)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		// The leaked loop device path must be returned (not "") so the caller can
+		// retain the backing file and operators can reclaim the device.
+		if dev != "/dev/loop2" {
+			t.Errorf("leaked device path = %q, want /dev/loop2", dev)
+		}
+		// Both the enumeration error and the detach failure (leaked loop device)
+		// must reach the caller so the leak is never silently swallowed.
+		if !strings.Contains(err.Error(), "lsblk failed") {
+			t.Errorf("error must include enumeration failure, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "detach failed") {
+			t.Errorf("error must include detach failure, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "/dev/loop2") {
+			t.Errorf("error must be annotated with leaked device path, got %v", err)
 		}
 	})
 }

--- a/internal/image/overlay/overlay.go
+++ b/internal/image/overlay/overlay.go
@@ -1,0 +1,436 @@
+// Package overlay implements baseline-image ingestion for overlay mode: it copies
+// the user-provided baseline RAW image into the build workspace (never mutating
+// the original), attaches a loop device with partition scanning, and guarantees
+// the loop device is detached on success, failure, or panic.
+//
+// This is the first concrete stage of the overlay build flow. Downstream stages
+// (mount, OS detection, package install) consume the Context populated here.
+package overlay
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/image/imagedisc"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/network"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
+)
+
+var log = logger.Logger()
+
+// baselineCopyName is the fixed filename of the workspace copy of the baseline
+// image. A fixed name keeps the layout predictable regardless of the source
+// path or URL filename.
+const baselineCopyName = "baseline.raw"
+
+// defaultSysConfigName is the workspace path segment used when a template omits
+// systemConfig.name (which is schema-optional). It is a safe, fixed segment so
+// the overlay workspace stays predictable and inside the work directory.
+const defaultSysConfigName = "overlay"
+
+// safePathSegment matches a conservative allowlist for user-supplied path
+// segments: ASCII letters, digits, and the separators "._-", one or more times.
+// It deliberately excludes whitespace and shell metacharacters (';', '&', '$',
+// backticks, quotes, globs, ...) because these segments are later both joined
+// into filesystem paths AND interpolated into commands executed via bash -c
+// (through internal/utils/shell), so anything outside this set could change
+// shell parsing or escape the workspace directory.
+var safePathSegment = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// validatePathSegment rejects values that are not a single, safe path segment.
+// It is used to guard user-supplied names (e.g. the system config name and the
+// target OS/dist/arch fields) before they are joined into filesystem paths and
+// embedded into shell commands, so a value like "../..", "/etc", or one carrying
+// shell metacharacters cannot redirect the overlay workspace or alter command
+// parsing.
+func validatePathSegment(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("must not be %q", name)
+	}
+	// The allowlist already forbids the path separator, so a valid value is
+	// inherently a single segment; this covers traversal and shell-injection in
+	// one check.
+	if !safePathSegment.MatchString(name) {
+		return fmt.Errorf("must contain only ASCII letters, digits, '.', '_' or '-' (no separators, whitespace, or shell metacharacters)")
+	}
+	return nil
+}
+
+// LoopDevManager is the subset of imagedisc.LoopDevInterface needed to attach
+// and detach a baseline image. It is declared here so tests can inject a fake.
+type LoopDevManager interface {
+	AttachImageToLoopDev(imagePath string) (string, []string, error)
+	LoopSetupDelete(loopDevPath string) error
+}
+
+// Context carries overlay ingestion state across downstream build stages.
+type Context struct {
+	// BaselineCopyPath is the workspace copy of the baseline RAW image. All
+	// modification happens here; the user-provided source is never touched.
+	BaselineCopyPath string
+	// LoopDevPath is the attached loop device, e.g. "/dev/loop0".
+	LoopDevPath string
+	// Partitions are the enumerated partition nodes, e.g. ["/dev/loop0p1"].
+	Partitions []string
+}
+
+// Ingestor copies a baseline image into the workspace and attaches it to a loop
+// device for downstream overlay stages.
+type Ingestor struct {
+	template *config.ImageTemplate
+	loopDev  LoopDevManager
+	// workDir is the per-build overlay workspace directory.
+	workDir string
+	// retainCopy, when true, keeps the workspace baseline copy after a
+	// successful build for debugging. Defaults to the global debug-mode flag.
+	retainCopy bool
+}
+
+// NewIngestor constructs an Ingestor for an overlay-mode template. It returns an
+// error if the template is not in overlay mode or is missing a baseline source.
+func NewIngestor(template *config.ImageTemplate) (*Ingestor, error) {
+	if template == nil {
+		return nil, fmt.Errorf("image template cannot be nil")
+	}
+	if !template.IsOverlayMode() {
+		return nil, fmt.Errorf("template is not in overlay mode")
+	}
+	if template.Baseline == nil || template.Baseline.Source == nil {
+		return nil, fmt.Errorf("overlay template is missing baseline.source")
+	}
+	// Enforce the baseline.source contract (exactly one of path or url, with a
+	// well-formed value) here as well as at template load. NewIngestor may be
+	// constructed from a programmatically built template that never passed
+	// through validateBaseline, so re-checking gives a clear error up front
+	// instead of an opaque copy/download failure later.
+	src := template.Baseline.Source
+	if err := src.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid baseline.source: %w", err)
+	}
+
+	globalWorkDir, err := config.WorkDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve work directory: %w", err)
+	}
+	// SystemConfig.Name is user-supplied and has no schema pattern, so it may
+	// contain path separators or "..". It is also schema-optional, so a valid
+	// template may omit it entirely; fall back to a safe default in that case
+	// rather than rejecting the template. A non-empty value is still constrained
+	// to a single, safe path segment before being joined into the workspace path,
+	// otherwise the overlay workspace (and the baseline copy/remove that operate
+	// under it) could escape the intended work directory.
+	sysConfigName := template.GetSystemConfigName()
+	if strings.TrimSpace(sysConfigName) == "" {
+		sysConfigName = defaultSysConfigName
+	} else if err := validatePathSegment(sysConfigName); err != nil {
+		return nil, fmt.Errorf("invalid system config name %q: %w", sysConfigName, err)
+	}
+	// Image.Name is user-supplied and, like SystemConfig.Name, has no schema
+	// pattern. It is later joined into the emitted artifact filename
+	// (<buildDir>/<image.name>-<version>.raw), so a programmatic caller supplying a
+	// name with path separators or ".." could write the artifact outside the build
+	// directory. Constrain it to a single, safe path segment here too.
+	imageName := template.GetImageName()
+	if err := validatePathSegment(imageName); err != nil {
+		return nil, fmt.Errorf("invalid image name %q: %w", imageName, err)
+	}
+	// Target.{OS,Dist,Arch} feed providerID, which is also joined into the
+	// workspace path. The JSON schema constrains these for YAML-loaded templates,
+	// but NewIngestor also accepts programmatically built templates that never
+	// passed schema validation, so a component containing separators or ".."
+	// could otherwise redirect the workspace. Validate each component too.
+	// Use a fixed-order slice (not a map) so that when more than one component
+	// is invalid the error is deterministic — a map iteration order would make
+	// the reported field vary between runs and can make tests flaky.
+	for _, part := range []struct {
+		label string
+		value string
+	}{
+		{"target.os", template.Target.OS},
+		{"target.dist", template.Target.Dist},
+		{"target.arch", template.Target.Arch},
+	} {
+		if err := validatePathSegment(part.value); err != nil {
+			return nil, fmt.Errorf("invalid %s %q: %w", part.label, part.value, err)
+		}
+	}
+	providerID := system.GetProviderId(template.Target.OS, template.Target.Dist, template.Target.Arch)
+	workDir := filepath.Join(globalWorkDir, providerID, "overlay", sysConfigName)
+
+	return &Ingestor{
+		template:   template,
+		loopDev:    imagedisc.NewLoopDev(),
+		workDir:    workDir,
+		retainCopy: config.IsDebugMode(),
+	}, nil
+}
+
+// WithBaseline acquires the baseline (copy into workspace + loop attach), invokes
+// fn with the resulting Context, and guarantees the loop device is detached on
+// success, failure, or panic. The workspace baseline copy is removed only on full
+// success, unless debug retention is enabled.
+//
+// fn carries the downstream overlay work (mount, inspect, install). Any error it
+// returns is propagated after cleanup runs. On a normal (non-panic) return a
+// detach failure is surfaced too (joined with fn's error when both fail) so a
+// leaked loop device is never hidden behind another error or mistaken for a
+// clean build; the copy is retained in that case. When fn panics, cleanup still
+// runs (detach is attempted and the copy retained) but the function re-panics,
+// so a detach failure on that path cannot be returned — it is only logged.
+func (ing *Ingestor) WithBaseline(fn func(*Context) error) (err error) {
+	if fn == nil {
+		return fmt.Errorf("WithBaseline: fn must not be nil")
+	}
+
+	ctx, err := ing.acquire()
+	if err != nil {
+		return err
+	}
+
+	// defer-based cleanup runs on normal return, error, or panic. The loop
+	// device is always detached. A detach failure is always surfaced to the
+	// caller (joined with fn's error if fn also failed), marking the run
+	// unsuccessful. The workspace copy is removed only on full success (fn ok
+	// and detach ok) unless retention is enabled.
+	fnErr := error(nil)
+	panicked := true // cleared right after fn returns; still set if fn panics
+	defer func() {
+		// Recover any panic so cleanup can treat it as an unsuccessful run
+		// (retain the copy for debugging) before re-panicking to preserve the
+		// original behavior. Without this, a panic leaves fnErr and err nil, so
+		// the deferred cleanup would wrongly remove the copy as if the build had
+		// fully succeeded.
+		r := recover()
+
+		detachErr := ing.detach(ctx)
+		if !panicked && detachErr != nil {
+			// A detach failure must always reach the caller so a leaked loop
+			// device is never silently swallowed. When fn already failed, join
+			// the two so both are reported; when fn succeeded, this alone marks
+			// the run unsuccessful.
+			err = errors.Join(fnErr, detachErr)
+		}
+		if !panicked && err == nil {
+			// Honor debug retention only on a fully successful build.
+			ing.removeCopy(ctx, false)
+		} else {
+			log.Debugf("Retaining workspace baseline copy after unsuccessful build: %s", ctx.BaselineCopyPath)
+		}
+
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	fnErr = fn(ctx)
+	panicked = false
+	err = fnErr
+	return err
+}
+
+// acquire prepares the workspace, copies (or downloads) the baseline image into
+// it, and attaches a loop device. On any failure it cleans up whatever it created
+// so no partial state (workspace copy or loop device) is leaked.
+func (ing *Ingestor) acquire() (*Context, error) {
+	if err := os.MkdirAll(ing.workDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create overlay workspace %s: %w", ing.workDir, err)
+	}
+
+	copyPath := filepath.Join(ing.workDir, baselineCopyName)
+	ctx := &Context{BaselineCopyPath: copyPath}
+	if err := ing.copyBaseline(copyPath); err != nil {
+		// copyBaseline may have created or partially written the destination
+		// before failing (a URL download truncates the output file before
+		// io.Copy completes). Force-remove it so no corrupt partial baseline
+		// is left behind, matching this function's no-leak contract.
+		ing.removeCopy(ctx, true)
+		return nil, err
+	}
+
+	loopDevPath, partitions, err := ing.loopDev.AttachImageToLoopDev(copyPath)
+	if err != nil {
+		if loopDevPath != "" {
+			// A loop device was created but could not be detached, so it still
+			// references this backing file. Removing the file now would unlink a
+			// file the leaked device points at, making recovery/debugging harder.
+			// Retain the copy and surface the (already path-annotated) error.
+			log.Errorf("Retaining workspace baseline copy %s: loop device %s may still be attached after attach failure", copyPath, loopDevPath)
+			return nil, fmt.Errorf("failed to attach baseline copy to loop device: %w", err)
+		}
+		// No loop device outstanding: remove the copy we just made so nothing
+		// leaks. Force removal regardless of debug retention — this is
+		// partial-state cleanup, not the post-success copy that retention keeps.
+		ing.removeCopy(ctx, true)
+		return nil, fmt.Errorf("failed to attach baseline copy to loop device: %w", err)
+	}
+	ctx.LoopDevPath = loopDevPath
+	ctx.Partitions = partitions
+
+	log.Infof("Attached baseline copy %s to loop device %s (%d partitions)",
+		copyPath, loopDevPath, len(partitions))
+	return ctx, nil
+}
+
+// copyBaseline copies the source baseline into dst. A local path is copied (never
+// symlinked or moved); an https URL is downloaded over TLS (BaselineSource.Validate
+// permits only https for remote sources). The user-provided source is never modified.
+func (ing *Ingestor) copyBaseline(dst string) error {
+	src := ing.template.Baseline.Source
+
+	switch {
+	case src.URL != "":
+		log.Debugf("Downloading baseline image from %s to %s", src.URL, dst)
+		if err := network.DownloadFile(src.URL, dst, false); err != nil {
+			return fmt.Errorf("failed to download baseline image from %s to %s: %w", src.URL, dst, err)
+		}
+		// DownloadFile creates the file 0644; tighten it to 0600 so the baseline
+		// stays private by default, matching the local-copy path (copyLocalFile),
+		// regardless of any pre-existing workspace directory permissions.
+		if err := os.Chmod(dst, 0600); err != nil {
+			return fmt.Errorf("failed to restrict permissions on downloaded baseline %s: %w", dst, err)
+		}
+		log.Debugf("Finished downloading baseline image to %s", dst)
+	default:
+		log.Debugf("Copying baseline image from %s to %s", src.Path, dst)
+		if err := copyLocalFile(src.Path, dst); err != nil {
+			return fmt.Errorf("failed to copy baseline image from %s to %s: %w", src.Path, dst, err)
+		}
+		log.Debugf("Finished copying baseline image to %s", dst)
+	}
+	return nil
+}
+
+// sparseCopyChunk is the block size used by copyLocalFile for zero-run detection.
+// It matches a common filesystem block/cluster granularity so a fully-zero chunk
+// can be turned into a hole in the destination.
+const sparseCopyChunk = 64 * 1024
+
+// copyLocalFile copies src to dst using a native streaming copy (no shell).
+// file.CopyFile shells out via bash -c with single-quoted paths, so a source or
+// destination path containing a single quote could break quoting; both paths
+// here are user-influenced (baseline.source.path and the systemConfig.name in
+// dst), so the copy is done in-process to avoid any shell handling. The
+// workspace copy is created user-owned, so no sudo is needed.
+//
+// The copy is sparse-aware: baseline RAW images are typically sparse (large runs
+// of holes that read back as zeros). A plain io.Copy would materialize every
+// hole into allocated zero blocks, inflating workspace usage and slowing the
+// copy. Instead, all-zero chunks are skipped by seeking the destination forward,
+// leaving a hole, and the file is truncated to the exact source size at the end
+// so a trailing zero run is preserved as a hole rather than written out.
+func copyLocalFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	buf := make([]byte, sparseCopyChunk)
+	var written int64
+	for {
+		n, readErr := io.ReadFull(in, buf)
+		if n > 0 {
+			chunk := buf[:n]
+			if isAllZero(chunk) {
+				// Leave a hole: advance the destination offset without writing.
+				if _, serr := out.Seek(int64(n), io.SeekCurrent); serr != nil {
+					return serr
+				}
+			} else {
+				nw, werr := out.Write(chunk)
+				if werr != nil {
+					return werr
+				}
+				// Guard against a short write: io.Writer may legally write fewer
+				// bytes than requested without an error, which would silently
+				// corrupt the copied image and desync the offset.
+				if nw != len(chunk) {
+					return fmt.Errorf("short write copying %s: wrote %d of %d bytes: %w", dst, nw, len(chunk), io.ErrShortWrite)
+				}
+			}
+			written += int64(n)
+		}
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+
+	// A trailing hole (or the seek past the final zero chunk) does not extend the
+	// file, so set the exact length explicitly. This also materializes a hole for
+	// any zero run at the very end of the source.
+	if terr := out.Truncate(written); terr != nil {
+		return terr
+	}
+	return nil
+}
+
+// isAllZero reports whether b consists entirely of zero bytes.
+func isAllZero(b []byte) bool {
+	for _, c := range b {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// detach detaches the loop device if one is attached. It returns the detach
+// error (also logged) so callers on the success path can surface a failed
+// cleanup instead of silently leaking the loop device. A no-op (nothing
+// attached) returns nil.
+func (ing *Ingestor) detach(ctx *Context) error {
+	if ctx == nil || ctx.LoopDevPath == "" {
+		return nil
+	}
+	if err := ing.loopDev.LoopSetupDelete(ctx.LoopDevPath); err != nil {
+		log.Errorf("Failed to detach loop device %s: %v", ctx.LoopDevPath, err)
+		return fmt.Errorf("failed to detach loop device %s: %w", ctx.LoopDevPath, err)
+	}
+	log.Infof("Detached loop device %s", ctx.LoopDevPath)
+	return nil
+}
+
+// removeCopy removes the workspace baseline copy. When force is false, debug
+// retention is honored and the copy is kept. When force is true (partial-state
+// cleanup after an acquire failure), the copy is always removed so nothing
+// leaks, regardless of retention.
+func (ing *Ingestor) removeCopy(ctx *Context, force bool) {
+	if ctx == nil || ctx.BaselineCopyPath == "" {
+		return
+	}
+	if ing.retainCopy && !force {
+		log.Infof("Retaining workspace baseline copy for debugging: %s", ctx.BaselineCopyPath)
+		return
+	}
+	// The copy is created user-owned (CopyFile with sudo=false), so removal
+	// needs no sudo and no shell: os.Remove takes the path literally, avoiding
+	// any shell-metacharacter handling on the workspace path.
+	if err := os.Remove(ctx.BaselineCopyPath); err != nil && !os.IsNotExist(err) {
+		log.Errorf("Failed to remove workspace baseline copy %s: %v", ctx.BaselineCopyPath, err)
+		return
+	}
+	log.Debugf("Removed workspace baseline copy %s", ctx.BaselineCopyPath)
+}

--- a/internal/image/overlay/overlay_integration_test.go
+++ b/internal/image/overlay/overlay_integration_test.go
@@ -1,0 +1,95 @@
+package overlay
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/image/imagedisc"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
+)
+
+// TestWithBaseline_RealLoopDevice exercises the full ingestion path against a
+// real loop device: it copies a generated RAW image into the workspace, attaches
+// it via losetup -fP, verifies the loop device exists, and confirms the deferred
+// cleanup detaches it and removes the workspace copy.
+//
+// Requires root (losetup needs privilege) and the losetup binary. Skips otherwise
+// so the suite stays green on unprivileged dev machines and CI sandboxes.
+func TestWithBaseline_RealLoopDevice(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to attach a real loop device")
+	}
+	if _, err := os.Stat("/dev/loop-control"); err != nil {
+		t.Skipf("loop devices unavailable: %v", err)
+	}
+	if ok, err := shell.IsCommandExist("losetup", shell.HostPath); err != nil || !ok {
+		t.Skip("losetup not available on host")
+	}
+
+	// Generate a small RAW source image (8 MiB) — large enough for losetup.
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "source.raw")
+	// shell.ExecCmd runs via bash -c, so single-quote the temp path (via
+	// shell.QuoteArg) in case TMPDIR contains spaces or shell metacharacters.
+	// Single quotes also suppress $()/backtick/${} expansion that double-quoting
+	// would still allow.
+	ddCmd := fmt.Sprintf("dd if=/dev/zero of=%s bs=1M count=8", shell.QuoteArg(srcPath))
+	if _, err := shell.ExecCmd(ddCmd, false, shell.HostPath, nil); err != nil {
+		t.Fatalf("create source image: %v", err)
+	}
+
+	tmpl := &config.ImageTemplate{
+		Baseline: &config.Baseline{
+			Mode:   config.BaselineModeOverlay,
+			Source: &config.BaselineSource{Path: srcPath},
+		},
+	}
+	ing := &Ingestor{
+		template:   tmpl,
+		loopDev:    imagedisc.NewLoopDev(),
+		workDir:    filepath.Join(t.TempDir(), "overlay"),
+		retainCopy: false,
+	}
+
+	var copyPath, loopDevPath string
+	err := ing.WithBaseline(func(ctx *Context) error {
+		copyPath = ctx.BaselineCopyPath
+		loopDevPath = ctx.LoopDevPath
+
+		// Source image untouched; workspace has a real copy.
+		if _, statErr := os.Stat(srcPath); statErr != nil {
+			t.Errorf("source image must remain after copy: %v", statErr)
+		}
+		if _, statErr := os.Stat(ctx.BaselineCopyPath); statErr != nil {
+			t.Errorf("workspace copy missing: %v", statErr)
+		}
+		// Loop device node exists while attached.
+		if _, statErr := os.Stat(ctx.LoopDevPath); statErr != nil {
+			t.Errorf("loop device %s should exist: %v", ctx.LoopDevPath, statErr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithBaseline: %v", err)
+	}
+
+	// After cleanup the loop device is detached and the workspace copy removed.
+	// The /dev/loopX node typically persists after detach (it just loses its
+	// backing file), so assert on losetup's active-device list rather than the
+	// node's existence. The test already runs as root, so invoke losetup without
+	// sudo — minimal root containers often lack the sudo binary.
+	activeLoops, lsErr := shell.ExecCmd("losetup -a", false, shell.HostPath, nil)
+	if lsErr != nil {
+		t.Fatalf("losetup -a: %v", lsErr)
+	}
+	if strings.Contains(activeLoops, loopDevPath+":") {
+		t.Errorf("loop device %s should be detached after cleanup, still listed by losetup -a:\n%s", loopDevPath, activeLoops)
+	}
+	if _, statErr := os.Stat(copyPath); !os.IsNotExist(statErr) {
+		t.Errorf("workspace copy %s should be removed after success, stat err = %v", copyPath, statErr)
+	}
+}

--- a/internal/image/overlay/overlay_test.go
+++ b/internal/image/overlay/overlay_test.go
@@ -1,0 +1,514 @@
+package overlay
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
+)
+
+// fakeLoopDev is an in-memory LoopDevManager for unit tests.
+type fakeLoopDev struct {
+	attachedPath    string // image path passed to AttachImageToLoopDev
+	loopDevPath     string
+	partitions      []string
+	failAttach      bool
+	leakOnAttach    bool // return a non-empty path alongside the attach error
+	detachCallCount int
+	detachedPath    string
+	failDetach      bool
+}
+
+func (f *fakeLoopDev) AttachImageToLoopDev(imagePath string) (string, []string, error) {
+	f.attachedPath = imagePath
+	if f.failAttach {
+		if f.leakOnAttach {
+			// Simulate a leaked loop device: a device was created but detach
+			// failed, so the path is returned even though the call errored.
+			return f.loopDevPath, nil, fmt.Errorf("fake attach failure (leaked %s)", f.loopDevPath)
+		}
+		return "", nil, fmt.Errorf("fake attach failure")
+	}
+	return f.loopDevPath, f.partitions, nil
+}
+
+func (f *fakeLoopDev) LoopSetupDelete(loopDevPath string) error {
+	f.detachCallCount++
+	f.detachedPath = loopDevPath
+	if f.failDetach {
+		return fmt.Errorf("fake detach failure")
+	}
+	return nil
+}
+
+// newTestIngestor builds an Ingestor wired to a fake loop device and a workspace
+// under t.TempDir(), bypassing NewIngestor's global-config dependency.
+func newTestIngestor(t *testing.T, src *config.BaselineSource, loop LoopDevManager, retain bool) *Ingestor {
+	t.Helper()
+	tmpl := &config.ImageTemplate{
+		Baseline: &config.Baseline{
+			Mode:   config.BaselineModeOverlay,
+			Source: src,
+		},
+	}
+	return &Ingestor{
+		template:   tmpl,
+		loopDev:    loop,
+		workDir:    filepath.Join(t.TempDir(), "overlay"),
+		retainCopy: retain,
+	}
+}
+
+// writeSourceImage creates a fake baseline RAW source file with known content.
+func writeSourceImage(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.raw")
+	if err := os.WriteFile(src, []byte("baseline-bytes"), 0644); err != nil {
+		t.Fatalf("write source image: %v", err)
+	}
+	return src
+}
+
+func TestWithBaseline_CopiesAttachesDetachesAndRemoves(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil) // real cp/rm against tmp dirs
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{loopDevPath: "/dev/loop7", partitions: []string{"/dev/loop7p1"}}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	var seenCopyPath string
+	err := ing.WithBaseline(func(ctx *Context) error {
+		seenCopyPath = ctx.BaselineCopyPath
+
+		// Source RAW is copied (not symlinked, not moved) into the workspace.
+		if _, statErr := os.Stat(srcPath); statErr != nil {
+			t.Errorf("source image must not be moved/removed: %v", statErr)
+		}
+		info, statErr := os.Lstat(ctx.BaselineCopyPath)
+		if statErr != nil {
+			t.Fatalf("workspace copy missing: %v", statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Errorf("workspace copy must be a real file, not a symlink")
+		}
+		got, readErr := os.ReadFile(ctx.BaselineCopyPath)
+		if readErr != nil {
+			t.Fatalf("read workspace copy: %v", readErr)
+		}
+		if string(got) != "baseline-bytes" {
+			t.Errorf("copy content = %q, want %q", got, "baseline-bytes")
+		}
+
+		// Loop device path + partitions stored in context for downstream stages.
+		if ctx.LoopDevPath != "/dev/loop7" {
+			t.Errorf("LoopDevPath = %q, want /dev/loop7", ctx.LoopDevPath)
+		}
+		if len(ctx.Partitions) != 1 || ctx.Partitions[0] != "/dev/loop7p1" {
+			t.Errorf("Partitions = %v, want [/dev/loop7p1]", ctx.Partitions)
+		}
+		// Loop attach received the workspace copy, never the original source.
+		if loop.attachedPath != ctx.BaselineCopyPath {
+			t.Errorf("attached %q, want workspace copy %q", loop.attachedPath, ctx.BaselineCopyPath)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithBaseline: %v", err)
+	}
+
+	// defer-based cleanup detaches the loop device exactly once.
+	if loop.detachCallCount != 1 {
+		t.Errorf("detach call count = %d, want 1", loop.detachCallCount)
+	}
+	if loop.detachedPath != "/dev/loop7" {
+		t.Errorf("detached %q, want /dev/loop7", loop.detachedPath)
+	}
+	// Workspace copy removed on full build success.
+	if _, statErr := os.Stat(seenCopyPath); !os.IsNotExist(statErr) {
+		t.Errorf("workspace copy should be removed on success, stat err = %v", statErr)
+	}
+}
+
+func TestWithBaseline_RetainsCopyWhenConfigured(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{loopDevPath: "/dev/loop3"}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, true) // retain
+
+	var copyPath string
+	if err := ing.WithBaseline(func(ctx *Context) error {
+		copyPath = ctx.BaselineCopyPath
+		return nil
+	}); err != nil {
+		t.Fatalf("WithBaseline: %v", err)
+	}
+
+	if loop.detachCallCount != 1 {
+		t.Errorf("detach call count = %d, want 1", loop.detachCallCount)
+	}
+	// Copy retained for debugging even after success.
+	if _, statErr := os.Stat(copyPath); statErr != nil {
+		t.Errorf("workspace copy should be retained, stat err = %v", statErr)
+	}
+}
+
+func TestWithBaseline_DetachesAndRetainsCopyOnError(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{loopDevPath: "/dev/loop1"}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	wantErr := fmt.Errorf("downstream stage failed")
+	var copyPath string
+	err := ing.WithBaseline(func(ctx *Context) error {
+		copyPath = ctx.BaselineCopyPath
+		return wantErr
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// Loop device detached even on failure.
+	if loop.detachCallCount != 1 {
+		t.Errorf("detach call count = %d, want 1", loop.detachCallCount)
+	}
+	// On failure the copy is retained for debugging (not removed).
+	if _, statErr := os.Stat(copyPath); statErr != nil {
+		t.Errorf("workspace copy should be retained on error, stat err = %v", statErr)
+	}
+}
+
+func TestWithBaseline_DetachesOnPanic(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{loopDevPath: "/dev/loop9"}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected panic to propagate")
+			}
+		}()
+		// The return value is unreachable (fn panics), but capture and assert on
+		// it anyway so errcheck stays satisfied.
+		if err := ing.WithBaseline(func(ctx *Context) error {
+			panic("boom")
+		}); err != nil {
+			t.Errorf("unexpected error return: %v", err)
+		}
+	}()
+
+	// Loop device detached even on panic.
+	if loop.detachCallCount != 1 {
+		t.Errorf("detach call count = %d, want 1 (cleanup must run on panic)", loop.detachCallCount)
+	}
+
+	// A panic is an unsuccessful run: the workspace copy must be retained (not
+	// removed as if the build had fully succeeded) so the failure can be
+	// debugged. This guards the recover()-based panic handling in WithBaseline.
+	copyPath := filepath.Join(ing.workDir, baselineCopyName)
+	if _, err := os.Stat(copyPath); err != nil {
+		t.Errorf("workspace baseline copy must be retained after panic, but Stat(%q) failed: %v", copyPath, err)
+	}
+}
+
+func TestWithBaseline_LoopAttachFailureRemovesCopy(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{failAttach: true}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	fnCalled := false
+	err := ing.WithBaseline(func(ctx *Context) error {
+		fnCalled = true
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected attach failure error, got nil")
+	}
+	if fnCalled {
+		t.Errorf("fn must not be called when loop attach fails")
+	}
+	// No detach attempted (nothing was attached).
+	if loop.detachCallCount != 0 {
+		t.Errorf("detach call count = %d, want 0", loop.detachCallCount)
+	}
+	// Copy removed since attach failed (no partial workspace state).
+	copyPath := filepath.Join(ing.workDir, baselineCopyName)
+	if _, statErr := os.Stat(copyPath); !os.IsNotExist(statErr) {
+		t.Errorf("workspace copy should be removed on attach failure, stat err = %v", statErr)
+	}
+}
+
+func TestWithBaseline_RetainsCopyWhenAttachLeaksLoopDevice(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	// Attach fails but returns a non-empty device path: a loop device was created
+	// and could not be detached, so it still references the backing file.
+	loop := &fakeLoopDev{failAttach: true, leakOnAttach: true, loopDevPath: "/dev/loop8"}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	err := ing.WithBaseline(func(ctx *Context) error {
+		t.Errorf("fn must not be called when loop attach fails")
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected attach failure error, got nil")
+	}
+	// The copy must be retained: removing it would unlink a file the leaked loop
+	// device still points at, making recovery/debugging harder.
+	copyPath := filepath.Join(ing.workDir, baselineCopyName)
+	if _, statErr := os.Stat(copyPath); statErr != nil {
+		t.Errorf("workspace copy should be retained when a loop device leaks, stat err = %v", statErr)
+	}
+}
+
+func TestNewIngestor_DefaultsEmptySystemConfigName(t *testing.T) {
+	// systemConfig.name is schema-optional; an otherwise-valid overlay template
+	// that omits it must not be rejected. NewIngestor should fall back to the
+	// default workspace segment instead.
+	tmpl := &config.ImageTemplate{
+		Image:  config.ImageInfo{Name: "img"},
+		Target: config.TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "amd64"},
+		Baseline: &config.Baseline{
+			Mode:   config.BaselineModeOverlay,
+			Source: &config.BaselineSource{Path: "/some/baseline.raw"},
+		},
+		// SystemConfig.Name intentionally left empty.
+	}
+	ing, err := NewIngestor(tmpl)
+	if err != nil {
+		t.Fatalf("NewIngestor with empty systemConfig.name should succeed, got %v", err)
+	}
+	if !strings.HasSuffix(ing.workDir, filepath.Join("overlay", defaultSysConfigName)) {
+		t.Errorf("workDir = %q, want it to end with overlay/%s", ing.workDir, defaultSysConfigName)
+	}
+}
+
+func TestWithBaseline_MissingSourceFileFails(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	loop := &fakeLoopDev{}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: "/nonexistent/baseline.raw"}, loop, false)
+
+	err := ing.WithBaseline(func(ctx *Context) error {
+		t.Errorf("fn must not run when copy fails")
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected copy failure error, got nil")
+	}
+	if loop.detachCallCount != 0 {
+		t.Errorf("detach call count = %d, want 0", loop.detachCallCount)
+	}
+}
+
+func TestWithBaseline_NilFnReturnsError(t *testing.T) {
+	loop := &fakeLoopDev{}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: "/does/not/matter"}, loop, false)
+
+	if err := ing.WithBaseline(nil); err == nil {
+		t.Fatalf("expected error for nil fn, got nil")
+	}
+	// Nothing should have been acquired when fn is nil.
+	if loop.detachCallCount != 0 {
+		t.Errorf("detach call count = %d, want 0", loop.detachCallCount)
+	}
+}
+
+func TestWithBaseline_DetachFailureOnSuccessFailsRun(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{loopDevPath: "/dev/loop4", failDetach: true}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	var copyPath string
+	err := ing.WithBaseline(func(ctx *Context) error {
+		copyPath = ctx.BaselineCopyPath
+		return nil // fn succeeds; only detach fails
+	})
+	if err == nil {
+		t.Fatalf("expected detach failure to be surfaced, got nil")
+	}
+	if loop.detachCallCount != 1 {
+		t.Errorf("detach call count = %d, want 1", loop.detachCallCount)
+	}
+	// A failed detach marks the run unsuccessful, so the copy is retained.
+	if _, statErr := os.Stat(copyPath); statErr != nil {
+		t.Errorf("workspace copy should be retained when detach fails, stat err = %v", statErr)
+	}
+}
+
+func TestWithBaseline_DetachFailureSurfacesAlongsideFnError(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+	shell.Default = shell.NewMockExecutor(nil)
+
+	srcPath := writeSourceImage(t)
+	loop := &fakeLoopDev{loopDevPath: "/dev/loop4", failDetach: true}
+	ing := newTestIngestor(t, &config.BaselineSource{Path: srcPath}, loop, false)
+
+	fnErr := fmt.Errorf("downstream boom")
+	err := ing.WithBaseline(func(ctx *Context) error {
+		return fnErr
+	})
+	if err == nil {
+		t.Fatalf("expected combined error, got nil")
+	}
+	// Both the fn error and the detach failure must reach the caller so a leaked
+	// loop device is never hidden behind the downstream error.
+	if !errors.Is(err, fnErr) {
+		t.Errorf("returned error must wrap fn error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "fake detach failure") {
+		t.Errorf("returned error must include detach failure, got %v", err)
+	}
+}
+
+func TestNewIngestor_RejectsNonOverlayTemplate(t *testing.T) {
+	tmpl := &config.ImageTemplate{} // create mode (no baseline)
+	if _, err := NewIngestor(tmpl); err == nil {
+		t.Fatalf("expected error for non-overlay template")
+	}
+}
+
+func TestNewIngestor_RejectsNilTemplate(t *testing.T) {
+	if _, err := NewIngestor(nil); err == nil {
+		t.Fatalf("expected error for nil template")
+	}
+}
+
+func TestNewIngestor_RejectsUnsafeImageName(t *testing.T) {
+	// A programmatic template can carry an image.name that never passed schema
+	// validation. Since it is later joined into the emitted artifact path, a name
+	// with traversal/separators must be rejected up front.
+	tmpl := &config.ImageTemplate{
+		Image:        config.ImageInfo{Name: "../../etc/evil"},
+		Target:       config.TargetInfo{OS: "ubuntu", Dist: "ubuntu24", Arch: "amd64"},
+		SystemConfig: config.SystemConfig{Name: "valid"}, // valid, so image.name is the failure point
+		Baseline: &config.Baseline{
+			Mode:   config.BaselineModeOverlay,
+			Source: &config.BaselineSource{Path: "/some/baseline.raw"},
+		},
+	}
+	_, err := NewIngestor(tmpl)
+	if err == nil {
+		t.Fatalf("expected error for image name with path separators")
+	}
+	if !strings.Contains(err.Error(), "invalid image name") {
+		t.Errorf("error = %v, want it to name the image-name validation", err)
+	}
+}
+
+func TestValidatePathSegment(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment string
+		wantErr bool
+	}{
+		{"plain name", "my-config", false},
+		{"name with dot", "config.v2", false},
+		{"underscore and digits", "cfg_01", false},
+		{"empty", "", true},
+		{"whitespace only", "   ", true},
+		{"internal whitespace", "a b", true},
+		{"dot", ".", true},
+		{"dotdot", "..", true},
+		{"parent traversal", "../etc", true},
+		{"nested traversal", "a/../../b", true},
+		{"absolute path", "/etc/passwd", true},
+		{"embedded separator", "a/b", true},
+		{"trailing separator", "a/", true},
+		{"semicolon", "a;rm -rf", true},
+		{"command substitution", "$(id)", true},
+		{"backtick", "a`id`", true},
+		{"ampersand", "a&b", true},
+		{"pipe", "a|b", true},
+		{"glob", "a*", true},
+		{"quote", "a'b", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePathSegment(tt.segment)
+			if tt.wantErr && err == nil {
+				t.Errorf("validatePathSegment(%q) = nil, want error", tt.segment)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validatePathSegment(%q) = %v, want nil", tt.segment, err)
+			}
+		})
+	}
+}
+
+// TestCopyLocalFile_RoundTripsContentWithZeroRuns verifies that the sparse-aware
+// copy reproduces the source byte-for-byte and at the exact size even when the
+// content contains large zero runs (which the copy turns into holes). It asserts
+// correctness of the copied bytes/size, not that the destination is physically
+// sparse — hole allocation depends on the underlying filesystem.
+func TestCopyLocalFile_RoundTripsContentWithZeroRuns(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.raw")
+	dst := filepath.Join(dir, "dst.raw")
+
+	// Build content that exercises the zero-run detection: a leading hole
+	// spanning multiple chunks, real data, an interior hole, more data, and a
+	// trailing hole (which must be preserved by the final Truncate).
+	var want bytes.Buffer
+	want.Write(make([]byte, sparseCopyChunk*2+123)) // leading zeros, non-aligned
+	want.WriteString("hello-baseline")
+	want.Write(make([]byte, sparseCopyChunk+7)) // interior hole
+	want.WriteString("more-data")
+	want.Write(make([]byte, sparseCopyChunk*3)) // trailing hole
+	if err := os.WriteFile(src, want.Bytes(), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	if err := copyLocalFile(src, dst); err != nil {
+		t.Fatalf("copyLocalFile: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(got, want.Bytes()) {
+		t.Errorf("copied content differs: got %d bytes, want %d bytes", len(got), want.Len())
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if info.Size() != int64(want.Len()) {
+		t.Errorf("dst size = %d, want %d", info.Size(), want.Len())
+	}
+}

--- a/internal/image/rawmaker/rawmaker_test.go
+++ b/internal/image/rawmaker/rawmaker_test.go
@@ -134,6 +134,13 @@ func (m *mockLoopDev) CreateRawImageLoopDev(filePath string, template *config.Im
 	return m.loopDevPath, diskPathIdMap, nil
 }
 
+func (m *mockLoopDev) AttachImageToLoopDev(imagePath string) (string, []string, error) {
+	if m.shouldFailCreate {
+		return m.failCreateLoopDevPath, nil, fmt.Errorf("mock loop device attach failure")
+	}
+	return m.loopDevPath, []string{"/dev/loop0p1", "/dev/loop0p2"}, nil
+}
+
 func (m *mockLoopDev) LoopSetupDelete(loopDevPath string) error {
 	m.deleteCallCount++
 	if m.shouldFailDelete {

--- a/internal/utils/shell/shell.go
+++ b/internal/utils/shell/shell.go
@@ -726,3 +726,14 @@ func ExecCmdWithStream(cmdStr string, sudo bool, chrootPath string, envVal []str
 func ExecCmdWithInput(inputStr string, cmdStr string, sudo bool, chrootPath string, envVal []string) (string, error) {
 	return Default.ExecCmdWithInput(inputStr, cmdStr, sudo, chrootPath, envVal)
 }
+
+// QuoteArg returns s quoted as a single shell argument safe to interpolate into
+// a command string that is later executed via "bash -c". It wraps the value in
+// single quotes, inside which bash performs no expansion at all — unlike double
+// quotes (as produced by strconv.Quote), which still allow $(...), ${...}, and
+// backtick command substitution. Any embedded single quote is emitted as the
+// standard close-quote, escaped-quote, reopen-quote sequence, i.e. the four
+// characters: single-quote, backslash, single-quote, single-quote.
+func QuoteArg(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/utils/shell/shell_test.go
+++ b/internal/utils/shell/shell_test.go
@@ -2,6 +2,7 @@ package shell_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -357,5 +358,45 @@ func TestGetFullCmdStr_Env(t *testing.T) {
 	// The env vars are added after sudo
 	if !strings.Contains(fullCmd, "VAR=VALUE") {
 		t.Errorf("Expected env var in command, got: %s", fullCmd)
+	}
+}
+
+func TestQuoteArg(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain path", "/dev/loop0", `'/dev/loop0'`},
+		{"empty", "", `''`},
+		{"command substitution stays literal", "$(reboot)", `'$(reboot)'`},
+		{"backticks stay literal", "`id`", "'`id`'"},
+		{"variable stays literal", "${HOME}", `'${HOME}'`},
+		{"embedded single quote", "a'b", `'a'\''b'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shell.QuoteArg(tt.in); got != tt.want {
+				t.Errorf("QuoteArg(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQuoteArgNeutralizesExpansion runs a quoted argument through bash to prove
+// no expansion occurs: the shell must echo the value back byte-for-byte.
+func TestQuoteArgNeutralizesExpansion(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-expansion check")
+	}
+	for _, in := range []string{"$(echo pwned)", "`echo pwned`", "${PATH}", "a'b'c"} {
+		cmd := exec.Command("bash", "-c", "printf %s "+shell.QuoteArg(in))
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("bash failed for %q: %v", in, err)
+		}
+		if string(out) != in {
+			t.Errorf("bash expanded %q to %q; single-quoting must prevent expansion", in, string(out))
+		}
 	}
 }


### PR DESCRIPTION
First concrete overlay ingestion stage: copy the user-provided baseline RAW into the build workspace (never mutating the original), attach a loop device for downstream inspection/modification, and guarantee cleanup on every exit path. Gated on overlay mode; downstream stages (mount, OS detection, install) consume the Context populated here.

Loop primitive (internal/image/imagedisc/loopdev.go):
  - AttachImageToLoopDev attaches an already-existing image via losetup -fP and enumerates partition nodes; unlike CreateRawImageLoopDev it neither creates nor partitions the backing file, so it is safe on a baseline that must not be modified
  - loopDevPartitions enumerates partition nodes via lsblk, excluding the base device
  - losetup output is validated against an anchored `^/dev/loop\d+$` regex before use, and device paths are single-quoted (shell.QuoteArg) before interpolation into the privileged bash -c command, so no shell expansion is possible
  - on partition-enumeration failure the loop device is detached before returning so no loop device leaks; if that detach also fails the leaked device path is returned (non-empty) and the error is annotated with it
  - AttachImageToLoopDev added to LoopDevInterface

Overlay ingestion (internal/image/overlay/overlay.go):
  - Ingestor.WithBaseline acquires (copy + loop attach), runs the downstream func, then cleans up
  - local source.path is copied by copyLocalFile — an in-process, sparse-aware streaming copy (no shell, so paths with metacharacters are safe): all-zero chunks are turned into holes and the destination is truncated to the exact source size; short writes are detected and rejected. It is a real file copy, never a symlink or move
  - source.url is downloaded over TLS via network.DownloadFile; only https is accepted (plain http is rejected in BaselineSource.Validate and by the schema), and the downloaded file is tightened to 0600. The user-provided source is never modified
  - user-supplied path segments (systemConfig.name, image.name, target.os/dist/arch) are validated as safe single path segments before being joined into the workspace path; an empty (schema-optional) systemConfig.name falls back to a safe default
  - defer-based cleanup detaches the loop device on success, failure, and panic; a detach failure on a non-panic return is surfaced (joined with any fn error). The workspace copy is removed only on full success; it is retained on error/panic, and also when a loop device may still reference it
  - retainCopy (defaults to debug mode) keeps the workspace copy for debugging
  - loop device path and partitions stored in Context for downstream stages; all shell ops route through the allowlist

Tests:
  - overlay_test.go (mocked loop device + shell): copy-not-symlink, detach on success/error/panic, copy removal on success, retention (including when a loop device leaks), attach-failure cleanup, missing-source, empty-name default, sparse zero-run round-trip
  - overlay_integration_test.go: attaches/detaches a real loop device (dd -> losetup -fP); skips when not root or losetup unavailable
  - loopdev_test.go: AttachImageToLoopDev and loopDevPartitions including detach-on-enumeration-failure and detach-failure-surfacing paths, plus canonical-loop-path validation
  - shell_test.go: QuoteArg quoting and a bash round-trip proving no expansion occurs
  - rawmaker_test.go: mockLoopDev satisfies the extended interface

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
