### PR TITLE
make cache validation use simple name compare

### DIFF
--- a/internal/ospackage/debutils/download.go
+++ b/internal/ospackage/debutils/download.go
@@ -284,7 +284,6 @@ func requirementCandidates(required string) []string {
 
 func isDebRequirementInCache(
 	required string,
-	cachedPackageNames map[string]struct{},
 	cachedPackageInfos []ospackage.PackageInfo,
 ) bool {
 	required = strings.TrimSpace(required)
@@ -292,44 +291,9 @@ func isDebRequirementInCache(
 		return true
 	}
 
-	candidates := requirementCandidates(required)
-	if len(candidates) == 0 {
-		return true
-	}
-
-	for _, cand := range candidates {
-		if pkg, found := ResolveTopPackageConflicts(cand, cachedPackageInfos); found && pkg.Name != "" {
+	for _, pkg := range cachedPackageInfos {
+		if strings.TrimSpace(pkg.Name) == required {
 			return true
-		}
-	}
-
-	for _, cand := range candidates {
-		candName := cand
-		if idx := strings.Index(candName, "_"); idx > 0 {
-			candName = candName[:idx]
-		}
-		candName = strings.TrimSpace(candName)
-		if candName == "" {
-			continue
-		}
-		if _, ok := cachedPackageNames[candName]; ok {
-			return true
-		}
-	}
-
-	for _, cand := range candidates {
-		candName := cand
-		if idx := strings.Index(candName, "_"); idx > 0 {
-			candName = candName[:idx]
-		}
-		candName = strings.TrimSpace(candName)
-		if candName == "" {
-			continue
-		}
-		for cachedName := range cachedPackageNames {
-			if matchesPackageFilter(cachedName, []string{candName}) {
-				return true
-			}
 		}
 	}
 
@@ -443,7 +407,7 @@ func isDebPackageCacheOutdated(requiredPackages []string, cacheDir string) (bool
 		if req == "" {
 			continue
 		}
-		if isDebRequirementInCache(req, cachedPackageNames, cachedPackageInfos) {
+		if isDebRequirementInCache(req, cachedPackageInfos) {
 			continue
 		}
 		if _, seen := missingSet[req]; seen {

--- a/internal/ospackage/debutils/download_test.go
+++ b/internal/ospackage/debutils/download_test.go
@@ -523,8 +523,11 @@ func TestIsDebPackageCacheOutdated_VersionPinnedRequirement(t *testing.T) {
 		t.Fatalf("isDebPackageCacheOutdated returned error: %v", err)
 	}
 
-	if outdated {
-		t.Fatalf("expected version-pinned requirement to be satisfied from cache, missing=%v", missing)
+	if !outdated {
+		t.Fatalf("expected version-pinned requirement to be reported missing when only exact cached package names are checked")
+	}
+	if len(missing) != 1 || missing[0] != "intel-dlstreamer_2025.2.0" {
+		t.Fatalf("expected missing=[intel-dlstreamer_2025.2.0], got %v", missing)
 	}
 }
 
@@ -543,8 +546,11 @@ func TestIsDebPackageCacheOutdated_EpochPinnedRequirement(t *testing.T) {
 		t.Fatalf("isDebPackageCacheOutdated returned error: %v", err)
 	}
 
-	if outdated {
-		t.Fatalf("expected epoch-pinned requirement to be satisfied from cache, missing=%v", missing)
+	if !outdated {
+		t.Fatalf("expected epoch-pinned requirement to be reported missing when only exact cached package names are checked")
+	}
+	if len(missing) != 1 || missing[0] != "qemu-system_4:9.1.0+git20251029-ppa1-noble3" {
+		t.Fatalf("expected missing=[qemu-system_4:9.1.0+git20251029-ppa1-noble3], got %v", missing)
 	}
 }
 

--- a/internal/ospackage/debutils/download_test.go
+++ b/internal/ospackage/debutils/download_test.go
@@ -481,6 +481,137 @@ func TestBuildRepoConfigs_UsesCachedPackageListOffline(t *testing.T) {
 	}
 }
 
+func TestStripDebEpoch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "version with epoch", input: "4:9.1.0+git", want: "9.1.0+git"},
+		{name: "trim surrounding spaces", input: " 2:1.0 ", want: "1.0"},
+		{name: "no epoch", input: "1.2.3", want: "1.2.3"},
+		{name: "colon at first position is unchanged", input: ":1.2.3", want: ":1.2.3"},
+		{name: "empty string", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := stripDebEpoch(tt.input)
+			if got != tt.want {
+				t.Fatalf("stripDebEpoch(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequirementCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "empty requirement", input: "", want: nil},
+		{name: "plain package", input: "bash", want: []string{"bash"}},
+		{
+			name:  "version pinned with epoch",
+			input: "qemu-system_4:9.1.0+git20251029",
+			want: []string{
+				"qemu-system_4:9.1.0+git20251029",
+				"qemu-system_4",
+				"qemu-system",
+				"qemu-system_9.1.0+git20251029",
+			},
+		},
+		{
+			name:  "dependency expression adds cleaned candidate",
+			input: "libc6 (>= 2.34)",
+			want: []string{
+				"libc6 (>= 2.34)",
+				"libc6",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := requirementCandidates(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("requirementCandidates(%q) len = %d, want %d (%v)", tt.input, len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("requirementCandidates(%q)[%d] = %q, want %q (full=%v)", tt.input, i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadDebPackageInfosFromMetadataCache(t *testing.T) {
+	origRepoCfg := RepoCfg
+	origRepoCfgs := RepoCfgs
+	origUserRepoCfgs := UserRepoCfgs
+	origLocalUserRepoCfgs := LocalUserRepoCfgs
+	t.Cleanup(func() {
+		RepoCfg = origRepoCfg
+		RepoCfgs = origRepoCfgs
+		UserRepoCfgs = origUserRepoCfgs
+		LocalUserRepoCfgs = origLocalUserRepoCfgs
+	})
+
+	dirDefault := t.TempDir()
+	dirUser := t.TempDir()
+	dirInvalid := t.TempDir()
+
+	defaultPkgs := []ospackage.PackageInfo{{
+		Name:    "bash",
+		Version: "1.0",
+		URL:     "https://repo.example/pool/bash_1.0_amd64.deb",
+		Type:    "deb",
+	}}
+	if err := saveParsedPackageCache(filepath.Join(dirDefault, "packages.parsed.json"), "sum-default", defaultPkgs); err != nil {
+		t.Fatalf("failed to write default metadata cache: %v", err)
+	}
+
+	userPkgs := []ospackage.PackageInfo{{
+		Name:    "coreutils",
+		Version: "9.0",
+		URL:     "https://repo.example/pool/coreutils_9.0_amd64.deb",
+		Type:    "deb",
+	}}
+	if err := saveParsedPackageCache(filepath.Join(dirUser, "packages.parsed.json"), "sum-user", userPkgs); err != nil {
+		t.Fatalf("failed to write user metadata cache: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dirInvalid, "packages.parsed.json"), []byte("{invalid-json"), 0644); err != nil {
+		t.Fatalf("failed to write invalid metadata cache: %v", err)
+	}
+
+	RepoCfg = RepoConfig{BuildPath: dirDefault}
+	RepoCfgs = []RepoConfig{{BuildPath: dirDefault}, {BuildPath: dirInvalid}}
+	UserRepoCfgs = []RepoConfig{{BuildPath: dirUser}}
+	LocalUserRepoCfgs = nil
+
+	got := loadDebPackageInfosFromMetadataCache()
+	if len(got) != 2 {
+		t.Fatalf("loadDebPackageInfosFromMetadataCache() returned %d packages, want 2", len(got))
+	}
+
+	if got[0].Name != "bash" || got[1].Name != "coreutils" {
+		t.Fatalf("unexpected package order/content: %#v", got)
+	}
+}
+
 func TestIsDebPackageCacheOutdated(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/ospackage/rpmutils/download.go
+++ b/internal/ospackage/rpmutils/download.go
@@ -578,17 +578,14 @@ func Resolve(req []ospackage.PackageInfo, all []ospackage.PackageInfo) ([]ospack
 	return needed, nil
 }
 
-func isRPMRequirementInCache(required string, cachedPackageNames map[string]struct{}) bool {
-	required = strings.TrimSpace(extractBaseNameFromDep(required))
+func isRPMRequirementInCache(required string, cachedPackageInfos []ospackage.PackageInfo) bool {
+	required = strings.TrimSpace(required)
 	if required == "" {
 		return true
 	}
 
-	for cachedName := range cachedPackageNames {
-		if matchesPackageFilter(cachedName, []string{required}) {
-			return true
-		}
-		if matchesPackageFilter(required, []string{cachedName}) {
+	for _, pkg := range cachedPackageInfos {
+		if strings.TrimSpace(pkg.Name) == required {
 			return true
 		}
 	}
@@ -603,12 +600,16 @@ func isRPMPackageCacheOutdated(requiredPackages []string, cacheDir string) (bool
 		return false, nil, nil, fmt.Errorf("glob %q: %w", pattern, err)
 	}
 
-	cachedPackageNames := make(map[string]struct{}, len(cachedPaths))
+	cachedPackageInfos := make([]ospackage.PackageInfo, 0, len(cachedPaths))
 	cachedFiles := make([]string, 0, len(cachedPaths))
 	for _, p := range cachedPaths {
 		base := filepath.Base(p)
 		cachedFiles = append(cachedFiles, base)
-		cachedPackageNames[extractBasePackageNameFromFile(base)] = struct{}{}
+		cachedPackageInfos = append(cachedPackageInfos, ospackage.PackageInfo{
+			Name: extractBasePackageNameFromFile(base),
+			URL:  p,
+			Type: "rpm",
+		})
 	}
 
 	missingSet := make(map[string]struct{})
@@ -618,7 +619,7 @@ func isRPMPackageCacheOutdated(requiredPackages []string, cacheDir string) (bool
 		if req == "" {
 			continue
 		}
-		if isRPMRequirementInCache(req, cachedPackageNames) {
+		if isRPMRequirementInCache(req, cachedPackageInfos) {
 			continue
 		}
 		if _, seen := missingSet[req]; seen {

--- a/internal/ospackage/rpmutils/download_cache_test.go
+++ b/internal/ospackage/rpmutils/download_cache_test.go
@@ -56,8 +56,11 @@ func TestIsRPMPackageCacheOutdated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("isRPMPackageCacheOutdated returned error: %v", err)
 	}
-	if outdated {
-		t.Fatalf("expected version-pinned package to be satisfied from cache, missing=%v", missing)
+	if !outdated {
+		t.Fatalf("expected version-pinned package to be reported missing when only exact cached package names are checked")
+	}
+	if len(missing) != 1 || missing[0] != "kernel-drivers-gpu-6.12.55" {
+		t.Fatalf("expected missing=[kernel-drivers-gpu-6.12.55], got %v", missing)
 	}
 }
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

This PR changes DEB/RPM package cache validation logic to use strict string-equality name comparisons (instead of filter/candidate-based matching), and updates/adds tests to reflect the new “exact-name-only” cache behavior.

Changes:

RPM: cache satisfaction checks now require exact equality between the requirement string and cached package “simple name”.
DEB: cache satisfaction checks now require exact equality between the requirement string and cached PackageInfo.Name, dropping candidate/epoch/version fallback matching.
Tests updated to assert that version/epoch-pinned requirements are reported missing under the new exact-match behavior, plus new unit tests for DEB helper functions.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->