### PR TITLE
Overlay work

### DIFF
--- a/docs/architecture-decision-record/adr-overlay-grow-resize.md
+++ b/docs/architecture-decision-record/adr-overlay-grow-resize.md
@@ -1,8 +1,9 @@
 # ADR: Grow-Only Resize for Overlay Baselines
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-14
-**Updated**: N/A
+**Updated**: 2026-07-16 — hardening story implemented (non-last-partition guard,
+LVM-specific rejection, resize tool pre-flight check, xfs marked best-effort).
 **Authors**: Image Composer Tool Team
 **Technical Area**: Image Composition / Overlay
 **Parent ADR**: [Baseline Image Overlay and ISO Composition Boundaries](adr-image-extension.md)
@@ -148,9 +149,10 @@ CI environment (hardening-story acceptance item).
 | Step | When | Tool | v1? |
 | --- | --- | --- | --- |
 | Reject unsupported FS | before | (map lookup) | Yes — already in `layout.go` |
-| Reject non-last root partition | before | partition-table inspection | **Yes — gap, tracked in JIRA** |
+| Reject non-last root partition | before | `lsblk` START-offset inspection | ✅ implemented (`assertRootIsLastPartition` in `resize.go`) |
 | Reject LUKS / dm-verity root | before | layout detection | ✅ already rejected in `analyzeLayout` |
-| Reject LVM root | before | layout detection | ⚠️ fails via unsupported-FS (`lvm2_member`); wants LVM-specific message |
+| Reject LVM root | before | layout detection | ✅ LVM-specific rejection in `analyzeLayout` (`lvm2_member`) |
+| Verify resize tools present | before | `IsCommandExist` | ✅ implemented (`checkResizeToolsAvailable` in `resize.go`) |
 | Reject `target ≤ current` / unparseable / > int64 | before | `planResize` | Yes — already implemented |
 | Filesystem clean check (`e2fsck -fn` / `xfs_repair -n`) | before | `e2fsck` / `xfs_repair` | **Defer** — see note |
 | Re-read table after `growpart` | during | `partx -u` | Yes — implemented |
@@ -171,21 +173,22 @@ is a fresh user-owned copy, lowering the dirty-FS risk.
 | `disk.size` > baseline but no opt-in | Hard error naming `allowDiskResize`, before touching disk | ✅ implemented |
 | Requested size ≤ current | No-op with logged reason | ✅ implemented |
 | Requested size unparseable / > int64 max | Hard error | ✅ implemented |
-| Root partition is **not** the last partition | Hard error before `growpart`; do not resize | ❌ **gap — tracked in JIRA** |
-| LVM logical-volume root | Detect and hard error | ⚠️ fails via unsupported-FS; wants LVM-specific message — tracked in JIRA |
+| Root partition is **not** the last partition | Hard error before `growpart`; do not resize | ✅ implemented (`assertRootIsLastPartition`) |
+| LVM logical-volume root | Detect and hard error | ✅ LVM-specific rejection in `analyzeLayout` |
 | LUKS / encrypted root | Detect and hard error | ✅ rejected in `analyzeLayout` |
 | dm-verity root | Refuse | ✅ rejected in `analyzeLayout` (`isDMVerity`) |
 | Unsupported FS type | Hard error | ✅ implemented (`growFilesystem` default case + layout check) |
 | Filesystem dirty | Surface `resize2fs`/tool error clearly | ⚠️ relies on tool error; no pre-check |
-| `growpart`/`resize2fs`/`sgdisk` missing in env | Fail with tool-not-found | ✅ via `commandMap` verify |
+| `growpart`/`resize2fs`/`sgdisk` missing in env | Fail with tool-not-found | ✅ pre-flight `checkResizeToolsAvailable` before mutation |
 | Any resize command fails mid-sequence | Wrapped error; build fails; artifact not emitted | ✅ implemented |
 
-The **non-last-partition** row is the one finding that makes the current code
+The **non-last-partition** row was the one finding that made the original code
 genuinely unsafe on general baselines even though it worked on the Ubuntu cloud
 image (whose root happens to be last, on a bare partition): a non-last root
-would be grown into space that belongs to a following partition. LUKS and
-dm-verity are already rejected up front; LVM already fails (as an unsupported
-FS) but deserves a clearer message. These are the core of the hardening story.
+would be grown into space that belongs to a following partition. The hardening
+story closed this by rejecting a non-last root (`assertRootIsLastPartition`)
+before any mutation. LUKS and dm-verity remain rejected up front; LVM now fails
+with an LVM-specific message rather than the generic unsupported-FS one.
 
 ---
 
@@ -210,25 +213,31 @@ tooling, and file a **JIRA hardening story** for the guard gaps and validation.
 baselines by rejecting layouts it cannot handle, rather than mis-resizing them.
 
 **Acceptance criteria**
-1. `overlayPolicy.allowDiskResize` is documented in schema + templates; a grow
-   without it is a clear hard error. *(done — verify only)*
-2. Resize **refuses** (clear error, no disk mutation) when the root partition is
-   not the last partition on the disk. *(primary safety gap)*
-3. An LVM logical-volume root is rejected with an **LVM-specific** message
-   (today it fails via the generic unsupported-FS path). LUKS and dm-verity
-   roots are already rejected in `analyzeLayout`; add a regression test pinning
-   that they never reach the resize path.
-4. Confirm `growpart`, `resize2fs`, `xfs_growfs`, `sgdisk`, `losetup`, `partx`
-   are present in the build/CI image; add a pre-flight tool-availability check
-   or documented dependency.
-5. xfs path is either CI-covered by a real xfs baseline or explicitly marked
-   best-effort/untested in docs.
-6. Unit tests: non-last-partition rejection, LVM/LUKS rejection, GPT vs MBR
-   sequence, ext4 and (if in scope) xfs grow, and the existing grow/no-grow/opt-in
-   cases. A boot-test of one grown Ubuntu image in CI.
-7. *(Optional, may split out)* pre-grow `e2fsck -fn` for ext roots (`e2fsck` is
-   already in `commandMap`); add `xfs_repair` to `commandMap` if the xfs path
-   gains a pre-grow check.
+1. ✅ `overlayPolicy.allowDiskResize` is documented in schema + templates; a grow
+   without it is a clear hard error. *(done — verified)*
+2. ✅ Resize **refuses** (clear error, no disk mutation) when the root partition
+   is not the last partition on the disk. *(primary safety gap —
+   `assertRootIsLastPartition`)*
+3. ✅ An LVM logical-volume root is rejected with an **LVM-specific** message
+   (previously it failed via the generic unsupported-FS path). LUKS and dm-verity
+   roots are already rejected in `analyzeLayout`; a regression test pins that they
+   never reach the resize path.
+4. ✅ `growpart`, `resize2fs`, `xfs_growfs`, `sgdisk`, `losetup`, `partx` are all
+   registered in `commandMap`; a pre-flight tool-availability check
+   (`checkResizeToolsAvailable`) rejects a resize up front if any is missing.
+5. ✅ xfs path is explicitly marked best-effort/untested in docs (no shipping xfs
+   baseline in CI).
+6. ✅ Unit tests: non-last-partition rejection, LVM/LUKS/dm-verity rejection,
+   GPT vs MBR sequence, ext4 and xfs grow, tool-missing rejection, and the
+   existing grow/no-grow/opt-in cases. *(A boot-test of one grown Ubuntu image in
+   CI is wired separately in the pipeline.)*
+7. *(Optional, deferred)* pre-grow `e2fsck -fn` for ext roots is **not applicable
+   as written**: the root filesystem is mounted during the resize (the mount
+   lifecycle spans install → boot-regen → resize), and `e2fsck`/`xfs_repair`
+   require an unmounted target. `resize2fs` on a mounted ext FS grows online and
+   errors clearly on inconsistency; `xfs_growfs` is online by design. A pre-grow
+   consistency check would require growing before mount, which is out of scope
+   for this story.
 
 **Out of scope**: shrinking, non-last-partition repartitioning, LVM/LUKS grow,
 FS-type conversion, multi-partition grow.
@@ -249,13 +258,13 @@ default-off `allowDiskResize` flag (safe: default is no resize).
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| Root not last partition | `growpart` grows into wrong/absent space; corrupt table | Reject non-last root before any mutation (hardening story AC2) |
-| LVM root grown as bare partition | Partition grown but LV/FS unchanged, or corruption | Already fails as unsupported FS; add LVM-specific rejection (hardening story AC3) |
+| Root not last partition | `growpart` grows into wrong/absent space; corrupt table | ✅ Reject non-last root before any mutation (`assertRootIsLastPartition`) |
+| LVM root grown as bare partition | Partition grown but LV/FS unchanged, or corruption | ✅ LVM-specific rejection in `analyzeLayout` |
 | GPT backup header not moved | Table invalid on grown disk | `sgdisk -e` before `growpart` (implemented) |
 | Dirty ext filesystem | `resize2fs` aborts | Tool errors clearly; optional pre-`e2fsck` (AC7) |
-| Tool missing in build env | Runtime failure late in build | Verify via `commandMap` + pre-flight check (AC4) |
+| Tool missing in build env | Runtime failure late in build | ✅ pre-flight `checkResizeToolsAvailable` before mutation (AC4) |
 | Silent grow surprises user | Unexpected layout change | Default-off `allowDiskResize`; hard error otherwise (implemented) |
-| xfs path unexercised | Undetected regression | CI baseline or mark best-effort (AC5) |
+| xfs path unexercised | Undetected regression | ✅ Marked best-effort/untested in docs (no shipping xfs baseline) |
 
 ---
 

--- a/docs/user-guide/architecture/image-composer-tool-templates.md
+++ b/docs/user-guide/architecture/image-composer-tool-templates.md
@@ -278,6 +278,19 @@ baseline:
 > larger than the baseline image and enable `allowDiskResize` to make room;
 > otherwise the package install step fails with a "no space left on device"
 > error (the failure message points back here).
+>
+> **Resize constraints.** The grow-only resize extends the **last** partition on
+> the disk and its filesystem in place. It is rejected (before any disk mutation,
+> with an actionable error) when the root is **not** the last partition, when the
+> root sits on **LVM**, and when the root is **LUKS-encrypted** or **dm-verity**
+> protected. `ext4`/`ext3`/`ext2` roots are the supported and CI-covered target;
+> `xfs` roots use the same code path (`xfs_growfs`) but are **best-effort**: the
+> grow sequence has unit-test coverage, but no shipping baseline exercises it
+> against a real xfs filesystem in CI/e2e, so treat xfs resize as unverified
+> end-to-end. The resize shells out to `growpart` (cloud-guest-utils), `sgdisk`
+> (gdisk, GPT only), `resize2fs` (e2fsprogs) or `xfs_growfs` (xfsprogs), and
+> `losetup`/`partx` (util-linux); these must be present on the build host, and
+> the build fails early with a clear message if any is missing.
 
 ---
 

--- a/internal/image/overlay/layout.go
+++ b/internal/image/overlay/layout.go
@@ -26,6 +26,12 @@ const (
 // Filesystem reported by lsblk/blkid for a LUKS container.
 const fsTypeLUKS = "crypto_luks"
 
+// Filesystem reported by lsblk/blkid for an LVM physical-volume member. A root on
+// an LVM logical volume sits behind this layer, which overlay's grow-only resize
+// cannot handle (it needs pvresize + lvextend and PV/VG/LV detection). Rejected
+// with an LVM-specific message rather than the generic unsupported-FS one.
+const fsTypeLVMMember = "lvm2_member"
+
 // Filesystem reported by lsblk/blkid for a swap partition. Swap is never a root
 // candidate, so it is excluded from the size-based root fallback.
 const fsTypeSwap = "swap"
@@ -353,7 +359,8 @@ func analyzeLayout(table string, parts []partition) (*Layout, error) {
 		}
 	}
 
-	// Reject integrity/encryption layouts before attempting to pick a root.
+	// Reject integrity/encryption/volume-manager layouts before attempting to pick
+	// a root.
 	for _, p := range parts {
 		if p.FSType == fsTypeLUKS {
 			return nil, &unsupportedLayoutError{
@@ -361,6 +368,15 @@ func analyzeLayout(table string, parts []partition) (*Layout, error) {
 				reason:   "overlay mode cannot modify a LUKS-encrypted filesystem in place",
 				remediation: "provide an unencrypted baseline image, or unlock and re-encrypt the " +
 					"volume out of band",
+			}
+		}
+		if p.FSType == fsTypeLVMMember {
+			return nil, &unsupportedLayoutError{
+				detected: fmt.Sprintf("LVM physical-volume member %s (filesystem type %s)", p.Path, fsTypeLVMMember),
+				reason: "overlay mode cannot mount or grow a root on an LVM logical volume: the root " +
+					"filesystem must sit directly on a partition, not behind an LVM layer",
+				remediation: "provide a baseline image whose root filesystem is on a plain partition " +
+					"(no LVM), or manage the LVM PV/VG/LV grow out of band",
 			}
 		}
 		if isDMVerity(p) {
@@ -512,5 +528,24 @@ func int64Field(dev map[string]interface{}, key string) int64 {
 		return n
 	default:
 		return 0
+	}
+}
+
+// int64FieldStrict reads an integer field like int64Field but reports whether the
+// value was actually present and parseable, so a caller that must fail closed can
+// distinguish a real 0 from a missing/unparseable/null field. A missing key, JSON
+// null, empty string, or non-numeric string returns ok=false.
+func int64FieldStrict(dev map[string]interface{}, key string) (int64, bool) {
+	switch v := dev[key].(type) {
+	case float64:
+		return int64(v), true
+	case json.Number:
+		n, err := v.Int64()
+		return n, err == nil
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		return n, err == nil
+	default:
+		return 0, false
 	}
 }

--- a/internal/image/overlay/layout_test.go
+++ b/internal/image/overlay/layout_test.go
@@ -107,6 +107,24 @@ func TestAnalyzeLayout_RejectsLUKS(t *testing.T) {
 	assertActionable(t, err, "crypto_LUKS")
 }
 
+func TestAnalyzeLayout_RejectsLVMWithSpecificMessage(t *testing.T) {
+	// A root on an LVM logical volume surfaces as an lvm2_member PV partition.
+	// It must be rejected with an LVM-specific message, not the generic
+	// unsupported-filesystem one, so the failure is actionable.
+	parts := []partition{
+		{Path: "/dev/loop0p1", FSType: "vfat", PartType: espTypeGUID, Size: 512 << 20},
+		{Path: "/dev/loop0p2", FSType: fsTypeLVMMember, Size: 8 << 30},
+	}
+	_, err := analyzeLayout(partitionTableGPT, parts)
+	if err == nil {
+		t.Fatal("expected LVM rejection, got nil")
+	}
+	assertActionable(t, err, "LVM")
+	if !strings.Contains(strings.ToLower(err.Error()), "logical volume") {
+		t.Errorf("LVM error should mention logical volume; got: %v", err)
+	}
+}
+
 func TestAnalyzeLayout_RejectsDMVerityByGUID(t *testing.T) {
 	parts := []partition{
 		{Path: "/dev/loop0p1", FSType: "ext4", PartType: "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", Size: 8 << 30},
@@ -153,6 +171,50 @@ func TestAnalyzeLayout_RejectsRootWithNoFilesystem(t *testing.T) {
 func TestAnalyzeLayout_RejectsNoPartitions(t *testing.T) {
 	if _, err := analyzeLayout(partitionTableGPT, nil); err == nil {
 		t.Fatal("expected rejection for empty partition list, got nil")
+	}
+}
+
+// Regression: LUKS, dm-verity, and LVM roots must be rejected by analyzeLayout
+// (which MountLayout calls before any Layout is produced), so they can never
+// reach the resize path. This pins that the resize hardening relies on
+// layout-time rejection rather than a guard inside ResizeBaseline for these.
+func TestAnalyzeLayout_EncryptedAndVolumeManagedRootsNeverYieldLayout(t *testing.T) {
+	cases := []struct {
+		name  string
+		parts []partition
+	}{
+		{
+			name: "luks",
+			parts: []partition{
+				{Path: "/dev/loop0p1", FSType: "vfat", PartType: espTypeGUID, Size: 512 << 20},
+				{Path: "/dev/loop0p2", FSType: fsTypeLUKS, Size: 8 << 30},
+			},
+		},
+		{
+			name: "dm-verity",
+			parts: []partition{
+				{Path: "/dev/loop0p1", FSType: "ext4", PartType: "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", Size: 8 << 30},
+				{Path: "/dev/loop0p2", PartType: "2c7357ed-ebd2-46d9-aec1-23d437ec2bf5", Size: 256 << 20},
+			},
+		},
+		{
+			name: "lvm",
+			parts: []partition{
+				{Path: "/dev/loop0p1", FSType: "vfat", PartType: espTypeGUID, Size: 512 << 20},
+				{Path: "/dev/loop0p2", FSType: fsTypeLVMMember, Size: 8 << 30},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			layout, err := analyzeLayout(partitionTableGPT, tc.parts)
+			if err == nil {
+				t.Fatalf("%s root must be rejected at layout time, got layout %+v", tc.name, layout)
+			}
+			if layout != nil {
+				t.Errorf("%s: no Layout must be produced for a rejected root; got %+v", tc.name, layout)
+			}
+		})
 	}
 }
 

--- a/internal/image/overlay/overlay.go
+++ b/internal/image/overlay/overlay.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -402,6 +403,57 @@ func prepareDestination(dst string) error {
 	return nil
 }
 
+// redactURL returns a URL safe to log: a non-empty query string is replaced with a
+// single "[REDACTED]" marker, the fragment is dropped, and any userinfo password is
+// masked (via url.URL.Redacted). Presigned download URLs (e.g. S3/Azure SAS) carry
+// credentials in the query parameters, so logging the raw URL at info level would
+// leak them; the marker keeps the log readable while withholding the secret tail.
+// On a parse failure the redaction is done textually (see redactURLTextual) so a
+// malformed URL can never fall through to logging a raw secret.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return redactURLTextual(raw)
+	}
+	if u.RawQuery != "" {
+		u.RawQuery = "[REDACTED]"
+	}
+	u.Fragment = ""
+	return u.Redacted()
+}
+
+// redactURLTextual is the best-effort fallback for a URL that url.Parse rejects. It
+// strips the query/fragment tail — preserving the original delimiter ('?' or '#') as
+// a redaction marker — and masks any userinfo password ("//user:password@" becomes
+// "//user:xxxxx@", matching url.URL.Redacted), so neither a secret query tail nor an
+// embedded credential leaks when the structured redaction path is unavailable.
+func redactURLTextual(raw string) string {
+	if i := strings.IndexAny(raw, "?#"); i >= 0 {
+		raw = raw[:i] + string(raw[i]) + "[REDACTED]"
+	}
+	// Userinfo sits between "//" and the "@" that precedes the host, before the path.
+	slashes := strings.Index(raw, "//")
+	if slashes < 0 {
+		return raw
+	}
+	authStart := slashes + 2
+	rest := raw[authStart:]
+	at := strings.Index(rest, "@")
+	if at < 0 {
+		return raw
+	}
+	// Only userinfo if the "@" comes before the path — a later "@" belongs to the path.
+	if slash := strings.Index(rest, "/"); slash >= 0 && slash < at {
+		return raw
+	}
+	userinfo := rest[:at]
+	colon := strings.Index(userinfo, ":")
+	if colon < 0 {
+		return raw
+	}
+	return raw[:authStart] + userinfo[:colon] + ":xxxxx" + rest[at:]
+}
+
 // copyBaseline copies the source baseline into dst. A local path is copied (never
 // symlinked or moved); an https URL is downloaded over TLS (BaselineSource.Validate
 // permits only https for remote sources). The user-provided source is never modified.
@@ -414,11 +466,11 @@ func (ing *Ingestor) copyBaseline(dst string) error {
 
 	switch {
 	case src.URL != "":
-		log.Debugf("Downloading baseline image from %s to %s", src.URL, dst)
+		log.Infof("Downloading baseline image from %s", redactURL(src.URL))
 		if err := downloadBaseline(src.URL, dst); err != nil {
-			return fmt.Errorf("failed to download baseline image from %s to %s: %w", src.URL, dst, err)
+			return fmt.Errorf("failed to download baseline image from %s to %s: %w", redactURL(src.URL), dst, err)
 		}
-		log.Debugf("Finished downloading baseline image to %s", dst)
+		log.Infof("Finished downloading baseline image to %s", dst)
 	default:
 		log.Debugf("Copying baseline image from %s to %s", src.Path, dst)
 		if err := copyLocalFile(src.Path, dst); err != nil {

--- a/internal/image/overlay/overlay_test.go
+++ b/internal/image/overlay/overlay_test.go
@@ -1047,3 +1047,59 @@ func TestNormalizeBaseline_RawDetectionErrorProceeds(t *testing.T) {
 		t.Errorf("attached %q, want baseline.raw %q", loop.attachedPath, ctx.BaselineCopyPath)
 	}
 }
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "presigned query params redacted",
+			in:   "https://bucket.s3.amazonaws.com/image.raw?X-Amz-Credential=AKIA123&X-Amz-Signature=deadbeef",
+			want: "https://bucket.s3.amazonaws.com/image.raw?[REDACTED]",
+		},
+		{
+			name: "userinfo password masked",
+			in:   "https://user:secret@example.com/image.raw",
+			want: "https://user:xxxxx@example.com/image.raw",
+		},
+		{
+			name: "fragment dropped",
+			in:   "https://example.com/image.raw#token=abc",
+			want: "https://example.com/image.raw",
+		},
+		{
+			name: "plain url unchanged",
+			in:   "https://example.com/path/image.raw",
+			want: "https://example.com/path/image.raw",
+		},
+		{
+			name: "unparseable url strips query tail",
+			in:   "https://exa mple.com/image.raw?sig=secret",
+			want: "https://exa mple.com/image.raw?[REDACTED]",
+		},
+		{
+			name: "unparseable url preserves fragment delimiter",
+			in:   "https://exa mple.com/image.raw#tok=secret",
+			want: "https://exa mple.com/image.raw#[REDACTED]",
+		},
+		{
+			name: "unparseable url masks userinfo password",
+			in:   "https://user:secret@exa mple.com/image.raw",
+			want: "https://user:xxxxx@exa mple.com/image.raw",
+		},
+		{
+			name: "unparseable url masks userinfo and strips query tail",
+			in:   "https://user:secret@exa mple.com/image.raw?sig=abc",
+			want: "https://user:xxxxx@exa mple.com/image.raw?[REDACTED]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactURL(tt.in); got != tt.want {
+				t.Errorf("redactURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/image/overlay/resize.go
+++ b/internal/image/overlay/resize.go
@@ -1,6 +1,7 @@
 package overlay
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -33,6 +34,13 @@ var resizeExec = func(cmd string) (string, error) {
 	return shell.ExecCmd(cmd, true, shell.HostPath, nil)
 }
 
+// resizeToolExists is the indirection over the host tool-availability probe so
+// the pre-flight check is unit-testable without depending on which tools happen
+// to be installed on the machine running the tests. Tests override it.
+var resizeToolExists = func(cmd string) (bool, error) {
+	return shell.IsCommandExist(cmd, shell.HostPath)
+}
+
 // ResizeBaseline performs an optional, GROW-ONLY resize of the overlaid baseline so
 // the final image matches a larger disk.size requested in the template. It never
 // shrinks (a smaller or unset target is a no-op) and it grows the existing root
@@ -61,6 +69,23 @@ func ResizeBaseline(template *config.ImageTemplate, ctx *Context, layout *Layout
 
 	disk, partNum, err := splitPartitionDevice(layout.RootDevice)
 	if err != nil {
+		return err
+	}
+
+	// Pre-flight: confirm every host tool the resize sequence shells out to is
+	// present before mutating anything, so a missing tool fails cleanly up front
+	// instead of half-way through (e.g. after the backing file has already been
+	// grown). Checked here rather than in planResize so a no-op build never
+	// requires the resize toolchain.
+	if err := checkResizeToolsAvailable(layout); err != nil {
+		return err
+	}
+
+	// Primary safety guard: growpart only extends a partition into free space that
+	// immediately follows it, so the root partition MUST be the last partition on
+	// the disk. Growing a non-last root would extend it into space owned by a
+	// following partition and corrupt the table. Reject before any mutation.
+	if err := assertRootIsLastPartition(ctx.LoopDevPath, layout.RootDevice); err != nil {
 		return err
 	}
 
@@ -186,6 +211,145 @@ func growFilesystem(layout *Layout) error {
 		return fmt.Errorf("overlay resize: unsupported root filesystem %q for grow", layout.RootFSType)
 	}
 	return nil
+}
+
+// resizeToolsForFS returns the host commands the resize sequence shells out to
+// for the given root filesystem type. losetup/partx/growpart are always needed;
+// sgdisk is only used on GPT; resize2fs vs xfs_growfs depends on the FS. The
+// backing-file grow uses os.Truncate (no tool), so it is intentionally omitted.
+func resizeToolsForFS(fsType, table string) []string {
+	tools := []string{"losetup", "partx", "growpart"}
+	if table == partitionTableGPT {
+		tools = append(tools, "sgdisk")
+	}
+	switch fsType {
+	case "ext2", "ext3", "ext4":
+		tools = append(tools, "resize2fs")
+	case "xfs":
+		tools = append(tools, "xfs_growfs")
+	}
+	return tools
+}
+
+// checkResizeToolsAvailable verifies every host tool the resize sequence needs is
+// present on the build host before any disk mutation, so a missing dependency
+// fails with a clear, actionable message up front rather than mid-sequence. The
+// partition-inspection guard also relies on lsblk, so it is included.
+func checkResizeToolsAvailable(layout *Layout) error {
+	tools := append([]string{"lsblk"}, resizeToolsForFS(layout.RootFSType, layout.PartitionTable)...)
+	var missing []string
+	for _, t := range tools {
+		ok, err := resizeToolExists(t)
+		if err != nil {
+			return fmt.Errorf("overlay resize: failed to probe for required tool %q: %w", t, err)
+		}
+		if !ok {
+			missing = append(missing, t)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"overlay resize: required tool(s) not found on the build host: %s; "+
+				"install them (growpart is in cloud-guest-utils, sgdisk in gdisk, "+
+				"resize2fs in e2fsprogs, xfs_growfs in xfsprogs, losetup/partx in util-linux) "+
+				"or remove/lower disk.size (optionally also set overlayPolicy.allowDiskResize: false) "+
+				"to keep the baseline layout and skip the resize",
+			strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// assertRootIsLastPartition rejects a resize when the root partition is not the
+// last partition (by on-disk start offset) on the loop device. growpart extends
+// a partition only into the free space that immediately follows it, so growing a
+// non-last root would run into — and corrupt — a following partition. It reads
+// each partition's START sector via lsblk and confirms none starts after the
+// root partition. It performs only reads; it never mutates the disk.
+func assertRootIsLastPartition(loopDevPath, rootDevice string) error {
+	cmd := fmt.Sprintf("lsblk -b --json -o PATH,START,TYPE %s", shell.QuoteArg(loopDevPath))
+	out, err := resizeExec(cmd)
+	if err != nil {
+		return fmt.Errorf("overlay resize: failed to read partition layout of %s: %w", loopDevPath, err)
+	}
+
+	starts, err := parsePartitionStarts(out)
+	if err != nil {
+		return fmt.Errorf("overlay resize: %w", err)
+	}
+
+	rootStart, ok := starts[rootDevice]
+	if !ok {
+		return fmt.Errorf(
+			"overlay resize: could not determine the start offset of root partition %s on %s; "+
+				"refusing to grow", rootDevice, loopDevPath)
+	}
+	for path, start := range starts {
+		if path == rootDevice {
+			continue
+		}
+		if start > rootStart {
+			return &unsupportedLayoutError{
+				detected: fmt.Sprintf("root partition %s (start sector %d) is not the last partition on %s; "+
+					"partition %s starts later (sector %d)", rootDevice, rootStart, loopDevPath, path, start),
+				reason: "overlay grow-only resize can only extend the last partition on the disk into the " +
+					"free space that follows it; growing a non-last root would corrupt the following partition",
+				remediation: "use a baseline whose root filesystem is the last partition on the disk, or " +
+					"remove/lower disk.size (or set overlayPolicy.allowDiskResize: false) to keep the baseline layout",
+			}
+		}
+	}
+	return nil
+}
+
+// parsePartitionStarts extracts the START sector offset of each partition node
+// from `lsblk --json` output, keyed by device path. Only rows of TYPE "part"
+// are included (the whole-disk/loop node and any nested LVM/crypt children carry
+// no meaningful partition-table start offset). It tolerates the numeric and
+// quoted-string forms lsblk emits across versions.
+func parsePartitionStarts(lsblkJSON string) (map[string]int64, error) {
+	var parsed struct {
+		BlockDevices []map[string]interface{} `json:"blockdevices"`
+	}
+	if err := json.Unmarshal([]byte(lsblkJSON), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse partition layout: %w", err)
+	}
+
+	starts := make(map[string]int64)
+	var parseErr error
+	var collect func(dev map[string]interface{})
+	collect = func(dev map[string]interface{}) {
+		if devType, _ := dev["type"].(string); devType == "part" {
+			if path := stringField(dev, "path"); path != "" {
+				// Fail closed: a partition whose START is missing or unparseable must
+				// abort the guard, never default to 0. A silent 0 would make a later
+				// partition look like it starts before root, so the non-last-partition
+				// safety check could pass and let growpart corrupt a following partition.
+				start, ok := int64FieldStrict(dev, "start")
+				if !ok {
+					if parseErr == nil {
+						parseErr = fmt.Errorf(
+							"missing or unparseable START offset for partition %s in lsblk output", path)
+					}
+					return
+				}
+				starts[path] = start
+			}
+		}
+		if children, ok := dev["children"].([]interface{}); ok {
+			for _, c := range children {
+				if cm, ok := c.(map[string]interface{}); ok {
+					collect(cm)
+				}
+			}
+		}
+	}
+	for _, dev := range parsed.BlockDevices {
+		collect(dev)
+	}
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return starts, nil
 }
 
 // splitPartitionDevice splits a partition device node into its parent disk and

--- a/internal/image/overlay/resize_test.go
+++ b/internal/image/overlay/resize_test.go
@@ -97,11 +97,44 @@ func TestPlanResize_RejectsSizeAboveInt64Max(t *testing.T) {
 	}
 }
 
+// lastPartitionJSON is an lsblk --json layout in which rootDevice is the last
+// partition on the disk (highest START). Used to satisfy the non-last-partition
+// guard in the grow-sequence tests.
+func lastPartitionJSON(rootDevice string) string {
+	return `{"blockdevices":[{"name":"loop0","path":"/dev/loop0","type":"loop","children":[
+	  {"name":"loop0p1","path":"/dev/loop0p1","start":2048,"type":"part"},
+	  {"name":"root","path":"` + rootDevice + `","start":1050624,"type":"part"}
+	]}]}`
+}
+
+// stubResizeToolsPresent overrides the tool-availability probe so all tools
+// report present, and restores it when the test ends.
+func stubResizeToolsPresent(t *testing.T) {
+	t.Helper()
+	orig := resizeToolExists
+	t.Cleanup(func() { resizeToolExists = orig })
+	resizeToolExists = func(string) (bool, error) { return true, nil }
+}
+
+// recordingExec returns a resizeExec stub that records every command and answers
+// the lsblk START-offset probe (the non-last-partition guard) with a layout in
+// which rootDevice is last. All other commands return empty output.
+func recordingExec(cmds *[]string, rootDevice string) func(string) (string, error) {
+	return func(cmd string) (string, error) {
+		*cmds = append(*cmds, cmd)
+		if strings.Contains(cmd, "lsblk") {
+			return lastPartitionJSON(rootDevice), nil
+		}
+		return "", nil
+	}
+}
+
 func TestResizeBaseline_GrowRunsExpectedSequence(t *testing.T) {
 	origExec := resizeExec
 	defer func() { resizeExec = origExec }()
+	stubResizeToolsPresent(t)
 	var cmds []string
-	resizeExec = func(cmd string) (string, error) { cmds = append(cmds, cmd); return "", nil }
+	resizeExec = recordingExec(&cmds, "/dev/loop0p2")
 
 	p := writeSizedFile(t, 100<<20)
 	tmpl := &config.ImageTemplate{
@@ -195,8 +228,18 @@ func TestResizeBaseline_GrowWithoutOptInErrorsAndRunsNothing(t *testing.T) {
 func TestResizeBaseline_XFSUsesGrowfsByMount(t *testing.T) {
 	origExec := resizeExec
 	defer func() { resizeExec = origExec }()
+	stubResizeToolsPresent(t)
 	var cmds []string
-	resizeExec = func(cmd string) (string, error) { cmds = append(cmds, cmd); return "", nil }
+	// Single-partition disk: the xfs root is trivially the last partition.
+	resizeExec = func(cmd string) (string, error) {
+		cmds = append(cmds, cmd)
+		if strings.Contains(cmd, "lsblk") {
+			return `{"blockdevices":[{"name":"loop0","path":"/dev/loop0","type":"loop","children":[
+			  {"name":"loop0p1","path":"/dev/loop0p1","start":2048,"type":"part"}
+			]}]}`, nil
+		}
+		return "", nil
+	}
 
 	p := writeSizedFile(t, 100<<20)
 	tmpl := &config.ImageTemplate{
@@ -250,6 +293,174 @@ func TestSplitPartitionDevice(t *testing.T) {
 		if disk != tt.wantDisk || part != tt.wantPart {
 			t.Errorf("splitPartitionDevice(%q) = %q/%q, want %q/%q", tt.dev, disk, part, tt.wantDisk, tt.wantPart)
 		}
+	}
+}
+
+// A grow must be refused, with no disk mutation, when the root is not the last
+// partition on the disk: growpart would otherwise extend it into a following
+// partition and corrupt the table. This is the primary safety guard.
+func TestResizeBaseline_RejectsNonLastRootPartition(t *testing.T) {
+	origExec := resizeExec
+	defer func() { resizeExec = origExec }()
+	stubResizeToolsPresent(t)
+	var cmds []string
+	// Layout where the root (loop0p2) is followed by a later partition (loop0p3).
+	resizeExec = func(cmd string) (string, error) {
+		cmds = append(cmds, cmd)
+		if strings.Contains(cmd, "lsblk") {
+			return `{"blockdevices":[{"name":"loop0","path":"/dev/loop0","type":"loop","children":[
+			  {"name":"loop0p1","path":"/dev/loop0p1","start":2048,"type":"part"},
+			  {"name":"loop0p2","path":"/dev/loop0p2","start":1050624,"type":"part"},
+			  {"name":"loop0p3","path":"/dev/loop0p3","start":9439232,"type":"part"}
+			]}]}`, nil
+		}
+		return "", nil
+	}
+
+	p := writeSizedFile(t, 100<<20)
+	tmpl := &config.ImageTemplate{
+		Disk:          config.DiskConfig{Size: "200MiB"},
+		OverlayPolicy: &config.OverlayPolicy{AllowDiskResize: true},
+	}
+	ctx := &Context{BaselineCopyPath: p, LoopDevPath: "/dev/loop0"}
+	layout := &Layout{RootDevice: "/dev/loop0p2", RootFSType: "ext4", RootMount: "/mnt/root", PartitionTable: partitionTableGPT}
+
+	err := ResizeBaseline(tmpl, ctx, layout)
+	if err == nil {
+		t.Fatal("expected rejection when root is not the last partition")
+	}
+	if !strings.Contains(err.Error(), "last partition") {
+		t.Errorf("error should explain the last-partition requirement; got: %v", err)
+	}
+	// No mutating command may have run, and the backing file must be untouched.
+	joined := strings.Join(cmds, "\n")
+	for _, forbidden := range []string{"growpart", "sgdisk", "resize2fs", "losetup -c"} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("no mutation must run on rejection; saw %q in:\n%s", forbidden, joined)
+		}
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat backing file: %v", err)
+	}
+	if fi.Size() != 100<<20 {
+		t.Errorf("backing file size = %d, want %d (must not grow on rejection)", fi.Size(), 100<<20)
+	}
+}
+
+// A required resize tool missing on the build host must abort the grow up front,
+// before any disk mutation, with a message naming the missing tool.
+func TestResizeBaseline_RejectsWhenToolMissing(t *testing.T) {
+	origExec := resizeExec
+	defer func() { resizeExec = origExec }()
+	ran := false
+	resizeExec = func(string) (string, error) { ran = true; return "", nil }
+
+	origTool := resizeToolExists
+	defer func() { resizeToolExists = origTool }()
+	resizeToolExists = func(cmd string) (bool, error) { return cmd != "growpart", nil }
+
+	p := writeSizedFile(t, 100<<20)
+	tmpl := &config.ImageTemplate{
+		Disk:          config.DiskConfig{Size: "200MiB"},
+		OverlayPolicy: &config.OverlayPolicy{AllowDiskResize: true},
+	}
+	ctx := &Context{BaselineCopyPath: p, LoopDevPath: "/dev/loop0"}
+	layout := &Layout{RootDevice: "/dev/loop0p2", RootFSType: "ext4", RootMount: "/mnt/root", PartitionTable: partitionTableGPT}
+
+	err := ResizeBaseline(tmpl, ctx, layout)
+	if err == nil {
+		t.Fatal("expected rejection when a required resize tool is missing")
+	}
+	if !strings.Contains(err.Error(), "growpart") {
+		t.Errorf("error should name the missing tool; got: %v", err)
+	}
+	if ran {
+		t.Error("no resize command must run when a required tool is missing")
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat backing file: %v", err)
+	}
+	if fi.Size() != 100<<20 {
+		t.Errorf("backing file size = %d, want %d (must not grow on rejection)", fi.Size(), 100<<20)
+	}
+}
+
+func TestResizeToolsForFS(t *testing.T) {
+	gptExt := resizeToolsForFS("ext4", partitionTableGPT)
+	if !contains(gptExt, "sgdisk") || !contains(gptExt, "resize2fs") {
+		t.Errorf("GPT ext4 tools = %v, want sgdisk + resize2fs", gptExt)
+	}
+	if contains(gptExt, "xfs_growfs") {
+		t.Errorf("GPT ext4 tools must not include xfs_growfs: %v", gptExt)
+	}
+	mbrXFS := resizeToolsForFS("xfs", partitionTableDOS)
+	if contains(mbrXFS, "sgdisk") {
+		t.Errorf("MBR must not require sgdisk: %v", mbrXFS)
+	}
+	if !contains(mbrXFS, "xfs_growfs") {
+		t.Errorf("xfs root must require xfs_growfs: %v", mbrXFS)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParsePartitionStarts(t *testing.T) {
+	js := `{"blockdevices":[{"name":"loop0","path":"/dev/loop0","type":"loop","start":null,"children":[
+	  {"name":"loop0p1","path":"/dev/loop0p1","start":2048,"type":"part"},
+	  {"name":"loop0p2","path":"/dev/loop0p2","start":"1050624","type":"part"}
+	]}]}`
+	starts, err := parsePartitionStarts(js)
+	if err != nil {
+		t.Fatalf("parsePartitionStarts: %v", err)
+	}
+	if len(starts) != 2 {
+		t.Fatalf("got %d partitions, want 2: %+v", len(starts), starts)
+	}
+	if starts["/dev/loop0p1"] != 2048 {
+		t.Errorf("p1 start = %d, want 2048", starts["/dev/loop0p1"])
+	}
+	// Quoted-string START (older lsblk) must parse too.
+	if starts["/dev/loop0p2"] != 1050624 {
+		t.Errorf("p2 start = %d, want 1050624", starts["/dev/loop0p2"])
+	}
+	// The whole-disk loop node (type "loop") must be excluded.
+	if _, ok := starts["/dev/loop0"]; ok {
+		t.Error("whole-disk node must not be counted as a partition")
+	}
+}
+
+// A partition row whose START is missing/null/unparseable must fail closed: the
+// guard cannot default it to 0 (which would make a later partition look like it
+// precedes root and let an unsafe growpart through).
+func TestParsePartitionStarts_FailsClosedOnMissingStart(t *testing.T) {
+	cases := map[string]string{
+		"null start": `{"blockdevices":[{"path":"/dev/loop0","type":"loop","children":[
+		  {"path":"/dev/loop0p1","start":2048,"type":"part"},
+		  {"path":"/dev/loop0p2","start":null,"type":"part"}
+		]}]}`,
+		"missing start key": `{"blockdevices":[{"path":"/dev/loop0","type":"loop","children":[
+		  {"path":"/dev/loop0p1","start":2048,"type":"part"},
+		  {"path":"/dev/loop0p2","type":"part"}
+		]}]}`,
+		"non-numeric start": `{"blockdevices":[{"path":"/dev/loop0","type":"loop","children":[
+		  {"path":"/dev/loop0p1","start":"notanumber","type":"part"}
+		]}]}`,
+	}
+	for name, js := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parsePartitionStarts(js); err == nil {
+				t.Error("expected error for missing/unparseable partition START, got nil")
+			}
+		})
 	}
 }
 

--- a/internal/image/overlay/session.go
+++ b/internal/image/overlay/session.go
@@ -213,8 +213,9 @@ func (b *Builder) Preprocess() (err error) {
 }
 
 // Build runs the overlay build phase against the already-mounted baseline: it
-// installs the approved package plan, regenerates the initramfs for any added
-// packages (never the bootloader), and performs an optional grow-only resize.
+// performs an optional grow-only resize (first, so the added packages have room),
+// installs the approved package plan, then regenerates the initramfs for any added
+// packages (never the bootloader).
 //
 // It requires Preprocess to have succeeded; the mount lifecycle opened there is
 // reused here and is not torn down until Postprocess.
@@ -224,6 +225,21 @@ func (b *Builder) Build() error {
 	}
 	if b.built {
 		return fmt.Errorf("overlay build: Build already ran")
+	}
+
+	// Resize FIRST, before installing packages: the whole point of a grow is to
+	// create the headroom the added packages need. Running it after install would
+	// be too late — a near-full baseline fails the install with "no space left on
+	// device" before the resize could ever make room. The root filesystem is
+	// mounted (resize2fs/xfs_growfs both grow online) and the loop device is
+	// already attached from Preprocess, so growing here is safe.
+	if err := b.timeStage("Resize", func() error {
+		if rerr := builderResizeFn(b.template, b.ctx, b.layout); rerr != nil {
+			return fmt.Errorf("overlay build: resize failed: %w", rerr)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	var installed *InstallResult
@@ -241,15 +257,6 @@ func (b *Builder) Build() error {
 	if err := b.timeStage("Boot Regeneration", func() error {
 		if berr := builderRegenBootFn(b.info, b.layout.RootMount, installed, b.plan); berr != nil {
 			return fmt.Errorf("overlay build: boot regeneration failed: %w", berr)
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if err := b.timeStage("Resize", func() error {
-		if rerr := builderResizeFn(b.template, b.ctx, b.layout); rerr != nil {
-			return fmt.Errorf("overlay build: resize failed: %w", rerr)
 		}
 		return nil
 	}); err != nil {

--- a/internal/image/overlay/session_test.go
+++ b/internal/image/overlay/session_test.go
@@ -174,7 +174,7 @@ func TestBuilder_HappyPathOrdersStagesAndCleansUp(t *testing.T) {
 		t.Fatalf("Postprocess: %v", err)
 	}
 
-	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "install", "regenBoot", "resize", "sbom", "emit:1.0"}
+	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "resize", "install", "regenBoot", "sbom", "emit:1.0"}
 	if !equalStrings(r.calls, want) {
 		t.Errorf("stage order = %v, want %v", r.calls, want)
 	}
@@ -190,7 +190,7 @@ func TestBuilder_HappyPathOrdersStagesAndCleansUp(t *testing.T) {
 	// execution order, so the caller can render an overlay timing table.
 	wantStages := []string{
 		"Acquire & Mount Baseline", "Inspect Baseline", "Resolve Packages", "Preflight",
-		"Install Packages", "Boot Regeneration", "Resize", "Generate SBOM", "Emit Artifact",
+		"Resize", "Install Packages", "Boot Regeneration", "Generate SBOM", "Emit Artifact",
 	}
 	gotStages := make([]string, 0, len(b.Timings()))
 	for _, ts := range b.Timings() {
@@ -218,7 +218,7 @@ func TestBuilder_InspectRunsAfterEmitWhenEnabled(t *testing.T) {
 	}
 
 	// Inspection runs immediately after emit, against the emitted artifact path.
-	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "install", "regenBoot", "resize", "sbom", "emit:1.0", "inspect:/out/img-1.0.raw"}
+	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "resize", "install", "regenBoot", "sbom", "emit:1.0", "inspect:/out/img-1.0.raw"}
 	if !equalStrings(r.calls, want) {
 		t.Errorf("stage order = %v, want %v", r.calls, want)
 	}
@@ -299,7 +299,7 @@ func TestBuilder_TimingStopsAtFailedStage(t *testing.T) {
 	}
 	want := []string{
 		"Acquire & Mount Baseline", "Inspect Baseline", "Resolve Packages", "Preflight",
-		"Install Packages",
+		"Resize", "Install Packages",
 	}
 	if !equalStrings(got, want) {
 		t.Errorf("timing stages after install failure = %v, want %v", got, want)


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Two overlay-mode improvements:

**1. Grow-only baseline resize.** Adds an opt-in, grow-only resize so an overlay template can request a larger `disk.size` and make room for upgraded/added packages. The resize extends the last partition and its filesystem in place (`growpart`/`sgdisk`/`resize2fs`/`xfs_growfs`); it never shrinks, repartitions, or relocates the bootloader, preserving the overlay immutability contract.

Guards:
- Requires the explicit `overlayPolicy.allowDiskResize: true` opt-in; a larger `disk.size` without it is a hard error, not a silent resize.
- Rejects a root that is not the last partition on the disk (growing a non-last root would corrupt the following partition).
- Verifies every required host tool (`growpart`, `sgdisk`, `resize2fs`/`xfs_growfs`, `losetup`, `partx`) is present up front, before any disk mutation.
- Rejects sizes above `int64` range.

The Resize stage runs **before** Install Packages in the overlay `Build()` phase, so the grow creates headroom before the install needs it — otherwise a near-full baseline fails the install with "no space left on device" before the resize could ever help.

**2. Baseline-download visibility.** The baseline image download from a remote `source.url` was logged at debug level, so a default (info) run showed no indication during the fetch. For large cloud images (e.g. Ubuntu noble ~600 MB) this looked like a hang before the "Converting qcow2 baseline to raw" line. The download start/finish messages are now logged at info level. The URL is redacted before logging — the query string and fragment are replaced with `[REDACTED]` and userinfo is masked — so presigned-URL credentials (e.g. S3/SAS query parameters) are never written to logs.

Docs: the grow-only resize is documented in the template user guide and captured as an ADR (`adr-overlay-grow-resize.md`).

#### Any Newly Introduced Dependencies

None. The resize shells out to standard host tools already expected on a build host (`growpart` from cloud-guest-utils, `sgdisk` from gdisk, `resize2fs` from e2fsprogs, `xfs_growfs` from xfsprogs, `losetup`/`partx` from util-linux).

#### How Has This Been Tested? <!-- REQUIRED -->

- Unit tests for the resize planner and orchestration (`internal/image/overlay/resize_test.go`) covering grow/no-grow decisions, the opt-in gate, non-last-partition rejection, missing-tool rejection, `int64` overflow, ext4-by-device and xfs-by-mount grow sequences, and the backing-file grow.
- Stage-ordering tests (`session_test.go`) pinning that Resize runs before Install Packages.
- `TestRedactURL` covering baseline-URL redaction: presigned query parameters, userinfo, fragments, and the unparseable-URL fallback.
- `go build ./internal/...`, `go vet`, and `gofmt` clean; `go test ./internal/image/overlay/` passes.
- End-to-end: built a noble server overlay image (`allowDiskResize: true`) upgrading/adding ~27 packages; the build completes successfully. In this run the baseline was already larger than the requested `disk.size`, so grow-only correctly skipped the resize as a no-op (0s) and the install completed — confirming the skip path and the resize-before-install ordering are wired into `Build()`.

