### PR TITLE
fix(overlay): print generated artifacts summary in overlay flow

### DIFF
--- a/internal/image/overlay/session.go
+++ b/internal/image/overlay/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/config/manifest"
 	"github.com/open-edge-platform/image-composer-tool/internal/image/imageinspect"
 	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/display"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 )
 
@@ -379,6 +380,14 @@ func (b *Builder) Postprocess(buildErr error) (err error) {
 	if config.IsDebugMode() {
 		PrintVerboseUnchangedPackages(stats)
 	}
+
+	// Print the same success/artifact summary box the create-mode makers emit, so
+	// overlay builds also report the generated artifacts. The build directory is the
+	// parent of the emitted RAW artifact; emitOverlayArtifact has placed the .raw
+	// there, and the SBOM sidecar too when its best-effort copy succeeded (the
+	// summary lists whatever files are actually present, so a missing sidecar simply
+	// isn't shown).
+	display.PrintImageDirectorySummary(filepath.Dir(artifact), "RAW")
 
 	return nil
 }


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

The overlay build path never called `display.PrintImageDirectorySummary`, so the "Generated Artifacts (including SBOM)" success summary box that create-mode image makers emit was missing for overlay builds.

This change prints that same summary box at the end of the overlay `Builder.Postprocess` success path, for the emitted RAW artifact's build directory, reusing the shared `display.PrintImageDirectorySummary` function. The summary lists whatever artifacts are actually present in the directory (the emitted `.raw` and, when its best-effort copy succeeded, the SBOM sidecar).

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

- `go build ./internal/image/overlay/...`
- `go test ./internal/image/overlay/... ./internal/api/...` — passing (the API test fixture asserts the exact "Generated Artifacts (including SBOM):" string and bullet-line artifact format).
- `golangci-lint run internal/image/overlay/...` — clean.
