### PR TITLE
fix(templates): pin ubuntu24 edge kernel to noble GA (6.8)

### DIFF
--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -92,6 +92,8 @@
 
 - `fix(templates)`: kernel version metadata 6.14 → 6.17 (#494): Template metadata version field for Ubuntu 24 kernels corrected to match the actual installed kernel series.
 
+- `fix(templates)`: pin ubuntu24 edge kernel to noble GA (6.8) (#761): The `ubuntu24-x86_64-edge-raw` and `ubuntu24-aarch64-edge-raw` templates pinned `kernel.version: 6.17` with `linux-image-generic-hwe-24.04`, a combination Ubuntu noble no longer ships — only `6.8.0-31.31` (GA) and `7.0.0-28.28~24.04.1` (HWE-edge) are available. Pin the kernel to the noble GA combination (`6.8` + `linux-image-generic`) so the `build-ubuntu24-immutable` CI job can complete.
+
 - RPM DOT file naming bug (#538): `GenerateDot` used the raw filename (e.g., `glibc-2.38-16.azl3.x86_64.rpm`) as a node label instead of the canonical package name (`glibc`), producing incorrect dependency graphs.
 
 - Swap partition cleanup before loop device detach (#568): Building images that include a swap partition would fail at teardown because the loop device was busy. The swap partition is now detected and disabled with `swapoff` before `losetup -d`.

--- a/image-templates/ubuntu24-aarch64-edge-raw.yml
+++ b/image-templates/ubuntu24-aarch64-edge-raw.yml
@@ -67,7 +67,7 @@ systemConfig:
     - systemd-timesyncd
 
   kernel:
-    version: "6.17"
+    version: "6.8"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-generic

--- a/image-templates/ubuntu24-x86_64-edge-raw.yml
+++ b/image-templates/ubuntu24-x86_64-edge-raw.yml
@@ -67,7 +67,7 @@ systemConfig:
     - systemd-timesyncd
 
   kernel:
-    version: "6.17"
+    version: "6.8"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-generic


### PR DESCRIPTION
#### Merge Checklist

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description

The `ubuntu24-x86_64-edge-raw` and `ubuntu24-aarch64-edge-raw` templates pinned `kernel.version: 6.17` with `linux-image-generic-hwe-24.04`. Ubuntu noble no longer ships either combination — the kernel-version resolver reports only `6.8.0-31.31` (GA) and `7.0.0-28.28~24.04.1` (HWE-edge) available.

As a result, every PR CI run currently sees `build-ubuntu24-immutable` fail with:

```
kernel version mismatch: requires kernel version "6.17", but available versions are: [6.8.0-31.31 7.0.0-28.28~24.04.1]
```

(`scripts/build_ubuntu24_immutable.sh` consumes `ubuntu24-x86_64-edge-raw.yml`.)

This PR pins the kernel to the noble GA combination: `kernel.version: 6.8` with the stable `linux-image-generic` metapackage. GA was chosen over HWE-edge because it's the most rigorously tested combination against noble's driver/firmware ecosystem and the metapackage name is stable across HWE cycles.

The same edit is applied to `ubuntu24-aarch64-edge-raw.yml`, which carried the same stale values.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

- `go build ./cmd/image-composer-tool` — clean.
- `image-composer-tool validate image-templates/ubuntu24-x86_64-edge-raw.yml` — `✓ Template validation passed`, reports `Kernel: 6.8`.
- `image-composer-tool validate image-templates/ubuntu24-aarch64-edge-raw.yml` — same result on the aarch64 template.
- The `build-ubuntu24-immutable` CI job will exercise the actual apt/dpkg resolve path end-to-end on this PR.
