### PR TITLE
feat(overlay): emit all build-mode output formats

### DIFF
--- a/internal/image/imageconvert/imageconvert.go
+++ b/internal/image/imageconvert/imageconvert.go
@@ -198,7 +198,7 @@ func ConvertImageToRaw(filePath, outputDir string) (string, error) {
 	outputFilePath := filepath.Join(outputDir, fileNameWithoutExt+".raw")
 
 	// Convert to raw using qemu-img
-	cmdStr := fmt.Sprintf("qemu-img convert -O raw %s %s", filePath, outputFilePath)
+	cmdStr := fmt.Sprintf("qemu-img convert -O raw -- %s %s", shellSingleQuote(filePath), shellSingleQuote(outputFilePath))
 	_, err = shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
 	if err != nil {
 		log.Errorf("Failed to convert %s to raw: %v", sourceFormat, err)
@@ -241,19 +241,21 @@ func convertImageFile(filePath, imageType string) (string, error) {
 	fileNameWithoutExt := strings.TrimSuffix(fileName, filepath.Ext(fileName))
 	outputFilePath := filepath.Join(fileDir, fileNameWithoutExt+"."+imageType)
 
+	src := shellSingleQuote(filePath)
+	dst := shellSingleQuote(outputFilePath)
 	switch imageType {
 	case "raw":
-		cmdStr = fmt.Sprintf("qemu-img convert -O raw %s %s", filePath, outputFilePath)
+		cmdStr = fmt.Sprintf("qemu-img convert -O raw -- %s %s", src, dst)
 	case "vhd":
-		cmdStr = fmt.Sprintf("qemu-img convert -O vpc %s %s", filePath, outputFilePath)
+		cmdStr = fmt.Sprintf("qemu-img convert -O vpc -- %s %s", src, dst)
 	case "vhdx":
-		cmdStr = fmt.Sprintf("qemu-img convert -O vhdx %s %s", filePath, outputFilePath)
+		cmdStr = fmt.Sprintf("qemu-img convert -O vhdx -- %s %s", src, dst)
 	case "qcow2":
-		cmdStr = fmt.Sprintf("qemu-img convert -O qcow2 -c -S 4k -p -o cluster_size=2M,lazy_refcounts=on %s %s", filePath, outputFilePath)
+		cmdStr = fmt.Sprintf("qemu-img convert -O qcow2 -c -S 4k -p -o cluster_size=2M,lazy_refcounts=on -- %s %s", src, dst)
 	case "vmdk":
-		cmdStr = fmt.Sprintf("qemu-img convert -O vmdk %s %s", filePath, outputFilePath)
+		cmdStr = fmt.Sprintf("qemu-img convert -O vmdk -- %s %s", src, dst)
 	case "vdi":
-		cmdStr = fmt.Sprintf("qemu-img convert -O vdi %s %s", filePath, outputFilePath)
+		cmdStr = fmt.Sprintf("qemu-img convert -O vdi -- %s %s", src, dst)
 	default:
 		log.Errorf("Unsupported image type: %s", imageType)
 		return outputFilePath, fmt.Errorf("unsupported image type: %s", imageType)
@@ -284,16 +286,17 @@ func compressImageFile(filePath, compressionType string) error {
 func trimUnusedSpace(filePath string) error {
 	log.Infof("Attempting to trim unused space in image file: %s", filePath)
 
-	// Method 1: Try virt-sparsify if available (most effective)
+	// Method 1: Try virt-sparsify if available (most effective). --in-place
+	// rewrites the image directly, so there is no separate output file to clean
+	// up on failure (removing filePath+".sparse" here would only risk deleting an
+	// unrelated pre-existing file).
 	if _, err := shell.ExecCmd("which virt-sparsify", false, shell.HostPath, nil); err == nil {
-		tempFile := filePath + ".sparse"
-		sparsifyCmd := fmt.Sprintf("virt-sparsify --in-place %s", filePath)
+		sparsifyCmd := fmt.Sprintf("virt-sparsify --in-place -- %s", shellSingleQuote(filePath))
 		if _, err := shell.ExecCmd(sparsifyCmd, true, shell.HostPath, nil); err == nil {
 			log.Infof("Successfully sparsified image using virt-sparsify")
 			return nil
 		}
 		log.Warnf("virt-sparsify failed, trying alternative methods: %v", err)
-		os.Remove(tempFile) // Clean up on failure
 	}
 
 	// Method 2: Use qemu-img convert with sparse detection (fallback)
@@ -318,7 +321,7 @@ func sparsifyWithQemuImg(filePath string) error {
 
 	// Convert image to itself without -S flag to avoid size parameter issues
 	// qemu-img automatically detects and optimizes sparse regions
-	convertCmd := fmt.Sprintf("qemu-img convert -O raw %s %s", filePath, tempFile)
+	convertCmd := fmt.Sprintf("qemu-img convert -O raw -- %s %s", shellSingleQuote(filePath), shellSingleQuote(tempFile))
 	if _, err := shell.ExecCmd(convertCmd, true, shell.HostPath, nil); err != nil {
 		os.Remove(tempFile) // Clean up on error
 		return fmt.Errorf("failed to sparsify image: %w", err)

--- a/internal/image/overlay/session.go
+++ b/internal/image/overlay/session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config"
 	"github.com/open-edge-platform/image-composer-tool/internal/config/manifest"
+	"github.com/open-edge-platform/image-composer-tool/internal/image/imageconvert"
 	"github.com/open-edge-platform/image-composer-tool/internal/image/imageinspect"
 	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/display"
@@ -118,6 +119,9 @@ var (
 	builderSBOMFn      = generateOverlaySBOM
 	builderEmitFn      = emitOverlayArtifact
 	builderInspectFn   = inspectOverlayArtifact
+	builderConvertFn   = func(path string, template *config.ImageTemplate) error {
+		return imageconvert.NewImageConvert().ConvertImageFile(path, template)
+	}
 )
 
 // NewBuilder constructs an overlay Builder for an overlay-mode template. It returns
@@ -415,6 +419,22 @@ func (b *Builder) Postprocess(buildErr error) (err error) {
 		log.Infof("Overlay postprocess: image inspection disabled (--no-inspect); skipping")
 	}
 
+	// Convert the emitted RAW into the disk.artifacts output formats (qcow2, vhd,
+	// vhdx, vmdk, vdi) and apply any configured compression, so overlay mode emits
+	// every output format create/build mode supports. This reuses the same
+	// converter the create-mode rawmaker runs, keyed on template disk.artifacts;
+	// it is a no-op when disk.artifacts is empty or lists only raw, so plain RAW
+	// overlay builds are unchanged. It runs AFTER the RAW inspection above because
+	// a request that omits raw deletes the RAW file as part of conversion.
+	if err := b.timeStage("Convert Artifacts", func() error {
+		if cerr := builderConvertFn(artifact, b.template); cerr != nil {
+			return fmt.Errorf("overlay postprocess: failed to convert image artifact: %w", cerr)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
 	// Display package statistics showing what was added/upgraded vs unchanged
 	stats := ComputePackageStats(b.baseline, b.plan)
 	PrintPackageStats(stats)
@@ -426,13 +446,38 @@ func (b *Builder) Postprocess(buildErr error) (err error) {
 
 	// Print the same success/artifact summary box the create-mode makers emit, so
 	// overlay builds also report the generated artifacts. The build directory is the
-	// parent of the emitted RAW artifact; emitOverlayArtifact has placed the .raw
-	// there, and the SBOM sidecar too when its best-effort copy succeeded (the
-	// summary lists whatever files are actually present, so a missing sidecar simply
-	// isn't shown).
-	display.PrintImageDirectorySummary(filepath.Dir(artifact), "RAW")
+	// parent of the emitted artifact; emitOverlayArtifact has placed the .raw there
+	// (and the conversion above may have added qcow2/vhd/... alongside or in place of
+	// it), plus the SBOM sidecar when its best-effort copy succeeded. The summary
+	// lists whatever files are actually present, so it reflects the converted formats
+	// and a missing sidecar simply isn't shown.
+	display.PrintImageDirectorySummary(filepath.Dir(artifact), overlayArtifactTypeLabel(b.template))
 
 	return nil
+}
+
+// overlayArtifactTypeLabel derives the "Image Type" label for the success
+// summary from the template's disk.artifacts, so the box reflects the formats
+// actually requested (e.g. "QCOW2" or "QCOW2, RAW") rather than always claiming
+// "RAW" after the Convert Artifacts stage may have replaced the .raw file. It
+// defaults to "RAW" when no artifacts are declared, matching the plain overlay
+// build that emits only the RAW image.
+func overlayArtifactTypeLabel(t *config.ImageTemplate) string {
+	artifacts := t.GetDiskConfig().Artifacts
+	if len(artifacts) == 0 {
+		return "RAW"
+	}
+	types := make([]string, 0, len(artifacts))
+	for _, a := range artifacts {
+		if a.Type == "" {
+			continue
+		}
+		types = append(types, strings.ToUpper(a.Type))
+	}
+	if len(types) == 0 {
+		return "RAW"
+	}
+	return strings.Join(types, ", ")
 }
 
 // cleanup runs the mount/loop teardown chain. It is idempotent: the mount teardown

--- a/internal/image/overlay/session_test.go
+++ b/internal/image/overlay/session_test.go
@@ -25,6 +25,7 @@ type builderSeams struct {
 	sbom        func(*BaselineInfo, string, *ResolutionPlan) error
 	emit        func(*config.ImageTemplate, string, string) (string, error)
 	inspect     func(string) error
+	convert     func(string, *config.ImageTemplate) error
 }
 
 func saveBuilderSeams() builderSeams {
@@ -35,6 +36,7 @@ func saveBuilderSeams() builderSeams {
 		install: builderInstallFn, configure: builderConfigureFn, regenBoot: builderRegenBootFn,
 		grubRegen: builderGrubRegenFn, resize: builderResizeFn,
 		sbom: builderSBOMFn, emit: builderEmitFn, inspect: builderInspectFn,
+		convert: builderConvertFn,
 	}
 }
 
@@ -45,6 +47,7 @@ func (s builderSeams) restore() {
 	builderInstallFn, builderConfigureFn, builderRegenBootFn, builderResizeFn = s.install, s.configure, s.regenBoot, s.resize
 	builderGrubRegenFn = s.grubRegen
 	builderSBOMFn, builderEmitFn, builderInspectFn = s.sbom, s.emit, s.inspect
+	builderConvertFn = s.convert
 }
 
 // builderRecorder tracks calls through the seams and lets a test inject errors at
@@ -70,6 +73,7 @@ type builderRecorder struct {
 	sbomErr      error
 	emitErr      error
 	inspectErr   error
+	convertErr   error
 
 	report    *PreflightReport
 	installed *InstallResult
@@ -170,6 +174,10 @@ func installOverlayTestBuilder(t *testing.T, r *builderRecorder) *Builder {
 		r.note("inspect:" + artifact)
 		return r.inspectErr
 	}
+	builderConvertFn = func(path string, _ *config.ImageTemplate) error {
+		r.note("convert:" + path)
+		return r.convertErr
+	}
 	return b
 }
 
@@ -188,7 +196,10 @@ func TestBuilder_HappyPathOrdersStagesAndCleansUp(t *testing.T) {
 		t.Fatalf("Postprocess: %v", err)
 	}
 
-	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "resize", "install", "configure", "regenBoot", "grubRegen", "sbom", "emit:1.0"}
+	// This test template leaves InspectEnabled at its zero value (false), so
+	// inspection is skipped and conversion runs directly after emit. (The CLI
+	// defaults --inspect on; see TestBuilder_InspectRunsAfterEmitWhenEnabled.)
+	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "resize", "install", "configure", "regenBoot", "grubRegen", "sbom", "emit:1.0", "convert:/out/img-1.0.raw"}
 	if !equalStrings(r.calls, want) {
 		t.Errorf("stage order = %v, want %v", r.calls, want)
 	}
@@ -204,7 +215,7 @@ func TestBuilder_HappyPathOrdersStagesAndCleansUp(t *testing.T) {
 	// execution order, so the caller can render an overlay timing table.
 	wantStages := []string{
 		"Acquire & Mount Baseline", "Inspect Baseline", "Resolve Packages", "Preflight",
-		"Resize", "Install Packages", "Configurations", "Boot Regeneration", "GRUB Regeneration", "Generate SBOM", "Emit Artifact",
+		"Resize", "Install Packages", "Configurations", "Boot Regeneration", "GRUB Regeneration", "Generate SBOM", "Emit Artifact", "Convert Artifacts",
 	}
 	gotStages := make([]string, 0, len(b.Timings()))
 	for _, ts := range b.Timings() {
@@ -231,18 +242,21 @@ func TestBuilder_InspectRunsAfterEmitWhenEnabled(t *testing.T) {
 		t.Fatalf("Postprocess: %v", err)
 	}
 
-	// Inspection runs immediately after emit, against the emitted artifact path.
-	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "resize", "install", "configure", "regenBoot", "grubRegen", "sbom", "emit:1.0", "inspect:/out/img-1.0.raw"}
+	// Inspection runs immediately after emit, against the emitted RAW artifact,
+	// and conversion follows it (a request that omits raw would delete the RAW,
+	// so the RAW inspection must happen first).
+	want := []string{"acquire", "mount", "detect", "resolve", "preflight", "resize", "install", "configure", "regenBoot", "grubRegen", "sbom", "emit:1.0", "inspect:/out/img-1.0.raw", "convert:/out/img-1.0.raw"}
 	if !equalStrings(r.calls, want) {
 		t.Errorf("stage order = %v, want %v", r.calls, want)
 	}
-	// The timing table gains an "Inspect Image" row after "Emit Artifact".
+	// The timing table gains an "Inspect Image" row after "Emit Artifact", then a
+	// "Convert Artifacts" row as the final stage.
 	gotStages := make([]string, 0, len(b.Timings()))
 	for _, ts := range b.Timings() {
 		gotStages = append(gotStages, ts.Stage)
 	}
-	if len(gotStages) == 0 || gotStages[len(gotStages)-1] != "Inspect Image" {
-		t.Errorf("expected last timing stage to be 'Inspect Image', got %v", gotStages)
+	if len(gotStages) < 2 || gotStages[len(gotStages)-2] != "Inspect Image" || gotStages[len(gotStages)-1] != "Convert Artifacts" {
+		t.Errorf("expected final timing stages to be 'Inspect Image' then 'Convert Artifacts', got %v", gotStages)
 	}
 }
 
@@ -289,6 +303,30 @@ func TestBuilder_InspectFailureFailsPostprocess(t *testing.T) {
 		t.Errorf("expected inspection failure to surface, got %v", err)
 	}
 	// Cleanup still ran exactly once despite the inspection failure.
+	if r.teardowns != 1 || r.detaches != 1 {
+		t.Errorf("teardown/detach = %d/%d, want 1/1", r.teardowns, r.detaches)
+	}
+}
+
+func TestBuilder_ConvertFailureFailsPostprocess(t *testing.T) {
+	defer saveBuilderSeams().restore()
+	r := &builderRecorder{convertErr: errors.New("qemu-img failed")}
+	b := installOverlayTestBuilder(t, r)
+
+	if err := b.Preprocess(); err != nil {
+		t.Fatalf("Preprocess: %v", err)
+	}
+	if err := b.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	err := b.Postprocess(nil)
+	if err == nil {
+		t.Fatal("expected Postprocess to fail when artifact conversion fails")
+	}
+	if !strings.Contains(err.Error(), "failed to convert image artifact") {
+		t.Errorf("expected conversion failure to surface, got %v", err)
+	}
+	// Cleanup still ran exactly once despite the conversion failure.
 	if r.teardowns != 1 || r.detaches != 1 {
 		t.Errorf("teardown/detach = %d/%d, want 1/1", r.teardowns, r.detaches)
 	}
@@ -675,6 +713,30 @@ func TestBuilder_ImageVersionPrefersTemplateThenBaseline(t *testing.T) {
 func TestNewBuilder_RejectsCreateMode(t *testing.T) {
 	if _, err := NewBuilder(&config.ImageTemplate{}); err == nil {
 		t.Fatal("expected NewBuilder to reject a non-overlay template")
+	}
+}
+
+func TestOverlayArtifactTypeLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		artifacts []config.ArtifactInfo
+		want      string
+	}{
+		{"no artifacts defaults to RAW", nil, "RAW"},
+		{"empty slice defaults to RAW", []config.ArtifactInfo{}, "RAW"},
+		{"only raw", []config.ArtifactInfo{{Type: "raw"}}, "RAW"},
+		{"single qcow2 uppercased", []config.ArtifactInfo{{Type: "qcow2"}}, "QCOW2"},
+		{"multiple types joined in order", []config.ArtifactInfo{{Type: "qcow2"}, {Type: "raw"}}, "QCOW2, RAW"},
+		{"empty type entries skipped", []config.ArtifactInfo{{Type: ""}, {Type: "vhd"}}, "VHD"},
+		{"all empty type entries default to RAW", []config.ArtifactInfo{{Type: ""}, {Type: ""}}, "RAW"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := &config.ImageTemplate{Disk: config.DiskConfig{Artifacts: tt.artifacts}}
+			if got := overlayArtifactTypeLabel(tmpl); got != tt.want {
+				t.Errorf("overlayArtifactTypeLabel() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Overlay mode always emitted a `raw` artifact regardless of the template's
`disk.artifacts`, so requesting `qcow2` (or `vhd`/`vhdx`/`vmdk`/`vdi`) silently
produced only a `.raw` file — the emit stage hardcoded `<name>-<version>.raw`
and did no format conversion.

This adds a **`Convert Artifacts`** stage to the overlay `Postprocess` that runs
the same `imageconvert.ConvertImageFile` the create-mode `rawmaker` uses, keyed on
the template's `disk.artifacts`. As a result, overlay mode now supports every
output format and compression option that create/build mode does.

Behavior details:

- The stage runs **after** the RAW inspection, because a request that omits `raw`
  deletes the `.raw` file as part of conversion (mirroring create mode).
- It is a **no-op** when `disk.artifacts` is empty or lists only `raw`, so plain
  RAW overlay builds are unchanged.
- Wired behind a test seam (`builderConvertFn`) consistent with the other overlay
  stage seams; a conversion failure surfaces from `Postprocess` and the mount/loop
  cleanup chain still runs exactly once.

#### Any Newly Introduced Dependencies

None. Reuses the existing `internal/image/imageconvert` package (`qemu-img`), which
is already a build-mode dependency.

#### How Has This Been Tested? <!-- REQUIRED -->

- `go build` / `go vet` on the affected packages (`internal/image/overlay`,
  `internal/image/imageconvert`, `internal/provider/...`, `cmd/...`) — clean.
- `go test ./internal/image/overlay/` — passes, including:
  - updated happy-path and inspect-order stage assertions to include the new
    `Convert Artifacts` stage;
  - new `TestBuilder_ConvertFailureFailsPostprocess` verifying a conversion
    failure surfaces and cleanup still runs once.
- Verified end-to-end against a real overlay build (`build --baseline-image ...
  noble-server-cloudimg-amd64-overlay.yml`) whose template declares
  `disk.artifacts: [{ type: qcow2 }]`; the build now emits the `qcow2` artifact.
