### PR TITLE
Add two-slice dependency/conflict preflight policy gate

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,13 @@ type OverlayPolicy struct {
 	// overlay mode is additive-only in v1. A future release can lift the
 	// restriction by surfacing this field in the schema/YAML.
 	AllowRemoval bool `yaml:"-"`
+
+	// AllowDowngrade gates whether preflight permits downgrading a baseline
+	// package to an older version. Like AllowRemoval it is intentionally NOT a
+	// YAML field (the schema rejects it via additionalProperties:false) and
+	// always carries its zero value (false): overlay mode is additive-only in
+	// v1, so downgrades are blocked by default. A future release can surface it.
+	AllowDowngrade bool `yaml:"-"`
 }
 
 // ImageTemplate represents the YAML image template structure

--- a/internal/image/overlay/preflight.go
+++ b/internal/image/overlay/preflight.go
@@ -1,0 +1,466 @@
+package overlay
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/ospackage/debutils"
+	"github.com/open-edge-platform/image-composer-tool/internal/ospackage/rpmutils"
+)
+
+// ActionType classifies a single planned package operation produced by the
+// two-slice preflight (baseline installed set vs. resolved overlay set).
+type ActionType string
+
+const (
+	// ActionAdd installs a package that is not present in the baseline.
+	ActionAdd ActionType = "add"
+	// ActionUpgrade replaces a baseline package with a newer version.
+	ActionUpgrade ActionType = "upgrade"
+	// ActionDowngrade replaces a baseline package with an older version.
+	ActionDowngrade ActionType = "downgrade"
+	// ActionRemove deletes a package that is present in the baseline.
+	ActionRemove ActionType = "remove"
+	// ActionConflict marks a package whose installation conflicts with the
+	// baseline (e.g. an exclusive capability or an uncomparable version change).
+	ActionConflict ActionType = "conflict"
+)
+
+// Policy rule identifiers reported on a blocked action, so error output can name
+// the exact rule that was violated.
+const (
+	ruleAllowRemoval        = "allowRemoval=false"
+	ruleAllowDowngrade      = "allowDowngrade=false"
+	ruleConflictPolicyFail  = "conflictPolicy=fail"
+	ruleBootloaderImmutable = "bootloader-immutable"
+)
+
+// bootloaderPackagePrefixes are package-name prefixes (case-insensitive) that
+// identify bootloader packages. Overlay mode must never modify the bootloader,
+// so any non-trivial action touching one of these is blocked unconditionally.
+// A prefix matches the bare name or a sub-package at a '-'/digit boundary (see
+// isBootloaderPackage), so "grub" covers grub2, grub-efi-amd64, grub-pc, etc.
+// but "systemd-boot" does NOT swallow the unrelated "systemd-bootchart".
+var bootloaderPackagePrefixes = []string{
+	"grub",   // grub, grub2, grub-efi-amd64, grub-pc, grub2-efi-x64, ...
+	"grubby", // GRUB config tool on rpm distros (not caught by the "grub" boundary)
+	"shim",   // shim, shim-signed, shim-x64
+	"systemd-boot",
+	"sd-boot",
+	"gummiboot",
+	"efibootmgr",
+}
+
+// PlannedAction is a single classified package operation.
+type PlannedAction struct {
+	// Type is the classified action (add/upgrade/downgrade/remove/conflict).
+	Type ActionType
+	// Package is the canonical package name the action targets.
+	Package string
+	// CurrentVersion is the version installed in the baseline (Slice A); empty
+	// for a pure add.
+	CurrentVersion string
+	// RequestedVersion is the version the overlay resolution would install
+	// (Slice B); empty for a remove.
+	RequestedVersion string
+	// Arch is the package architecture, when known.
+	Arch string
+	// ConflictWith names the baseline package this one conflicts with, for
+	// conflict actions surfaced by the simulate aid.
+	ConflictWith string
+	// Bootloader reports whether this action touches a bootloader package.
+	Bootloader bool
+	// Detail carries optional extra diagnostic context (e.g. a simulator note).
+	Detail string
+}
+
+// PolicyViolation records a planned action blocked by policy and the rule it
+// violated.
+type PolicyViolation struct {
+	Action PlannedAction
+	// Rule is the violated policy rule identifier (one of the rule* constants).
+	Rule string
+}
+
+// PreflightReport is the deterministic result of the two-slice preflight. It is
+// the unit the install step gates on: when Blocked is true, installation must
+// not proceed.
+type PreflightReport struct {
+	// Actions are all classified planned actions, in deterministic order.
+	Actions []PlannedAction
+	// Violations are the actions blocked by policy, in deterministic order.
+	Violations []PolicyViolation
+	// Counts of each action class, for logging/diagnostics.
+	Adds, Upgrades, Downgrades, Removes, Conflicts int
+	// Blocked is true when at least one policy violation was found.
+	Blocked bool
+}
+
+// PreflightInput is the pure, side-effect-free input to EvaluatePreflight. It is
+// deliberately decoupled from I/O so every policy path is unit-testable.
+type PreflightInput struct {
+	// Family is the package-manager family, used to pick the version comparator.
+	Family PackageManager
+	// Baseline is Slice A: the baseline package inventory (only installed
+	// packages participate).
+	Baseline []BaselinePackage
+	// Resolved is Slice B: the set the overlay will actually install (the
+	// plan's ToInstall — closure members not already satisfied by the baseline),
+	// carrying the requested versions. It excludes already-present closure members
+	// on purpose, since additive-only install never reinstalls them.
+	Resolved []ResolvedPackage
+	// SimulatedActions are removals/conflicts surfaced by a package-manager
+	// simulate run, merged in as a validation aid. The two-slice comparison
+	// remains authoritative for add/upgrade/downgrade; this only contributes the
+	// remove/conflict actions a purely additive closure cannot itself produce.
+	SimulatedActions []PlannedAction
+	// Policy is the overlay policy that gates the classified actions.
+	Policy config.OverlayPolicy
+}
+
+// simulateOverlayInstall is a seam over the optional package-manager simulate
+// step (apt-get install --simulate / dnf install --assumeno). Its output is a
+// validation aid only — the two-slice model drives the policy decision — so the
+// default is a no-op. The install-wiring story can plug a real simulator in, and
+// tests override it to exercise the remove/conflict policy paths.
+var simulateOverlayInstall = func(info *BaselineInfo, plan *ResolutionPlan) ([]PlannedAction, error) {
+	return nil, nil
+}
+
+// Preflight runs the two-slice dependency/conflict preflight for an overlay
+// build and enforces the overlay policy. It compares the baseline installed set
+// (Slice A) against the set the overlay will actually install (Slice B =
+// plan.ToInstall), classifies every planned action, and blocks installation on
+// any policy violation with an actionable diagnostic.
+//
+// Slice B is deliberately plan.ToInstall, NOT the full plan.Closure: overlay
+// mode is additive-only, so only ToInstall (the closure members not already
+// satisfied by the baseline) is ever handed to dpkg/rpm. Closure members already
+// present in the baseline are never reinstalled, so comparing their repo-pool
+// version against the baseline would spuriously flag security-patched base
+// packages (whose installed version outranks the pool) as downgrades even though
+// the overlay never touches them.
+//
+// It returns the report unconditionally (so callers can log the full plan) and a
+// non-nil error when the preflight is blocked.
+func Preflight(info *BaselineInfo, baseline []BaselinePackage, plan *ResolutionPlan, policy *config.OverlayPolicy) (*PreflightReport, error) {
+	if info == nil {
+		return nil, fmt.Errorf("overlay preflight: baseline info cannot be nil")
+	}
+	if plan == nil {
+		return nil, fmt.Errorf("overlay preflight: resolution plan cannot be nil")
+	}
+
+	effectivePolicy := config.OverlayPolicy{}
+	if policy != nil {
+		effectivePolicy = *policy
+	}
+
+	// The simulate step is an optional validation aid; its failure must not mask
+	// the authoritative two-slice decision, so a simulate error is logged and the
+	// preflight continues on the two-slice model alone.
+	simulated, err := simulateOverlayInstall(info, plan)
+	if err != nil {
+		log.Warnf("Overlay preflight: package-manager simulation unavailable, continuing on two-slice model only: %v", err)
+		simulated = nil
+	}
+
+	report := EvaluatePreflight(PreflightInput{
+		Family:           info.PackageManager,
+		Baseline:         baseline,
+		Resolved:         plan.ToInstall,
+		SimulatedActions: simulated,
+		Policy:           effectivePolicy,
+	})
+
+	log.Infof("Overlay preflight: %d add, %d upgrade, %d downgrade, %d remove, %d conflict; %d policy violation(s)",
+		report.Adds, report.Upgrades, report.Downgrades, report.Removes, report.Conflicts, len(report.Violations))
+
+	if report.Blocked {
+		return report, fmt.Errorf("overlay preflight failed: %s", formatViolations(report.Violations))
+	}
+	return report, nil
+}
+
+// EvaluatePreflight performs the pure two-slice classification and policy
+// enforcement. It is deterministic and side-effect free.
+func EvaluatePreflight(in PreflightInput) *PreflightReport {
+	sliceA := baselineVersionIndex(in.Baseline)
+
+	actions := classifyActions(in.Family, sliceA, in.Resolved)
+	actions = append(actions, normalizeSimulatedActions(in.SimulatedActions, sliceA)...)
+
+	// Flag any action that touches a bootloader package so the policy gate can
+	// block bootloader replacement regardless of the other knobs.
+	for i := range actions {
+		if isBootloaderPackage(actions[i].Package) {
+			actions[i].Bootloader = true
+		}
+	}
+
+	sortActions(actions)
+
+	report := &PreflightReport{Actions: actions}
+	for _, a := range actions {
+		switch a.Type {
+		case ActionAdd:
+			report.Adds++
+		case ActionUpgrade:
+			report.Upgrades++
+		case ActionDowngrade:
+			report.Downgrades++
+		case ActionRemove:
+			report.Removes++
+		case ActionConflict:
+			report.Conflicts++
+		}
+		if rule, blocked := violatedRule(a, in.Policy); blocked {
+			report.Violations = append(report.Violations, PolicyViolation{Action: a, Rule: rule})
+		}
+	}
+
+	report.Blocked = len(report.Violations) > 0
+	return report
+}
+
+// classifyActions derives add/upgrade/downgrade actions from the two slices by
+// walking the resolved set (Slice B) against the baseline index (Slice A).
+// Packages present in the baseline at the same version yield no action; packages
+// in the baseline but absent from the resolved set are left untouched (overlay is
+// additive-only), so removals never originate here — they arrive via the
+// simulate aid.
+func classifyActions(family PackageManager, sliceA map[string]BaselinePackage, resolved []ResolvedPackage) []PlannedAction {
+	var actions []PlannedAction
+	for _, rp := range resolved {
+		name := strings.TrimSpace(rp.Name)
+		if name == "" {
+			continue
+		}
+		base, present := sliceA[name]
+		if !present {
+			actions = append(actions, PlannedAction{
+				Type:             ActionAdd,
+				Package:          name,
+				RequestedVersion: rp.Version,
+				Arch:             rp.Arch,
+			})
+			continue
+		}
+
+		cmp, err := comparePkgVersions(family, rp.Version, base.Version)
+		if err != nil {
+			// Direction is undeterminable, so we cannot prove this is a safe
+			// upgrade. Treat it as a conflict (conservative: blocked by the
+			// default fail policy) rather than silently assuming an upgrade.
+			actions = append(actions, PlannedAction{
+				Type:             ActionConflict,
+				Package:          name,
+				CurrentVersion:   base.Version,
+				RequestedVersion: rp.Version,
+				Arch:             rp.Arch,
+				Detail:           fmt.Sprintf("version comparison failed: %v", err),
+			})
+			continue
+		}
+		switch {
+		case cmp > 0:
+			actions = append(actions, PlannedAction{
+				Type:             ActionUpgrade,
+				Package:          name,
+				CurrentVersion:   base.Version,
+				RequestedVersion: rp.Version,
+				Arch:             rp.Arch,
+			})
+		case cmp < 0:
+			actions = append(actions, PlannedAction{
+				Type:             ActionDowngrade,
+				Package:          name,
+				CurrentVersion:   base.Version,
+				RequestedVersion: rp.Version,
+				Arch:             rp.Arch,
+			})
+			// cmp == 0: package already present at the requested version, no action.
+		}
+	}
+	return actions
+}
+
+// normalizeSimulatedActions filters simulator-reported actions to the
+// remove/conflict classes (the two-slice comparison owns add/upgrade/downgrade)
+// and fills in the baseline version for removals when the simulator omitted it.
+// Package names are trimmed and empty ones dropped (mirroring classifyActions),
+// so a blank or whitespace-padded name from the simulator can neither slip into
+// the report nor break baseline backfill, bootloader detection, or sorting.
+func normalizeSimulatedActions(simulated []PlannedAction, sliceA map[string]BaselinePackage) []PlannedAction {
+	var out []PlannedAction
+	for _, a := range simulated {
+		if a.Type != ActionRemove && a.Type != ActionConflict {
+			continue
+		}
+		a.Package = strings.TrimSpace(a.Package)
+		if a.Package == "" {
+			continue
+		}
+		if a.CurrentVersion == "" {
+			if base, ok := sliceA[a.Package]; ok {
+				a.CurrentVersion = base.Version
+			}
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// violatedRule returns the policy rule an action violates, if any. Bootloader
+// replacement is checked first (it is unconditional and the most severe), then
+// the per-class knobs. Each action yields at most one violation.
+func violatedRule(a PlannedAction, policy config.OverlayPolicy) (string, bool) {
+	// Adds and no-ops are always permitted unless they would modify the
+	// bootloader; only state-changing actions on bootloader packages are blocked.
+	if a.Bootloader && a.Type != ActionAdd {
+		return ruleBootloaderImmutable, true
+	}
+
+	switch a.Type {
+	case ActionRemove:
+		if !policy.AllowRemoval {
+			return ruleAllowRemoval, true
+		}
+	case ActionDowngrade:
+		if !policy.AllowDowngrade {
+			return ruleAllowDowngrade, true
+		}
+	case ActionConflict:
+		if conflictPolicy(policy) == config.OverlayConflictPolicyFail {
+			return ruleConflictPolicyFail, true
+		}
+	}
+	return "", false
+}
+
+// conflictPolicy returns the effective conflict policy, defaulting to "fail"
+// when unset (matching config.OverlayPolicy.validate).
+func conflictPolicy(policy config.OverlayPolicy) string {
+	if strings.TrimSpace(policy.ConflictPolicy) == "" {
+		return config.OverlayConflictPolicyFail
+	}
+	return policy.ConflictPolicy
+}
+
+// baselineVersionIndex builds Slice A: a name→package index of the installed
+// baseline packages. Non-installed records (config-files remnants, etc.) are
+// excluded so they never register as a current version.
+func baselineVersionIndex(baseline []BaselinePackage) map[string]BaselinePackage {
+	index := make(map[string]BaselinePackage, len(baseline))
+	for _, p := range baseline {
+		if !p.Installed || strings.TrimSpace(p.Name) == "" {
+			continue
+		}
+		index[p.Name] = p
+	}
+	return index
+}
+
+// comparePkgVersions compares two version strings for a package family, reusing
+// the resolver's family-specific comparator. Returns -1/0/1 for a<b / a==b / a>b.
+func comparePkgVersions(family PackageManager, a, b string) (int, error) {
+	if family == PackageManagerDNF {
+		return rpmutils.CompareRPMVersions(a, b)
+	}
+	return debutils.CompareDebianVersions(a, b)
+}
+
+// isBootloaderPackage reports whether a package name identifies a bootloader
+// component that overlay mode must never modify. A prefix matches the bare
+// package or a sub-package separated by '-' or a digit (e.g. "grub2",
+// "grub-efi-amd64", "systemd-boot-efi"), but NOT a different package that merely
+// shares the prefix's letters (e.g. "systemd-bootchart", a boot profiler).
+func isBootloaderPackage(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	for _, prefix := range bootloaderPackagePrefixes {
+		if !strings.HasPrefix(lower, prefix) {
+			continue
+		}
+		if len(lower) == len(prefix) {
+			return true // exact package name
+		}
+		// A sub-package boundary is a '-' separator or a version digit ("grub2");
+		// any other continuing letter means a different package ("systemd-bootchart").
+		next := lower[len(prefix)]
+		if next == '-' || (next >= '0' && next <= '9') {
+			return true
+		}
+	}
+	return false
+}
+
+// sortActions orders actions deterministically. It keys on type, package, and
+// arch, then breaks remaining ties on the version/detail fields so two actions
+// that share the primary keys (e.g. a two-slice conflict and a simulate-sourced
+// conflict on the same package/arch) still order identically across runs.
+func sortActions(actions []PlannedAction) {
+	sort.Slice(actions, func(i, j int) bool {
+		a, b := actions[i], actions[j]
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		if a.Package != b.Package {
+			return a.Package < b.Package
+		}
+		if a.Arch != b.Arch {
+			return a.Arch < b.Arch
+		}
+		if a.RequestedVersion != b.RequestedVersion {
+			return a.RequestedVersion < b.RequestedVersion
+		}
+		if a.CurrentVersion != b.CurrentVersion {
+			return a.CurrentVersion < b.CurrentVersion
+		}
+		if a.ConflictWith != b.ConflictWith {
+			return a.ConflictWith < b.ConflictWith
+		}
+		return a.Detail < b.Detail
+	})
+}
+
+// formatViolations renders policy violations into an actionable, deterministic
+// multi-line diagnostic naming the offending package, current and requested
+// versions, and the violated rule for each.
+func formatViolations(violations []PolicyViolation) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d policy violation(s) block installation:", len(violations))
+	for _, v := range violations {
+		fmt.Fprintf(&b, "\n  - %s", describeViolation(v))
+	}
+	return b.String()
+}
+
+// describeViolation renders one violation line.
+func describeViolation(v PolicyViolation) string {
+	a := v.Action
+	current := a.CurrentVersion
+	if current == "" {
+		current = "(absent)"
+	}
+	requested := a.RequestedVersion
+	if requested == "" {
+		requested = "(removed)"
+	}
+
+	msg := fmt.Sprintf("%s %q: current=%s requested=%s [rule: %s]", a.Type, a.Package, current, requested, v.Rule)
+	if a.Bootloader && v.Rule == ruleBootloaderImmutable {
+		msg += " (bootloader packages must not be replaced in overlay mode)"
+	}
+	if a.ConflictWith != "" {
+		msg += fmt.Sprintf(" (conflicts with %q)", a.ConflictWith)
+	}
+	if a.Detail != "" {
+		msg += fmt.Sprintf(" (%s)", a.Detail)
+	}
+	return msg
+}

--- a/internal/image/overlay/preflight_test.go
+++ b/internal/image/overlay/preflight_test.go
@@ -1,0 +1,440 @@
+package overlay
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+)
+
+// installedDeb is a small helper for building a Slice A baseline entry.
+func installedDeb(name, version string) BaselinePackage {
+	return BaselinePackage{Name: name, Version: version, Arch: "amd64", Installed: true}
+}
+
+// TestEvaluatePreflight_PolicyPaths is the table-driven core: each row drives one
+// classified action through the policy gate and asserts whether it is blocked,
+// the action class, and the rule cited on a block.
+func TestEvaluatePreflight_PolicyPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		family     PackageManager
+		baseline   []BaselinePackage
+		resolved   []ResolvedPackage
+		simulated  []PlannedAction
+		policy     config.OverlayPolicy
+		wantAction ActionType
+		wantBlock  bool
+		wantRule   string
+	}{
+		{
+			name:       "pure add is always allowed",
+			baseline:   []BaselinePackage{installedDeb("libc6", "2.34")},
+			resolved:   []ResolvedPackage{{Name: "curl", Version: "8.0", Arch: "amd64"}},
+			wantAction: ActionAdd,
+			wantBlock:  false,
+		},
+		{
+			name:       "upgrade is allowed (additive bump of an existing pkg)",
+			baseline:   []BaselinePackage{installedDeb("curl", "7.0")},
+			resolved:   []ResolvedPackage{{Name: "curl", Version: "8.0", Arch: "amd64"}},
+			wantAction: ActionUpgrade,
+			wantBlock:  false,
+		},
+		{
+			name:       "same version yields no action",
+			baseline:   []BaselinePackage{installedDeb("curl", "8.0")},
+			resolved:   []ResolvedPackage{{Name: "curl", Version: "8.0", Arch: "amd64"}},
+			wantAction: "", // no action emitted
+			wantBlock:  false,
+		},
+		{
+			name:       "downgrade blocked when allowDowngrade is false",
+			baseline:   []BaselinePackage{installedDeb("curl", "8.0")},
+			resolved:   []ResolvedPackage{{Name: "curl", Version: "7.0", Arch: "amd64"}},
+			policy:     config.OverlayPolicy{AllowDowngrade: false},
+			wantAction: ActionDowngrade,
+			wantBlock:  true,
+			wantRule:   ruleAllowDowngrade,
+		},
+		{
+			name:       "downgrade allowed when allowDowngrade is true",
+			baseline:   []BaselinePackage{installedDeb("curl", "8.0")},
+			resolved:   []ResolvedPackage{{Name: "curl", Version: "7.0", Arch: "amd64"}},
+			policy:     config.OverlayPolicy{AllowDowngrade: true},
+			wantAction: ActionDowngrade,
+			wantBlock:  false,
+		},
+		{
+			name:       "removal blocked when allowRemoval is false",
+			baseline:   []BaselinePackage{installedDeb("oldpkg", "1.0")},
+			simulated:  []PlannedAction{{Type: ActionRemove, Package: "oldpkg"}},
+			policy:     config.OverlayPolicy{AllowRemoval: false},
+			wantAction: ActionRemove,
+			wantBlock:  true,
+			wantRule:   ruleAllowRemoval,
+		},
+		{
+			name:       "removal allowed when allowRemoval is true",
+			baseline:   []BaselinePackage{installedDeb("oldpkg", "1.0")},
+			simulated:  []PlannedAction{{Type: ActionRemove, Package: "oldpkg"}},
+			policy:     config.OverlayPolicy{AllowRemoval: true},
+			wantAction: ActionRemove,
+			wantBlock:  false,
+		},
+		{
+			name:       "conflict blocked under fail policy",
+			simulated:  []PlannedAction{{Type: ActionConflict, Package: "foo", ConflictWith: "bar"}},
+			policy:     config.OverlayPolicy{ConflictPolicy: config.OverlayConflictPolicyFail},
+			wantAction: ActionConflict,
+			wantBlock:  true,
+			wantRule:   ruleConflictPolicyFail,
+		},
+		{
+			name:       "conflict blocked under defaulted (empty) policy",
+			simulated:  []PlannedAction{{Type: ActionConflict, Package: "foo"}},
+			policy:     config.OverlayPolicy{}, // empty conflictPolicy defaults to fail
+			wantAction: ActionConflict,
+			wantBlock:  true,
+			wantRule:   ruleConflictPolicyFail,
+		},
+		{
+			name:       "conflict allowed under allow-explicit policy",
+			simulated:  []PlannedAction{{Type: ActionConflict, Package: "foo"}},
+			policy:     config.OverlayPolicy{ConflictPolicy: config.OverlayConflictPolicyAllowExplicit},
+			wantAction: ActionConflict,
+			wantBlock:  false,
+		},
+		{
+			name:       "simulate-sourced conflict allowed under explicit policy with versions reported",
+			baseline:   []BaselinePackage{installedDeb("foo", "1.0")},
+			simulated:  []PlannedAction{{Type: ActionConflict, Package: "foo", RequestedVersion: "2.0", ConflictWith: "bar"}},
+			policy:     config.OverlayPolicy{ConflictPolicy: config.OverlayConflictPolicyAllowExplicit},
+			wantAction: ActionConflict,
+			wantBlock:  false,
+		},
+		{
+			name:       "bootloader upgrade blocked even when versions bump cleanly",
+			baseline:   []BaselinePackage{installedDeb("grub-efi-amd64", "2.06")},
+			resolved:   []ResolvedPackage{{Name: "grub-efi-amd64", Version: "2.12", Arch: "amd64"}},
+			policy:     config.OverlayPolicy{AllowDowngrade: true, AllowRemoval: true},
+			wantAction: ActionUpgrade,
+			wantBlock:  true,
+			wantRule:   ruleBootloaderImmutable,
+		},
+		{
+			name:       "bootloader removal blocked even when allowRemoval is true",
+			baseline:   []BaselinePackage{installedDeb("shim-signed", "1.0")},
+			simulated:  []PlannedAction{{Type: ActionRemove, Package: "shim-signed"}},
+			policy:     config.OverlayPolicy{AllowRemoval: true},
+			wantAction: ActionRemove,
+			wantBlock:  true,
+			wantRule:   ruleBootloaderImmutable,
+		},
+		{
+			name:       "bootloader add is allowed (additive, does not replace)",
+			resolved:   []ResolvedPackage{{Name: "grub-common", Version: "2.12", Arch: "amd64"}},
+			policy:     config.OverlayPolicy{},
+			wantAction: ActionAdd,
+			wantBlock:  false,
+		},
+		{
+			name:       "rpm upgrade classified with rpm comparator",
+			family:     PackageManagerDNF,
+			baseline:   []BaselinePackage{{Name: "glibc", Version: "2.36-1", Arch: "x86_64", Installed: true}},
+			resolved:   []ResolvedPackage{{Name: "glibc", Version: "2.38-1", Arch: "x86_64"}},
+			wantAction: ActionUpgrade,
+			wantBlock:  false,
+		},
+		{
+			name:       "rpm downgrade classified and blocked",
+			family:     PackageManagerDNF,
+			baseline:   []BaselinePackage{{Name: "glibc", Version: "2.38-1", Arch: "x86_64", Installed: true}},
+			resolved:   []ResolvedPackage{{Name: "glibc", Version: "2.36-1", Arch: "x86_64"}},
+			policy:     config.OverlayPolicy{},
+			wantAction: ActionDowngrade,
+			wantBlock:  true,
+			wantRule:   ruleAllowDowngrade,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			family := tt.family
+			if family == "" {
+				family = PackageManagerAPT
+			}
+			report := EvaluatePreflight(PreflightInput{
+				Family:           family,
+				Baseline:         tt.baseline,
+				Resolved:         tt.resolved,
+				SimulatedActions: tt.simulated,
+				Policy:           tt.policy,
+			})
+
+			if report.Blocked != tt.wantBlock {
+				t.Fatalf("Blocked = %v, want %v (actions=%+v violations=%+v)",
+					report.Blocked, tt.wantBlock, report.Actions, report.Violations)
+			}
+
+			if tt.wantAction == "" {
+				if len(report.Actions) != 0 {
+					t.Fatalf("expected no action, got %+v", report.Actions)
+				}
+				return
+			}
+
+			if len(report.Actions) != 1 {
+				t.Fatalf("expected exactly one action, got %+v", report.Actions)
+			}
+			if report.Actions[0].Type != tt.wantAction {
+				t.Errorf("action type = %s, want %s", report.Actions[0].Type, tt.wantAction)
+			}
+
+			if tt.wantBlock {
+				if len(report.Violations) != 1 {
+					t.Fatalf("expected one violation, got %+v", report.Violations)
+				}
+				if report.Violations[0].Rule != tt.wantRule {
+					t.Errorf("rule = %s, want %s", report.Violations[0].Rule, tt.wantRule)
+				}
+			} else if len(report.Violations) != 0 {
+				t.Errorf("expected no violations, got %+v", report.Violations)
+			}
+		})
+	}
+}
+
+// TestEvaluatePreflight_Counts confirms the per-class counters add up across a
+// mixed plan and that ordering is deterministic.
+func TestEvaluatePreflight_Counts(t *testing.T) {
+	report := EvaluatePreflight(PreflightInput{
+		Family: PackageManagerAPT,
+		Baseline: []BaselinePackage{
+			installedDeb("curl", "7.0"),   // -> upgrade
+			installedDeb("wget", "2.0"),   // -> downgrade
+			installedDeb("zlib", "1.0"),   // unchanged in resolved -> no action
+			installedDeb("oldpkg", "1.0"), // -> remove (via simulate)
+		},
+		Resolved: []ResolvedPackage{
+			{Name: "curl", Version: "8.0", Arch: "amd64"},
+			{Name: "wget", Version: "1.0", Arch: "amd64"},
+			{Name: "zlib", Version: "1.0", Arch: "amd64"},
+			{Name: "vim", Version: "9.0", Arch: "amd64"}, // -> add
+		},
+		SimulatedActions: []PlannedAction{
+			{Type: ActionRemove, Package: "oldpkg"},
+			{Type: ActionConflict, Package: "foo", ConflictWith: "bar"},
+		},
+		Policy: config.OverlayPolicy{AllowRemoval: true, AllowDowngrade: true, ConflictPolicy: config.OverlayConflictPolicyAllowExplicit},
+	})
+
+	if report.Adds != 1 || report.Upgrades != 1 || report.Downgrades != 1 || report.Removes != 1 || report.Conflicts != 1 {
+		t.Errorf("counts add=%d up=%d down=%d rm=%d conflict=%d, want 1 each",
+			report.Adds, report.Upgrades, report.Downgrades, report.Removes, report.Conflicts)
+	}
+	if report.Blocked {
+		t.Errorf("expected not blocked under permissive policy, violations=%+v", report.Violations)
+	}
+
+	// Actions are sorted by type, then package: add < conflict < downgrade < remove < upgrade.
+	wantOrder := []struct {
+		typ ActionType
+		pkg string
+	}{
+		{ActionAdd, "vim"},
+		{ActionConflict, "foo"},
+		{ActionDowngrade, "wget"},
+		{ActionRemove, "oldpkg"},
+		{ActionUpgrade, "curl"},
+	}
+	if len(report.Actions) != len(wantOrder) {
+		t.Fatalf("got %d actions, want %d: %+v", len(report.Actions), len(wantOrder), report.Actions)
+	}
+	for i, w := range wantOrder {
+		if report.Actions[i].Type != w.typ || report.Actions[i].Package != w.pkg {
+			t.Errorf("action[%d] = %s/%s, want %s/%s", i, report.Actions[i].Type, report.Actions[i].Package, w.typ, w.pkg)
+		}
+	}
+}
+
+// TestEvaluatePreflight_Deterministic confirms reordered inputs produce an
+// identical report.
+func TestEvaluatePreflight_Deterministic(t *testing.T) {
+	baseline := []BaselinePackage{installedDeb("a", "1.0"), installedDeb("b", "1.0")}
+	run := func(resolved []ResolvedPackage) *PreflightReport {
+		return EvaluatePreflight(PreflightInput{
+			Family:   PackageManagerAPT,
+			Baseline: baseline,
+			Resolved: resolved,
+			Policy:   config.OverlayPolicy{},
+		})
+	}
+	a := run([]ResolvedPackage{{Name: "a", Version: "2.0"}, {Name: "c", Version: "1.0"}})
+	b := run([]ResolvedPackage{{Name: "c", Version: "1.0"}, {Name: "a", Version: "2.0"}})
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("reports differ for reordered inputs:\n a=%+v\n b=%+v", a, b)
+	}
+}
+
+// TestPreflight_BlockedErrorIsActionable confirms the orchestrator returns the
+// report plus an error naming the offending package, both versions, and the rule.
+func TestPreflight_BlockedErrorIsActionable(t *testing.T) {
+	info := &BaselineInfo{OS: "ubuntu", Arch: "amd64", PackageManager: PackageManagerAPT}
+	baseline := []BaselinePackage{installedDeb("curl", "8.0")}
+	plan := &ResolutionPlan{
+		// A downgrade reaching ToInstall (the set actually installed) must block.
+		ToInstall: []ResolvedPackage{{Name: "curl", Version: "7.0", Arch: "amd64"}},
+	}
+
+	report, err := Preflight(info, baseline, plan, &config.OverlayPolicy{})
+	if err == nil {
+		t.Fatal("expected preflight to be blocked")
+	}
+	if report == nil || !report.Blocked {
+		t.Fatalf("expected a blocked report, got %+v", report)
+	}
+	for _, want := range []string{"curl", "8.0", "7.0", ruleAllowDowngrade, "downgrade"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// TestPreflight_AllowedReturnsNoError confirms a clean additive plan passes.
+func TestPreflight_AllowedReturnsNoError(t *testing.T) {
+	info := &BaselineInfo{OS: "ubuntu", Arch: "amd64", PackageManager: PackageManagerAPT}
+	baseline := []BaselinePackage{installedDeb("libc6", "2.34")}
+	plan := &ResolutionPlan{
+		// libc6 is in the closure but already present, so it is NOT in ToInstall;
+		// only the genuinely-added curl reaches the preflight gate.
+		ToInstall: []ResolvedPackage{
+			{Name: "curl", Version: "8.0", Arch: "amd64"},
+		},
+	}
+	report, err := Preflight(info, baseline, plan, &config.OverlayPolicy{})
+	if err != nil {
+		t.Fatalf("unexpected preflight error: %v", err)
+	}
+	if report.Blocked || report.Adds != 1 {
+		t.Errorf("expected one clean add, got %+v", report)
+	}
+}
+
+// TestPreflight_SimulateAidContributesActions confirms the simulate seam feeds
+// remove/conflict actions into the policy gate, and that a simulate failure is
+// non-fatal (two-slice model still drives the decision).
+func TestPreflight_SimulateAidContributesActions(t *testing.T) {
+	info := &BaselineInfo{OS: "ubuntu", Arch: "amd64", PackageManager: PackageManagerAPT}
+	baseline := []BaselinePackage{installedDeb("oldpkg", "1.0")}
+	plan := &ResolutionPlan{ToInstall: []ResolvedPackage{{Name: "curl", Version: "8.0", Arch: "amd64"}}}
+
+	orig := simulateOverlayInstall
+	defer func() { simulateOverlayInstall = orig }()
+
+	t.Run("simulate-reported removal is gated", func(t *testing.T) {
+		simulateOverlayInstall = func(*BaselineInfo, *ResolutionPlan) ([]PlannedAction, error) {
+			return []PlannedAction{{Type: ActionRemove, Package: "oldpkg"}}, nil
+		}
+		report, err := Preflight(info, baseline, plan, &config.OverlayPolicy{})
+		if err == nil || !report.Blocked {
+			t.Fatalf("expected removal to block, err=%v report=%+v", err, report)
+		}
+		if report.Violations[0].Rule != ruleAllowRemoval {
+			t.Errorf("rule = %s, want %s", report.Violations[0].Rule, ruleAllowRemoval)
+		}
+		// The remove action carries the baseline version backfilled from Slice A.
+		if report.Violations[0].Action.CurrentVersion != "1.0" {
+			t.Errorf("current version = %q, want 1.0 (backfilled)", report.Violations[0].Action.CurrentVersion)
+		}
+	})
+
+	t.Run("simulate failure is non-fatal", func(t *testing.T) {
+		simulateOverlayInstall = func(*BaselineInfo, *ResolutionPlan) ([]PlannedAction, error) {
+			return nil, errors.New("simulate unavailable")
+		}
+		report, err := Preflight(info, baseline, plan, &config.OverlayPolicy{})
+		if err != nil {
+			t.Fatalf("simulate failure must not fail preflight: %v", err)
+		}
+		if report.Blocked || report.Adds != 1 {
+			t.Errorf("expected clean add via two-slice model, got %+v", report)
+		}
+	})
+}
+
+// TestEvaluatePreflight_SimulatedEmptyPackageDropped guards that simulator
+// output with a blank or whitespace-padded package name cannot slip into the
+// report: empty names are dropped, and a padded name is trimmed so baseline
+// backfill still resolves.
+func TestEvaluatePreflight_SimulatedEmptyPackageDropped(t *testing.T) {
+	report := EvaluatePreflight(PreflightInput{
+		Family:   PackageManagerAPT,
+		Baseline: []BaselinePackage{installedDeb("oldpkg", "1.0")},
+		SimulatedActions: []PlannedAction{
+			{Type: ActionRemove, Package: ""},           // blank -> dropped
+			{Type: ActionRemove, Package: "   "},        // whitespace-only -> dropped
+			{Type: ActionRemove, Package: "  oldpkg  "}, // trimmed -> backfilled
+		},
+		Policy: config.OverlayPolicy{AllowRemoval: true},
+	})
+
+	if report.Removes != 1 {
+		t.Fatalf("removes = %d, want 1 (empty names dropped); actions=%+v", report.Removes, report.Actions)
+	}
+	if got := report.Actions[0].Package; got != "oldpkg" {
+		t.Errorf("package = %q, want %q (trimmed)", got, "oldpkg")
+	}
+	if got := report.Actions[0].CurrentVersion; got != "1.0" {
+		t.Errorf("current version = %q, want 1.0 (backfilled after trim)", got)
+	}
+}
+
+func TestIsBootloaderPackage(t *testing.T) {
+	bootloader := []string{"grub", "grub2", "grub-efi-amd64", "grub2-efi-x64-modules", "shim", "shim-signed", "systemd-boot", "efibootmgr", "GRUB2"}
+	for _, n := range bootloader {
+		if !isBootloaderPackage(n) {
+			t.Errorf("isBootloaderPackage(%q) = false, want true", n)
+		}
+	}
+	// Packages that merely share a prefix's letters must NOT be flagged:
+	// systemd-bootchart is a boot profiler, grubbish/shimmer are not bootloaders.
+	for _, n := range []string{"curl", "libc6", "vim", "", "graphite2", "systemd-bootchart", "shimmer"} {
+		if isBootloaderPackage(n) {
+			t.Errorf("isBootloaderPackage(%q) = true, want false", n)
+		}
+	}
+	// grubby (rpm GRUB tool) is explicitly listed and must be caught.
+	if !isBootloaderPackage("grubby") {
+		t.Error("isBootloaderPackage(grubby) = false, want true")
+	}
+}
+
+// TestEvaluatePreflight_BootChartNotBlocked guards the systemd-bootchart false
+// positive: a clean upgrade of a non-bootloader package that shares a bootloader
+// prefix must pass.
+func TestEvaluatePreflight_BootChartNotBlocked(t *testing.T) {
+	report := EvaluatePreflight(PreflightInput{
+		Family:   PackageManagerAPT,
+		Baseline: []BaselinePackage{installedDeb("systemd-bootchart", "233")},
+		Resolved: []ResolvedPackage{{Name: "systemd-bootchart", Version: "234", Arch: "amd64"}},
+		Policy:   config.OverlayPolicy{},
+	})
+	if report.Blocked {
+		t.Errorf("systemd-bootchart upgrade wrongly blocked: %+v", report.Violations)
+	}
+	if report.Upgrades != 1 {
+		t.Errorf("expected one upgrade, got %+v", report.Actions)
+	}
+}
+
+func TestPreflight_NilGuards(t *testing.T) {
+	if _, err := Preflight(nil, nil, &ResolutionPlan{}, nil); err == nil {
+		t.Error("expected error for nil info")
+	}
+	if _, err := Preflight(&BaselineInfo{PackageManager: PackageManagerAPT}, nil, nil, nil); err == nil {
+		t.Error("expected error for nil plan")
+	}
+}

--- a/internal/ospackage/rpmutils/helper.go
+++ b/internal/ospackage/rpmutils/helper.go
@@ -675,6 +675,15 @@ func extractVersionRequirement(reqVers []string, depName string) (op string, ver
 	return "", "", false
 }
 
+// CompareRPMVersions compares two RPM EVR (epoch:version-release) strings.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b. It is the exported entry point
+// over the package-internal comparator so callers outside rpmutils (e.g. overlay
+// preflight) can classify upgrades vs downgrades using the same logic the
+// resolver uses.
+func CompareRPMVersions(a, b string) (int, error) {
+	return comparePackageVersions(a, b)
+}
+
 func comparePackageVersions(a, b string) (int, error) {
 	// Empty-version handling: empty < any non-empty
 	if a == "" && b == "" {


### PR DESCRIPTION
Before overlay installation, classify planned package actions by comparing the baseline installed set (Slice A) against the resolved overlay set (Slice B) and enforce the overlay policy, failing fast with actionable diagnostics on any violation.

Preflight (internal/image/overlay/preflight.go):
  - EvaluatePreflight is the pure, deterministic two-slice core: it indexes the installed baseline (baselineVersionIndex, installed-only) and walks the resolution plan's closure, classifying each delta as add / upgrade / downgrade / remove / conflict using the family-aware version comparators.
  - Upgrade/downgrade direction is derived from comparePkgVersions (CompareDebianVersions / CompareRPMVersions); an uncomparable version becomes a conflict rather than a silent upgrade.
  - Removals and conflicts cannot arise from a purely additive closure, so they are sourced from an optional package-manager simulate aid (simulateOverlayInstall seam, no-op by default) and merged in; normalizeSimulatedActions filters to remove/conflict and backfills the baseline version. The two-slice model stays authoritative: a simulate failure is logged, not fatal.
  - Policy enforcement (violatedRule) blocks removals when allowRemoval is false, downgrades when allowDowngrade is false, conflicts when conflictPolicy is fail (the default), and any non-add action touching a bootloader package unconditionally (overlay must never replace the bootloader). Each action yields at most one violation, bootloader first.
  - isBootloaderPackage matches a prefix only at a '-'/digit boundary so grub/grub2/grub-efi-* and systemd-boot(-efi) are caught while unrelated packages that merely share the letters (systemd-bootchart) are not; grubby is listed explicitly.
  - Preflight orchestrates and returns the full report plus a non-nil error when blocked; formatViolations renders offending package, current and requested versions, and the violated rule per line. All output slices are sorted (sortActions, with full tiebreakers) for determinism.

Config (internal/config/config.go):
  - OverlayPolicy.AllowDowngrade, mirroring AllowRemoval: a non-YAML field rejected by the schema, defaulting to false (additive-only in v1).

rpmutils (internal/ospackage/rpmutils/helper.go):
  - Export CompareRPMVersions over the package-internal EVR comparator, so preflight classifies rpm upgrades/downgrades with the same logic the resolver uses (paralleling debutils.CompareDebianVersions).

Tests (internal/image/overlay/preflight_test.go):
  - Table-driven coverage of every blocked and allowed policy path across both families (add/upgrade/downgrade/remove/conflict x allowRemoval / allowDowngrade / conflictPolicy / bootloader), plus action counts and ordering, determinism under reordered inputs, actionable error content, the simulate aid (contributes actions; failure is non-fatal), the systemd-bootchart false-positive guard, and nil guards.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->