### PR TITLE
feat(build): support --nocache option to build image from scratch

### DIFF
--- a/cmd/image-composer-tool/build.go
+++ b/cmd/image-composer-tool/build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/provider/rcd"
 	"github.com/open-edge-platform/image-composer-tool/internal/provider/ubuntu"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/display"
+	fileutil "github.com/open-edge-platform/image-composer-tool/internal/utils/file"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 	"github.com/spf13/cobra"
@@ -31,6 +32,7 @@ var (
 	workDir            string = "" // Empty means use config file value
 	dotFile            string = "" // Generate a dot file for the dependency graph
 	systemPackagesOnly bool   = false
+	noCache            bool   = false // Build from scratch in fresh, unique cache/workspace dirs
 )
 
 // createBuildCommand creates the build subcommand
@@ -55,6 +57,8 @@ The template file must be in YAML format following the image template schema.`,
 	buildCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	buildCmd.Flags().StringVarP(&dotFile, "dotfile", "f", "", "Generate a dot file for the dependency graph")
 	buildCmd.Flags().BoolVar(&systemPackagesOnly, "system-packages-only", false, "When generating a dot graph, only include roots from SystemConfig.Packages")
+	buildCmd.Flags().BoolVar(&noCache, "nocache", false,
+		"Build from scratch using fresh, unique cache and workspace directories that are removed after the build (the final image is copied to the configured workspace)")
 
 	return buildCmd
 }
@@ -77,6 +81,22 @@ func executeBuild(cmd *cobra.Command, args []string) error {
 		currentConfig := config.Global()
 		currentConfig.WorkDir = workDir
 		config.SetGlobal(currentConfig)
+	}
+
+	// When --nocache is set, run the build in fresh, unique cache and workspace
+	// directories so nothing is reused from previous builds, then remove them once the
+	// build finishes. The final image is copied back to the configured workspace.
+	var nc *noCacheContext
+	if noCache {
+		if cmd.Flags().Changed("cache-dir") || cmd.Flags().Changed("work-dir") {
+			return fmt.Errorf("--nocache cannot be combined with --cache-dir or --work-dir")
+		}
+		ctx, cleanup, err := setupNoCache()
+		if err != nil {
+			return fmt.Errorf("setting up --nocache directories: %w", err)
+		}
+		defer cleanup()
+		nc = ctx
 	}
 
 	var buildErr error
@@ -150,6 +170,16 @@ post:
 		log.Info("image build completed successfully")
 		template.MarkBuildFinished()
 		displayImageBuildTiming(template.Target.ImageType, template)
+
+		// Copy the freshly built image out of the temporary --nocache workspace before
+		// the deferred cleanup removes it, so the output lands in the configured workspace.
+		if nc != nil {
+			providerId := system.GetProviderId(template.Target.OS, template.Target.Dist, template.Target.Arch)
+			if err := preserveNoCacheOutput(nc, providerId, template.GetSystemConfigName()); err != nil {
+				nc.keepWorkDir = true
+				return fmt.Errorf("preserving --nocache build output: %w", err)
+			}
+		}
 	} else {
 		// Avoid logging the full error chain to prevent potential leakage of sensitive data.
 		// Log only the error type/category to aid debugging without exposing sensitive details.
@@ -157,6 +187,93 @@ post:
 	}
 
 	return buildErr
+}
+
+// noCacheContext holds the unique directories created for a --nocache build so the
+// final image can be copied out and the directories removed once the build finishes.
+type noCacheContext struct {
+	uniqueCacheDir string
+	uniqueWorkDir  string
+	origWorkDir    string
+	keepWorkDir    bool // preserve the workspace for recovery when output copy-out fails
+}
+
+// setupNoCache creates fresh, unique cache and workspace directories adjacent to the
+// configured ones, points the global config at them, and returns the context plus a
+// cleanup function that removes the unique directories.
+func setupNoCache() (*noCacheContext, func(), error) {
+	origCacheDir, err := config.CacheDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving cache directory: %w", err)
+	}
+	origWorkDir, err := config.WorkDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving work directory: %w", err)
+	}
+
+	uniqueCacheDir, err := os.MkdirTemp(filepath.Dir(origCacheDir), "ict-nocache-cache-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating unique cache directory: %w", err)
+	}
+	uniqueWorkDir, err := os.MkdirTemp(filepath.Dir(origWorkDir), "ict-nocache-workspace-*")
+	if err != nil {
+		if rmErr := os.RemoveAll(uniqueCacheDir); rmErr != nil {
+			logger.Logger().Warnf("failed to remove unique cache directory %s: %v", uniqueCacheDir, rmErr)
+		}
+		return nil, nil, fmt.Errorf("creating unique workspace directory: %w", err)
+	}
+
+	currentConfig := config.Global()
+	currentConfig.CacheDir = uniqueCacheDir
+	currentConfig.WorkDir = uniqueWorkDir
+	config.SetGlobal(currentConfig)
+
+	nc := &noCacheContext{
+		uniqueCacheDir: uniqueCacheDir,
+		uniqueWorkDir:  uniqueWorkDir,
+		origWorkDir:    origWorkDir,
+	}
+
+	log := logger.Logger()
+	log.Infof("--nocache: building in fresh cache %s and workspace %s", uniqueCacheDir, uniqueWorkDir)
+
+	cleanup := func() {
+		if err := os.RemoveAll(uniqueCacheDir); err != nil {
+			log.Warnf("failed to remove --nocache cache directory %s: %v", uniqueCacheDir, err)
+		}
+		if nc.keepWorkDir {
+			log.Infof("--nocache: preserving workspace %s for recovery", uniqueWorkDir)
+			return
+		}
+		if err := os.RemoveAll(uniqueWorkDir); err != nil {
+			log.Warnf("failed to remove --nocache workspace directory %s: %v", uniqueWorkDir, err)
+		}
+	}
+
+	return nc, cleanup, nil
+}
+
+// preserveNoCacheOutput copies the built image directory from the unique --nocache
+// workspace back to the originally configured workspace so it survives cleanup.
+func preserveNoCacheOutput(nc *noCacheContext, providerId, configName string) error {
+	srcImageDir := filepath.Join(nc.uniqueWorkDir, providerId, "imagebuild", configName)
+	if _, err := os.Stat(srcImageDir); err != nil {
+		if os.IsNotExist(err) {
+			// No image build directory was produced; nothing to preserve.
+			return nil
+		}
+		return fmt.Errorf("checking image output directory: %w", err)
+	}
+
+	// The build runs as root (image files are root-owned) and the copy happens in the
+	// same process, so no privilege escalation is needed here.
+	dstImageDir := filepath.Join(nc.origWorkDir, providerId, "imagebuild", configName)
+	if err := fileutil.CopyDir(srcImageDir, dstImageDir, "-p", false); err != nil {
+		return fmt.Errorf("copying image output to %s: %w", dstImageDir, err)
+	}
+
+	logger.Logger().Infof("--nocache: build output copied to %s", dstImageDir)
+	return nil
 }
 
 func displayImageBuildTiming(imageType string, template *config.ImageTemplate) {

--- a/cmd/image-composer-tool/build_test.go
+++ b/cmd/image-composer-tool/build_test.go
@@ -20,6 +20,7 @@ func resetBuildFlags() {
 	workers = defaultWorkers
 	cacheDir = ""
 	workDir = ""
+	noCache = false
 }
 
 // createTestTemplate creates a minimal valid template file for testing
@@ -104,6 +105,7 @@ func TestCreateBuildCommand(t *testing.T) {
 			{name: "workers", shorthand: "w", shouldExist: true},
 			{name: "cache-dir", shorthand: "d", shouldExist: true},
 			{name: "work-dir", shorthand: "", shouldExist: true},
+			{name: "nocache", shorthand: "", shouldExist: true},
 		}
 
 		for _, expected := range expectedFlags {
@@ -575,6 +577,7 @@ func TestBuildCommand_HelpText(t *testing.T) {
 		"--workers",
 		"--cache-dir",
 		"--work-dir",
+		"--nocache",
 	}
 
 	for _, expected := range expectedInHelp {
@@ -735,6 +738,241 @@ func TestBuildCommand_ArgumentValidation(t *testing.T) {
 			}
 			if !tt.expectErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestSetupNoCache verifies that setupNoCache creates fresh unique cache/workspace
+// directories adjacent to the configured ones, points the global config at them, and
+// that its cleanup function removes them again.
+func TestSetupNoCache(t *testing.T) {
+	prev := *config.Global()
+	defer config.SetGlobal(&prev)
+
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, "cache")
+	workDir := filepath.Join(tmp, "workspace")
+
+	cfg := config.DefaultGlobalConfig()
+	cfg.CacheDir = cacheDir
+	cfg.WorkDir = workDir
+	cfg.ConfigDir = filepath.Join(tmp, "config")
+	cfg.TempDir = filepath.Join(tmp, "tmp")
+	config.SetGlobal(cfg)
+
+	nc, cleanup, err := setupNoCache()
+	if err != nil {
+		t.Fatalf("setupNoCache failed: %v", err)
+	}
+
+	// Unique dirs should have been created.
+	if _, err := os.Stat(nc.uniqueCacheDir); err != nil {
+		t.Errorf("unique cache dir should exist: %v", err)
+	}
+	if _, err := os.Stat(nc.uniqueWorkDir); err != nil {
+		t.Errorf("unique work dir should exist: %v", err)
+	}
+
+	// They must differ from the configured dirs but share the same parent.
+	absCache, _ := filepath.Abs(cacheDir)
+	absWork, _ := filepath.Abs(workDir)
+	if nc.uniqueCacheDir == absCache {
+		t.Error("unique cache dir should differ from configured cache dir")
+	}
+	if nc.uniqueWorkDir == absWork {
+		t.Error("unique work dir should differ from configured work dir")
+	}
+	if got, want := filepath.Dir(nc.uniqueCacheDir), filepath.Dir(absCache); got != want {
+		t.Errorf("unique cache dir parent = %q, want %q", got, want)
+	}
+	if got, want := filepath.Dir(nc.uniqueWorkDir), filepath.Dir(absWork); got != want {
+		t.Errorf("unique work dir parent = %q, want %q", got, want)
+	}
+
+	// The global config must now point at the unique dirs.
+	if resolved, _ := config.CacheDir(); resolved != nc.uniqueCacheDir {
+		t.Errorf("config cache dir = %q, want %q", resolved, nc.uniqueCacheDir)
+	}
+	if resolved, _ := config.WorkDir(); resolved != nc.uniqueWorkDir {
+		t.Errorf("config work dir = %q, want %q", resolved, nc.uniqueWorkDir)
+	}
+
+	// origWorkDir must capture the pre-override configured workspace.
+	if nc.origWorkDir != absWork {
+		t.Errorf("origWorkDir = %q, want %q", nc.origWorkDir, absWork)
+	}
+
+	// Cleanup should remove both unique dirs.
+	cleanup()
+	if _, err := os.Stat(nc.uniqueCacheDir); !os.IsNotExist(err) {
+		t.Errorf("unique cache dir should be removed after cleanup, stat err: %v", err)
+	}
+	if _, err := os.Stat(nc.uniqueWorkDir); !os.IsNotExist(err) {
+		t.Errorf("unique work dir should be removed after cleanup, stat err: %v", err)
+	}
+}
+
+// TestSetupNoCache_CleanupKeepsWorkspaceOnFlag verifies that when keepWorkDir is set
+// (e.g. output copy-out failed), cleanup removes the cache but preserves the workspace.
+func TestSetupNoCache_CleanupKeepsWorkspaceOnFlag(t *testing.T) {
+	prev := *config.Global()
+	defer config.SetGlobal(&prev)
+
+	tmp := t.TempDir()
+	cfg := config.DefaultGlobalConfig()
+	cfg.CacheDir = filepath.Join(tmp, "cache")
+	cfg.WorkDir = filepath.Join(tmp, "workspace")
+	cfg.ConfigDir = filepath.Join(tmp, "config")
+	cfg.TempDir = filepath.Join(tmp, "tmp")
+	config.SetGlobal(cfg)
+
+	nc, cleanup, err := setupNoCache()
+	if err != nil {
+		t.Fatalf("setupNoCache failed: %v", err)
+	}
+
+	nc.keepWorkDir = true
+	cleanup()
+
+	if _, err := os.Stat(nc.uniqueCacheDir); !os.IsNotExist(err) {
+		t.Errorf("cache dir should be removed even when keepWorkDir is set")
+	}
+	if _, err := os.Stat(nc.uniqueWorkDir); err != nil {
+		t.Errorf("workspace should be preserved when keepWorkDir is set: %v", err)
+	}
+}
+
+// TestSetupNoCache_ErrorWhenCacheParentMissing verifies setupNoCache surfaces an error
+// when the unique cache directory cannot be created.
+func TestSetupNoCache_ErrorWhenCacheParentMissing(t *testing.T) {
+	prev := *config.Global()
+	defer config.SetGlobal(&prev)
+
+	cfg := config.DefaultGlobalConfig()
+	// The cache dir's parent does not exist, so os.MkdirTemp fails.
+	cfg.CacheDir = filepath.Join(t.TempDir(), "does-not-exist", "cache")
+	cfg.WorkDir = filepath.Join(t.TempDir(), "workspace")
+	config.SetGlobal(cfg)
+
+	if _, _, err := setupNoCache(); err == nil {
+		t.Fatal("expected setupNoCache to fail when the cache parent directory is missing")
+	}
+}
+
+// TestSetupNoCache_ErrorWhenWorkParentMissing verifies that when creating the unique
+// workspace fails, the already-created unique cache directory is cleaned up.
+func TestSetupNoCache_ErrorWhenWorkParentMissing(t *testing.T) {
+	prev := *config.Global()
+	defer config.SetGlobal(&prev)
+
+	tmp := t.TempDir()
+	cfg := config.DefaultGlobalConfig()
+	cfg.CacheDir = filepath.Join(tmp, "cache")                      // parent (tmp) exists
+	cfg.WorkDir = filepath.Join(tmp, "missing-parent", "workspace") // parent missing
+	config.SetGlobal(cfg)
+
+	if _, _, err := setupNoCache(); err == nil {
+		t.Fatal("expected setupNoCache to fail when the workspace parent directory is missing")
+	}
+
+	// The unique cache dir created before the failure must have been removed.
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("failed to read temp dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "ict-nocache-cache-") {
+			t.Errorf("leftover unique cache dir was not cleaned up: %s", e.Name())
+		}
+	}
+}
+
+// TestPreserveNoCacheOutput verifies that the built image directory is copied from the
+// unique --nocache workspace back to the originally configured workspace.
+func TestPreserveNoCacheOutput(t *testing.T) {
+	const providerId = "azure-linux-azl3-x86_64"
+	const configName = "edge"
+
+	t.Run("CopiesImageOutput", func(t *testing.T) {
+		tmp := t.TempDir()
+		uniqueWork := filepath.Join(tmp, "unique-workspace")
+		origWork := filepath.Join(tmp, "orig-workspace")
+
+		srcImageDir := filepath.Join(uniqueWork, providerId, "imagebuild", configName)
+		if err := os.MkdirAll(srcImageDir, 0o755); err != nil {
+			t.Fatalf("failed to create src image dir: %v", err)
+		}
+		imageContent := []byte("fake image bytes")
+		if err := os.WriteFile(filepath.Join(srcImageDir, "image.raw"), imageContent, 0o644); err != nil {
+			t.Fatalf("failed to write fake image: %v", err)
+		}
+
+		nc := &noCacheContext{uniqueWorkDir: uniqueWork, origWorkDir: origWork}
+		if err := preserveNoCacheOutput(nc, providerId, configName); err != nil {
+			t.Fatalf("preserveNoCacheOutput failed: %v", err)
+		}
+
+		dstImage := filepath.Join(origWork, providerId, "imagebuild", configName, "image.raw")
+		got, err := os.ReadFile(dstImage)
+		if err != nil {
+			t.Fatalf("expected copied image at %s: %v", dstImage, err)
+		}
+		if string(got) != string(imageContent) {
+			t.Errorf("copied image content mismatch: got %q, want %q", got, imageContent)
+		}
+	})
+
+	t.Run("NoOutputDirIsNoOp", func(t *testing.T) {
+		tmp := t.TempDir()
+		nc := &noCacheContext{
+			uniqueWorkDir: filepath.Join(tmp, "unique-workspace"),
+			origWorkDir:   filepath.Join(tmp, "orig-workspace"),
+		}
+		// No imagebuild dir was produced -> should be a no-op, not an error.
+		if err := preserveNoCacheOutput(nc, providerId, configName); err != nil {
+			t.Errorf("expected no error when image dir is missing, got: %v", err)
+		}
+		dst := filepath.Join(nc.origWorkDir, providerId, "imagebuild", configName)
+		if _, err := os.Stat(dst); !os.IsNotExist(err) {
+			t.Errorf("destination should not exist when there is no output, stat err: %v", err)
+		}
+	})
+}
+
+// TestExecuteBuild_NoCacheMutualExclusion verifies that --nocache cannot be combined
+// with --cache-dir or --work-dir.
+func TestExecuteBuild_NoCacheMutualExclusion(t *testing.T) {
+	prev := *config.Global()
+	defer config.SetGlobal(&prev)
+
+	tests := []struct {
+		name string
+		flag string
+		val  string
+	}{
+		{name: "WithCacheDir", flag: "cache-dir", val: "/tmp/some-cache"},
+		{name: "WithWorkDir", flag: "work-dir", val: "/tmp/some-work"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer resetBuildFlags()
+
+			cmd := createBuildCommand()
+			if err := cmd.Flags().Set("nocache", "true"); err != nil {
+				t.Fatalf("failed to set nocache flag: %v", err)
+			}
+			if err := cmd.Flags().Set(tt.flag, tt.val); err != nil {
+				t.Fatalf("failed to set %s flag: %v", tt.flag, err)
+			}
+
+			err := executeBuild(cmd, []string{"template.yml"})
+			if err == nil {
+				t.Fatalf("expected error when combining --nocache with --%s", tt.flag)
+			}
+			if !strings.Contains(err.Error(), "cannot be combined") {
+				t.Errorf("expected mutual-exclusion error, got: %v", err)
 			}
 		})
 	}

--- a/docs/architecture/image-composer-tool-caching.md
+++ b/docs/architecture/image-composer-tool-caching.md
@@ -345,6 +345,21 @@ sudo -E image-composer-tool build \
   template.yml
 ```
 
+### Bypassing the Cache (`--nocache`)
+
+Use `--nocache` to build entirely from scratch without reusing — or leaving behind —
+any cache or workspace state:
+
+```bash
+sudo -E image-composer-tool build --nocache template.yml
+```
+
+When set, the build runs in fresh, unique cache and workspace directories created
+adjacent to the configured `cache_dir`/`work_dir`. These directories are removed once
+the build finishes, so nothing persists for later builds to reuse. The final image is
+copied into the configured `work_dir` before cleanup. `--nocache` cannot be combined
+with `--cache-dir` or `--work-dir`.
+
 ## Cache Management
 
 ### Cache Locations

--- a/docs/architecture/image-composer-tool-cli-specification.md
+++ b/docs/architecture/image-composer-tool-cli-specification.md
@@ -145,6 +145,7 @@ image-composer-tool build [flags] TEMPLATE_FILE
 | `--verbose, -v` | Enable verbose output (equivalent to --log-level debug). Displays detailed information about each step of the build process. |
 | `--dotfile, -f FILE` | Generate a dot file for the merged template dependency graph (user + defaults with resolved packages). |
 | `--system-packages-only` | When paired with `--dotfile`, limit the dependency graph to roots defined in `SystemConfig.Packages`. Dependencies pulled in by those roots still appear, but essentials/kernel/bootloader packages aren't drawn unless required by a system package. |
+| `--nocache` | Build from scratch: create fresh, unique cache and workspace directories (ignoring any existing caches), then remove them once the build finishes. The final image is copied into the configured `work_dir`. Cannot be combined with `--cache-dir` or `--work-dir`. |
 
 **Example:**
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,7 +5,7 @@
 **June 17, 2026**
 
 **New**
-
+- Build from scratch with `--nocache`: The `build` command now accepts a `--nocache` flag that runs the build in fresh, unique cache and workspace directories (ignoring any existing caches) and removes them once the build finishes. The final image is copied into the configured `work_dir` beforehand. `--nocache` cannot be combined with `--cache-dir` or `--work-dir`.
 - ARM64/aarch64 cross-architecture image builds: Ubuntu 24, eLxR 12, and AZL3 images can now be composed on an x86_64 host targeting ARM64. The builder validates host-side prerequisites (arch-test, qemu-user-static), normalizes architectures for `mmdebstrap` and `dpkg`, and forces a host-side ukify execution when the host and target architectures differ.
 
 - Ubuntu 24 ARM64 bootable server image: Added a user template and supporting configuration to produce a bootable Ubuntu 24 `aarch64` server image.

--- a/docs/tutorial/usage-guide.md
+++ b/docs/tutorial/usage-guide.md
@@ -80,9 +80,12 @@ sudo image-composer-tool build /usr/share/image-composer-tool/examples/azl3-x86_
 
 # Override config settings with flags
 sudo -E ./image-composer-tool build --workers 16 --cache-dir /tmp/cache image-templates/azl3-x86_64-edge-raw.yml
+
+# Build from scratch in throwaway cache/workspace dirs (removed after the build)
+sudo -E ./image-composer-tool build --nocache image-templates/azl3-x86_64-edge-raw.yml
 ```
 
-Common flags: `--workers`, `--cache-dir`, `--work-dir`, `--verbose`,
+Common flags: `--workers`, `--cache-dir`, `--work-dir`, `--nocache`, `--verbose`,
 `--dotfile`, `--config`, `--log-level`.
 See the full
 [build flag reference](../architecture/image-composer-tool-cli-specification.md#build-command)


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

Adds a `--nocache` flag to the `build` command. When set, the build runs in fresh, unique cache and workspace directories instead of the configured ones, so nothing is reused from previous builds (a true from-scratch build). The unique directories are created adjacent to the configured `cache_dir`/`work_dir` (same filesystem, safe for multi-GB builds) and removed once the build finishes.

Because every subsystem resolves directories from the config singleton, overriding it once in `executeBuild` propagates to all consumers — the same mechanism the existing `--cache-dir`/`--work-dir` flags use. Since the final image is written inside the workspace, it is copied into the configured `work_dir` before the temporary directories are cleaned up, so the output is preserved. `--nocache` is mutually exclusive with `--cache-dir`/`--work-dir`; if the output copy-out fails, the unique workspace is kept for recovery.

Key changes:
- `cmd/image-composer-tool/build.go`: new `--nocache` flag; `setupNoCache()` (creates unique dirs, overrides config, returns a cleanup closure) and `preserveNoCacheOutput()` helpers; wiring in `executeBuild` with a deferred cleanup that runs after `PostProcess` unmounts the chroots (so `RemoveAll` is safe).
- Tests for the helpers, the copy-out, the error/cleanup paths, and the mutual-exclusion check.
- Docs: CLI spec flag table, usage guide, caching doc, and release notes.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

- `go test ./cmd/image-composer-tool/` — all tests pass, including new tests for `setupNoCache` (success, cleanup, keep-workspace-on-failure, and missing-parent error paths), `preserveNoCacheOutput` (copy + no-op when no output), and `--nocache` + `--cache-dir`/`--work-dir` mutual exclusion.
- `gofmt -l`, `go vet ./cmd/image-composer-tool/`, and `golangci-lint run ./cmd/image-composer-tool/` (v1.64.7) — all clean.
- `go build ./...` — succeeds.
