### PR TITLE
(bug) Removing awk dependency replacing with sed

### DIFF
--- a/config/general/wsl2/ict-wsl2-profile.sh
+++ b/config/general/wsl2/ict-wsl2-profile.sh
@@ -18,5 +18,7 @@ fi
 
 instructions="/usr/share/doc/ict-wsl2/resize-filesystem.txt"
 if [ -r "$instructions" ]; then
-  sed "s/<distribution-name>/${WSL_DISTRO_NAME:-<distribution-name>}/g" "$instructions"
+  distro="${WSL_DISTRO_NAME:-<distribution-name>}"
+  distro_escaped=$(printf '%s' "$distro" | sed 's/[\/&\\]/\\&/g')
+  sed "s/<distribution-name>/${distro_escaped}/g" "$instructions"
 fi

--- a/config/general/wsl2/ict-wsl2-profile.sh
+++ b/config/general/wsl2/ict-wsl2-profile.sh
@@ -18,6 +18,5 @@ fi
 
 instructions="/usr/share/doc/ict-wsl2/resize-filesystem.txt"
 if [ -r "$instructions" ]; then
-  awk -v distro="${WSL_DISTRO_NAME:-<distribution-name>}" \
-    '{gsub(/<distribution-name>/, distro); print}' "$instructions"
+  sed "s/<distribution-name>/${WSL_DISTRO_NAME:-<distribution-name>}/g" "$instructions"
 fi

--- a/docs/architecture/image-composer-tool-templates.md
+++ b/docs/architecture/image-composer-tool-templates.md
@@ -1,5 +1,7 @@
 # Image Template Reference
 
+<!-- markdownlint-configure-file {"MD051": false, "MD060": false} -->
+
 Templates are YAML files that define what goes into a custom OS image, the
 target platform, packages, disk layout, users, and build-time customizations.
 This document is the authoritative field-by-field reference for the template
@@ -19,6 +21,7 @@ For a conceptual overview of how templates fit into the build pipeline, see
     - [`metadata`](#metadata)
     - [`image` (required)](#image-required)
     - [`target` (required)](#target-required)
+    - [WSL-Compatible Images](#wsl-compatible-images)
     - [`baseline`](#baseline)
       - [`baseline.source`](#baselinesource)
     - [`overlayPolicy`](#overlaypolicy)
@@ -37,18 +40,12 @@ For a conceptual overview of how templates fit into the build pipeline, see
       - [`systemConfig.configurations[]`](#systemconfigconfigurations)
   - [Template Merge Behavior](#template-merge-behavior)
   - [Variable Substitution](#variable-substitution)
-- [Using Templates to Build Images](#using-templates-to-build-images)
-- [Template Storage](#template-storage)
-- [Template Variables](#template-variables)
+- [WSL Required Fields](#wsl-required-fields)
 - [Package Repositories](#package-repositories)
   - [Repository Fields](#repository-fields)
   - [Priority Behavior](#priority-behavior)
   - [AllowPackages White List](#allowpackages-white-list)
 - [Best Practices](#best-practices)
-  - [Template Organization](#template-organization)
-  - [Template Design](#template-design)
-  - [Template Sharing](#template-sharing)
-- [Conclusion](#conclusion)
 - [Related Documentation](#related-documentation)
 
 ## What Are Templates and How Do They Work?
@@ -193,7 +190,7 @@ Target platform. All four fields are required.
 | `os` | string | **Yes** | `azure-linux`, `edge-microvisor-toolkit`, `wind-river-elxr`, `ubuntu`, `redhat-compatible-distro` | Target operating system |
 | `dist` | string | **Yes** | See OS constraints below | Distribution identifier |
 | `arch` | string | **Yes** | `x86_64`, `aarch64`, `armv7hl` | Target CPU architecture |
-| `imageType` | string | **Yes** | `raw`, `iso`, `img` | Output image format |
+| `imageType` | string | **Yes** | `raw`, `iso`, `img`, `wsl2` | Output image format |
 
 **OS → dist constraints:**
 
@@ -212,6 +209,21 @@ target:
   arch: x86_64
   imageType: raw
 ```
+
+### WSL-Compatible Images
+
+Set `target.imageType: wsl2` to compose a WSL-compatible root filesystem.
+
+```yaml
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: wsl2
+```
+
+For a complete Ubuntu 24 WSL example, see
+[`image-templates/ubuntu24-x86_64-agentic-wsl2.yml`](../../image-templates/ubuntu24-x86_64-agentic-wsl2.yml).
 
 ---
 
@@ -321,7 +333,7 @@ Each entry defines one output format:
 
 | Field | Type | Required | Valid Values | Description |
 |-------|------|----------|--------------|-------------|
-| `type` | string | **Yes** | `raw`, `qcow2`, `vhd`, `vhdx`, `vmdk`, `vdi` | Output image format |
+| `type` | string | **Yes** | `raw`, `qcow2`, `vhd`, `vhdx`, `vmdk`, `vdi`, `tar` | Output image format |
 | `compression` | string | No | `gz`, `gzip`, `xz`, `zstd`, `bz2` | Compression to apply |
 
 #### `disk.partitions[]`
@@ -707,7 +719,40 @@ build time.
 To learn how variables interact with each build stage, see
 [Build Stages in Detail](./image-composer-tool-build-process.md#build-stages-in-detail).
 
+## WSL Required Fields
 
+To compose a WSL-compatible image, set `target.imageType: wsl2` and include a
+WSL-compatible `disk` artifact definition.
+
+| Field | Required for WSL | Requirement |
+|-------|------------------|-------------|
+| `image.name` | **Yes** | Standard image identifier |
+| `image.version` | **Yes** | Standard image version |
+| `target.os` | **Yes** | Any supported OS/distribution with a WSL2 default template |
+| `target.dist` | **Yes** | Distribution for the selected OS (for example, `ubuntu24`) |
+| `target.arch` | **Yes** | Use `x86_64` for current WSL2 templates |
+| `target.imageType` | **Yes** | Must be `wsl2` |
+| `disk.name` | **Yes** | Required when `imageType: wsl2` |
+| `disk.artifacts[].type` | **Yes** | Must be `tar` |
+| `disk.artifacts[].compression` | **Yes** | Must be `gz` |
+
+Additional notes for WSL builds:
+
+- `disk.partitionTableType` and `disk.partitions` are not used for `wsl2` templates.
+- `systemConfig.kernel` is not allowed for `wsl2` templates.
+
+Example `disk` block for WSL:
+
+```yaml
+disk:
+  name: ubuntu24-x86_64-agentic
+  artifacts:
+    - type: tar
+      compression: gz
+```
+
+See the full end-to-end example at
+[`image-templates/ubuntu24-x86_64-agentic-wsl2.yml`](../../image-templates/ubuntu24-x86_64-agentic-wsl2.yml).
 
 ## Best Practices
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [X] Documentation has been updated to reflect the changes (or no doc update needed)
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
This PR includes a bug fix relating to the welcome message not being displayed properly for a distribution that does not include `awk`. To make this more robust and generic, changed the dependency to `sed` as it is more commonly included in most distributions by default, eliminating the need to explicitly state for the user to include in the packageList for the image teamplate.

Added documentation for WSL images.

<!-- Fixes # (issue) -->
Welcome instructions failed to be displayed using image templates that did not explicitly add `awk` in the package list. Updated the instruction + substitution using `sed` as it is more universally available across distributions.
[WSL2] [Interactive welcome script fails on AZL and EMT due to missing 'awk' command](https://jira.devtools.intel.com/browse/ITEP-94112)

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->
`sed` must be present in the image for the instructions to be displayed properly.
#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->