### PR TITLE
fix(templates): pin ubuntu24 kernels to concrete versioned packages

### DIFF
--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -94,6 +94,8 @@
 
 - `fix(templates)`: pin ubuntu24 edge kernel to noble GA (6.8) (#761): The `ubuntu24-x86_64-edge-raw` and `ubuntu24-aarch64-edge-raw` templates pinned `kernel.version: 6.17` with `linux-image-generic-hwe-24.04`, a combination Ubuntu noble no longer ships — only `6.8.0-31.31` (GA) and `7.0.0-28.28~24.04.1` (HWE-edge) are available. Pin the kernel to the noble GA combination (`6.8` + `linux-image-generic`) so the `build-ubuntu24-immutable` CI job can complete.
 
+- `fix(templates)`: replace ubuntu24 rolling-metapackage kernel pins with concrete versioned packages: Every ubuntu24 template that combined a `kernel.version` string with a rolling metapackage (`linux-image-generic-hwe-24.04`, `linux-image-generic`, `linux-image-generic*`) was one archive update away from the same CI break that #494, #669, and #761 fixed. Replace those metapackages with concrete versioned kernel packages so the `kernel.version` pin points at a package that actually exists in the archive. HWE-family templates now install `linux-image-7.0.0-28-generic` (noble HWE-edge current); GA-family templates now install `linux-image-6.8.0-31-generic` (noble GA current). Concrete pins mean CVE-triggered bumps become a normal template maintenance task rather than a silent archive drift.
+
 - RPM DOT file naming bug (#538): `GenerateDot` used the raw filename (e.g., `glibc-2.38-16.azl3.x86_64.rpm`) as a node label instead of the canonical package name (`glibc`), producing incorrect dependency graphs.
 
 - Swap partition cleanup before loop device detach (#568): Building images that include a swap partition would fail at teardown because the loop device was busy. The swap partition is now detected and disabled with `swapoff` before `losetup -d`.

--- a/image-templates/ubuntu24-aarch64-edge-raw.yml
+++ b/image-templates/ubuntu24-aarch64-edge-raw.yml
@@ -67,7 +67,7 @@ systemConfig:
     - systemd-timesyncd
 
   kernel:
-    version: "6.8"
+    version: "6.8.0-31"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic
+      - linux-image-6.8.0-31-generic

--- a/image-templates/ubuntu24-aarch64-minimal-raw.yml
+++ b/image-templates/ubuntu24-aarch64-minimal-raw.yml
@@ -86,7 +86,7 @@ systemConfig:
     - grub-efi-arm64
 
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic

--- a/image-templates/ubuntu24-aarch64-minimal-uki.yml
+++ b/image-templates/ubuntu24-aarch64-minimal-uki.yml
@@ -87,7 +87,7 @@ systemConfig:
     - dracut-core
 
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic

--- a/image-templates/ubuntu24-aarch64-server-cloud.yml
+++ b/image-templates/ubuntu24-aarch64-server-cloud.yml
@@ -147,7 +147,7 @@ systemConfig:
 
   # Kernel metadata used by builder to set cmdline and module hints
   kernel:
-    version: "6.11"
+    version: "7.0.0-28"
     cmdline: "root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyS0"
     packages:
-      - linux-image-generic-hwe-24.04 
+      - linux-image-7.0.0-28-generic

--- a/image-templates/ubuntu24-x86_64-dkms-demo.yml
+++ b/image-templates/ubuntu24-x86_64-dkms-demo.yml
@@ -95,8 +95,8 @@ systemConfig:
     - apfs-dkms
 
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
-      - linux-headers-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic
+      - linux-headers-7.0.0-28-generic

--- a/image-templates/ubuntu24-x86_64-edge-raw.yml
+++ b/image-templates/ubuntu24-x86_64-edge-raw.yml
@@ -67,7 +67,7 @@ systemConfig:
     - systemd-timesyncd
 
   kernel:
-    version: "6.8"
+    version: "6.8.0-31"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic
+      - linux-image-6.8.0-31-generic

--- a/image-templates/ubuntu24-x86_64-minimal-desktop-raw.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-desktop-raw.yml
@@ -116,7 +116,7 @@ systemConfig:
     - efibootmgr
   
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic

--- a/image-templates/ubuntu24-x86_64-minimal-raw-expand-partition.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-raw-expand-partition.yml
@@ -95,7 +95,7 @@ systemConfig:
     - parted
 
   kernel:
-    version: "6.14"
+    version: "6.8.0-31"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic*
+      - linux-image-6.8.0-31-generic

--- a/image-templates/ubuntu24-x86_64-minimal-raw.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-raw.yml
@@ -82,7 +82,7 @@ systemConfig:
     - systemd-timesyncd
 
   kernel:
-    version: "6.14"
+    version: "6.8.0-31"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic*
+      - linux-image-6.8.0-31-generic

--- a/image-templates/ubuntu24-x86_64-robotics-jazzy-iso.yml
+++ b/image-templates/ubuntu24-x86_64-robotics-jazzy-iso.yml
@@ -191,10 +191,10 @@ systemConfig:
     - intel-driver-compiler-npu
 
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic
 
   configurations:
     # ── ROS 2 environment setup ────────────────────────────────────

--- a/image-templates/ubuntu24-x86_64-robotics-jazzy-raw.yml
+++ b/image-templates/ubuntu24-x86_64-robotics-jazzy-raw.yml
@@ -216,10 +216,10 @@ systemConfig:
     - intel-driver-compiler-npu
 
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic
 
   configurations:
     # ── ROS 2 environment setup ────────────────────────────────────

--- a/image-templates/ubuntu24-x86_64-ros2.yml
+++ b/image-templates/ubuntu24-x86_64-ros2.yml
@@ -43,10 +43,10 @@ systemConfig:
     - ros-jazzy-demo-nodes-py
 
   kernel:
-    version: "6.17"
+    version: "7.0.0-28"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
+      - linux-image-7.0.0-28-generic
   
   configurations:
     # Create ROS data directories with full permissions


### PR DESCRIPTION
#### Merge Checklist

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description

This PR is one of **two independent responses** to [yktyagi's post-merge review comment on #761](https://github.com/open-edge-platform/image-composer-tool/pull/761#discussion_r3601861995). It implements the second resolution he proposed: *"I need exactly kernel X — name a concrete versioned kernel package (e.g. `linux-image-6.8.0-31-generic`) instead of a metapackage, and set `kernel.version` to match. This is a genuine pin and won't drift — but you own bumping it for CVEs."*

The companion PR (#765) implements the first resolution — drop the `kernel.version` pin and let the metapackage roll — for cases where the intent is "always current." The two are mutually exclusive; reviewers pick whichever matches the repo's preferred direction.

#### The problem

PR #761 fixed a hard CI failure in `build-ubuntu24-immutable` caused by `kernel.version: 6.17` combined with `linux-image-generic-hwe-24.04`: Ubuntu noble no longer ships 6.17. The kernel-version resolver at `internal/ospackage/debutils/download.go:1024` fails the build when the pinned version does not exist in the archive.

That same antipattern is present in **12 ubuntu24 templates** that combine a `kernel.version` string with a rolling metapackage (`linux-image-generic-hwe-24.04`, `linux-image-generic`, `linux-image-generic*`). PRs #494 (6.14 → 6.17), #669 (ubuntu26 6.17 → 7.0), and #761 (6.17 → 6.8) are three iterations of the same recurring fix. The metapackage + version-pin combination is a semantic mismatch: the metapackage says *give me whatever's current*, the pin says *give me exactly X* — and only one of them can win at resolve time.

#### The fix (this PR)

Replace rolling metapackages with concrete versioned kernel packages so the \`kernel.version\` pin points at a package that actually exists in the archive. **Preserve original intent per template**:

- **HWE-family** (was \`linux-image-generic-hwe-24.04\`, 8 templates): install \`linux-image-7.0.0-28-generic\` + \`kernel.version: 7.0.0-28\` (noble HWE-edge current).
- **GA-family** (was \`linux-image-generic\` post-#761, 2 edge-raw templates): install \`linux-image-6.8.0-31-generic\` + \`kernel.version: 6.8.0-31\` (noble GA current).
- **Glob templates** (was \`linux-image-generic*\`, 2 minimal-raw): install \`linux-image-6.8.0-31-generic\` + \`kernel.version: 6.8.0-31\`. The glob had relied on the GA metapackage and the \`6.14\` pin never resolved cleanly against the current archive anyway.

Concrete pins mean CVE-triggered bumps become a normal template maintenance task rather than a silent archive drift.

#### Files touched

12 templates + 1 release-notes entry.

**HWE → 7.0.0-28**:
- \`image-templates/ubuntu24-aarch64-minimal-raw.yml\`
- \`image-templates/ubuntu24-aarch64-minimal-uki.yml\`
- \`image-templates/ubuntu24-aarch64-server-cloud.yml\`
- \`image-templates/ubuntu24-x86_64-dkms-demo.yml\` (also \`linux-headers-7.0.0-28-generic\`)
- \`image-templates/ubuntu24-x86_64-minimal-desktop-raw.yml\`
- \`image-templates/ubuntu24-x86_64-robotics-jazzy-iso.yml\`
- \`image-templates/ubuntu24-x86_64-robotics-jazzy-raw.yml\`
- \`image-templates/ubuntu24-x86_64-ros2.yml\`

**GA → 6.8.0-31**:
- \`image-templates/ubuntu24-aarch64-edge-raw.yml\`
- \`image-templates/ubuntu24-x86_64-edge-raw.yml\`

**Glob → 6.8.0-31**:
- \`image-templates/ubuntu24-x86_64-minimal-raw.yml\`
- \`image-templates/ubuntu24-x86_64-minimal-raw-expand-partition.yml\`

**Unchanged intentionally**: templates that already use a concrete versioned kernel package (\`linux-image-6.11.0-17-generic\` in \`ubuntu24-server-cloud-amd64.yml\`, \`linux-image-6.12-intel\` / \`linux-image-6.18-intel\` in dlstreamer / ptl-pv). Those already follow this pattern.

#### Note on prior claim

PR #494's commit message stated *\"kernel.version is metadata only — the actual kernel installed is determined by the packages list.\"* That is not true against the current resolver: \`internal/ospackage/debutils/resolver.go:1419-1424\` filters candidates by \`KernelVersion\`, which is exactly why #761's CI was hard-failing. Concrete packages neutralise the mismatch by making the pin's target unambiguous.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

- \`go build ./cmd/image-composer-tool\` — clean.
- \`image-composer-tool validate\` — passes on every touched template; \`Kernel: 6.8.0-31\` and \`Kernel: 7.0.0-28\` reported.
- The \`build-ubuntu24-*\` CI jobs on this PR will exercise the actual apt/dpkg resolve path end-to-end.

#### Follow-up worth flagging

The default configs under \`config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/\` still carry the same antipattern. Templates override them, so the CI break was limited to templates, but the defaults would trip a new downstream user who copies them. Left for a separate discussion.
