### PR TITLE
Build lifecycle control: status, cancellation & guaranteed cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# ignore build artifacts, cache files, and temporary files 
+# ignore build artifacts, cache files, and temporary files
+build/
 downloads/
-builds/  
+builds/
 # Ignore cache directories anywhere (root runtime cache and provider test
 # caches), but keep the internal/cache source package tracked.
 cache/

--- a/api/v1/openapi-template-builder.yaml
+++ b/api/v1/openapi-template-builder.yaml
@@ -268,6 +268,48 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /builds/{buildId}/cancel:
+    post:
+      tags: [Builds]
+      operationId: cancelBuild
+      summary: Cancel a running build
+      description: |
+        Requests cancellation of an in-flight build. The server sends `SIGTERM` to
+        the build's process group so the image-composer-tool child performs its own
+        teardown (unmounting, detaching loop devices) and exits with code 130.
+
+        The call is asynchronous: it returns `202` with status `cancelling`, and the
+        terminal state (`cancelled`, or `failed` if the child exited non-130) is
+        delivered on the SSE log stream's `complete` event.
+
+        If the signal cannot be delivered — most often because the server runs
+        non-root without the scoped `sudo kill` rule — the response is still `202`
+        but carries a `residual` of kind `cancellation-failure`. That is the only
+        prompt notification of the failure, since no terminal event may follow.
+      parameters:
+        - $ref: "#/components/parameters/BuildId"
+      responses:
+        "202":
+          description: Cancellation accepted; the build is now cancelling
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CancelAccepted"
+        "404":
+          description: Build not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: |
+            Build is not cancellable — it already reached a terminal state, or it
+            has no live process on this server (a record that predates a restart).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /builds/{buildId}/logs:
     get:
       tags: [Builds]
@@ -280,7 +322,9 @@ paths:
 
         Event types:
         - `log`: A log line with timestamp and message
-        - `complete`: Build finished (includes pass/fail status and artifacts)
+        - `complete`: Build reached a terminal state (`success`, `failed` or
+          `cancelled`). Carries the artifacts — partial ones on `failed`/`cancelled`
+          — and a `residual` warning if teardown left mounts or loop devices behind.
         - `error`: Build failed with error details
       parameters:
         - $ref: "#/components/parameters/BuildId"
@@ -661,8 +705,7 @@ components:
           type: string
           format: uuid
         status:
-          type: string
-          enum: [running]
+          $ref: "#/components/schemas/BuildStatus"
         startedAt:
           type: string
           format: date-time
@@ -671,14 +714,21 @@ components:
           description: SSE endpoint for streaming logs
           example: /api/v1/builds/abc-123/logs
 
+    BuildStatus:
+      type: string
+      description: |
+        Build lifecycle state. `not-started` is the brief window after the build is
+        accepted but before its process group exists (a cancel is already honoured
+        there). `cancelling` lasts until the child finishes its own teardown.
+      enum: [not-started, running, cancelling, cancelled, success, failed]
+
     BuildDetail:
       type: object
       properties:
         buildId:
           type: string
         status:
-          type: string
-          enum: [running, success, failed]
+          $ref: "#/components/schemas/BuildStatus"
         startedAt:
           type: string
           format: date-time
@@ -688,9 +738,15 @@ components:
         durationSeconds:
           type: integer
         artifacts:
+          description: |
+            Output artifacts. On `failed`/`cancelled` these are the *partial*
+            outputs left on disk, reported with their paths so the user can inspect
+            or delete them.
           type: array
           items:
             $ref: "#/components/schemas/Artifact"
+        residual:
+          $ref: "#/components/schemas/ResidualIssue"
         error:
           type: object
           properties:
@@ -698,6 +754,44 @@ components:
               type: string
             phase:
               type: string
+
+    CancelAccepted:
+      type: object
+      properties:
+        buildId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [cancelling]
+        residual:
+          $ref: "#/components/schemas/ResidualIssue"
+
+    ResidualIssue:
+      type: object
+      description: |
+        Warning that a cancelled or failed build may have left the machine needing
+        manual cleanup. Present on `BuildDetail`, the SSE `complete` event, and a
+        cancel response.
+      properties:
+        kind:
+          type: string
+          description: |
+            - `cancellation-failure` — the cancel signal could not be delivered (or
+              the build never exited), so teardown may never have run.
+            - `cleanup-failure` — the build ran its teardown but reported leftover
+              mounts or loop devices.
+          enum: [cancellation-failure, cleanup-failure]
+        detail:
+          type: string
+          description: |
+            Remediation detail: the failing signal error, or the tool's residual
+            cleanup report including its `mount | grep` / `losetup -l` hint.
+          example: |
+            residual cleanup issues (1):
+            - loop:/dev/loop3: detaching loop device: device or resource busy
+            some resources may still be held; consider running 'mount | grep /var/tmp/ict/builds/abc-123' and 'losetup -l' to identify leftovers
+      required: [kind, detail]
 
     ArtifactList:
       type: object

--- a/cmd/image-composer-tool/serve.go
+++ b/cmd/image-composer-tool/serve.go
@@ -50,8 +50,12 @@ image builds via the image-composer-tool binary with streaming build logs.`,
 			"The second rule lets the (non-root) server cancel a build by signalling the "+
 			"root-owned build process group; without it, cancellation cannot deliver "+
 			"SIGTERM across the sudo boundary. Adjust the kill path (e.g. /bin/kill) to "+
-			"your distro. Security note: this grants the service user a scoped root "+
-			"`kill` — signalling process groups only, TERM only.")
+			"your distro. SECURITY: the pgid isn't known ahead of time, so sudoers "+
+			"cannot scope it — this rule grants the service user root SIGTERM to ANY "+
+			"process group, including `kill -TERM -1` (every process on the host). The "+
+			"signal is limited to TERM. Accept this deliberately, or run the server as "+
+			"root on an isolated build host (no kill rule needed), or omit the rule and "+
+			"accept that Cancel reports a cancellation-failure. See web/README.md.")
 	serveCmd.Flags().StringVar(&serveManifest, "manifest", "",
 		"Path to a manifest YAML to read from disk (live-editable, no rebuild). "+
 			"When empty, the manifest embedded at build time is used.")

--- a/cmd/image-composer-tool/serve.go
+++ b/cmd/image-composer-tool/serve.go
@@ -43,9 +43,15 @@ image builds via the image-composer-tool binary with streaming build logs.`,
 	serveCmd.Flags().StringVar(&serveWorkDir, "work-dir", "webui-workspace", "Base directory for per-build work/output directories")
 	serveCmd.Flags().BoolVar(&serveSudo, "sudo", false,
 		"Run builds under `sudo -n` (ICT requires root for chroot/mount). "+
-			"Grant a scoped, passwordless sudoers rule for the ICT binary only, "+
-			"e.g. `<svc-user> ALL=(root) NOPASSWD: /path/to/image-composer-tool build *` "+
-			"— do not give the service blanket sudo.")
+			"Grant scoped, passwordless sudoers rules for the ICT binary only — do not "+
+			"give the service blanket sudo. Two rules are needed:\n"+
+			"  <svc-user> ALL=(root) NOPASSWD: /path/to/image-composer-tool build *\n"+
+			"  <svc-user> ALL=(root) NOPASSWD: /usr/bin/kill -TERM -[0-9]*\n"+
+			"The second rule lets the (non-root) server cancel a build by signalling the "+
+			"root-owned build process group; without it, cancellation cannot deliver "+
+			"SIGTERM across the sudo boundary. Adjust the kill path (e.g. /bin/kill) to "+
+			"your distro. Security note: this grants the service user a scoped root "+
+			"`kill` — signalling process groups only, TERM only.")
 	serveCmd.Flags().StringVar(&serveManifest, "manifest", "",
 		"Path to a manifest YAML to read from disk (live-editable, no rebuild). "+
 			"When empty, the manifest embedded at build time is used.")

--- a/internal/api/builds.go
+++ b/internal/api/builds.go
@@ -28,6 +28,10 @@ import (
 type buildStatus string
 
 const (
+	// statusNotStarted is the state between accepting the request and the ICT
+	// child actually being spawned (runBuild promotes it to running once
+	// cmd.Start succeeds). A cancel is already accepted in this window; see
+	// setPgidCheckCancel.
 	statusNotStarted buildStatus = "not-started"
 	statusRunning    buildStatus = "running"
 	statusCancelling buildStatus = "cancelling"
@@ -35,6 +39,13 @@ const (
 	statusSuccess    buildStatus = "success" // surfaced as "completed" in the UI
 	statusFailed     buildStatus = "failed"
 )
+
+// isTerminal reports whether a status is final, i.e. no further transition can
+// happen. Used to make terminal recording single-shot: both the wait path and
+// the cancel watchdog can reach a build, and the first one to classify it wins.
+func isTerminal(s buildStatus) bool {
+	return s == statusSuccess || s == statusFailed || s == statusCancelled
+}
 
 // artifact describes one output file (image or SBOM).
 type artifact struct {
@@ -60,6 +71,8 @@ type build struct {
 	CreatedAt    time.Time       // when the compose was started
 	LogFile      string          // on-disk log file path, written at finish
 	done         chan struct{}   // closed when the build finishes
+
+	doneOnce sync.Once // guards close(done): both runBuild and the cancel watchdog can finish a build
 
 	mu        sync.Mutex
 	status    buildStatus
@@ -172,15 +185,17 @@ func (b *build) snapshotLogs() []string {
 	return out
 }
 
-// beginCancel marks the build as cancel-requested and transitions running →
-// cancelling. It reports whether the transition happened (false if the build is
-// not currently running — already terminal or already cancelling) and returns
-// the process-group id to signal. Idempotent: a second cancel on an
-// already-cancelling build returns cancelling=false so the handler can 409.
+// beginCancel marks the build as cancel-requested and transitions
+// not-started/running → cancelling. It reports whether the transition happened
+// (false if the build is already terminal or already cancelling) and returns the
+// process-group id to signal — 0 when the child hasn't been spawned yet, in
+// which case runBuild delivers the signal as soon as it has a group (see
+// setPgidCheckCancel). Idempotent: a second cancel on an already-cancelling
+// build returns transitioned=false so the handler can 409.
 func (b *build) beginCancel() (transitioned bool, pgid int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.status != statusRunning {
+	if b.status != statusRunning && b.status != statusNotStarted {
 		return false, b.pgid
 	}
 	b.cancelRequested = true
@@ -188,19 +203,38 @@ func (b *build) beginCancel() (transitioned bool, pgid int) {
 	return true, b.pgid
 }
 
-// setPgidCheckCancel records the running child's process-group id and reports,
-// atomically under the same lock, whether a cancel was already requested while
-// pgid was still unset (the start-race window). When pending is true the caller
-// must deliver the cancel signal now, since the earlier handleCancelBuild call
-// transitioned to cancelling but had no group to signal. Returns the recorded
-// pgid so the caller can signal without re-taking the lock.
+// setPgidCheckCancel records the running child's process-group id, promotes
+// not-started → running, and reports — atomically under the same lock — whether
+// a cancel was already requested while pgid was still unset (the start-race
+// window). When pending is true the caller must deliver the cancel signal now,
+// since the earlier handleCancelBuild call transitioned to cancelling but had no
+// group to signal. Returns the recorded pgid so the caller can signal without
+// re-taking the lock.
 func (b *build) setPgidCheckCancel(pgid int) (recorded int, pending bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.pgid = pgid
+	if b.status == statusNotStarted {
+		b.status = statusRunning
+	}
 	// A cancel is pending for us to service only if one was requested and the
 	// build is still in the cancelling state (not already terminal).
 	return pgid, b.cancelRequested && b.status == statusCancelling
+}
+
+// currentPgid returns the recorded process-group id under lock (0 before the
+// child is spawned). Used by the cancel watchdog, which may re-signal after the
+// start race has resolved.
+func (b *build) currentPgid() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.pgid
+}
+
+// closeDone closes the done channel exactly once. Both runBuild's wait path and
+// the cancel watchdog can conclude a build, so the close is guarded.
+func (b *build) closeDone() {
+	b.doneOnce.Do(func() { close(b.done) })
 }
 
 // wasCancelRequested reports whether a user cancel was issued for this build.
@@ -296,8 +330,11 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 
 	name, cmdArgs := s.buildCommand(templatePath, workDir, cacheDir)
 	b := &build{
-		ID:           id,
-		status:       statusRunning,
+		ID: id,
+		// not-started until runBuild's cmd.Start succeeds and records the process
+		// group (setPgidCheckCancel promotes it to running). A cancel arriving in
+		// that window is still accepted and serviced once there's a group to signal.
+		status:       statusNotStarted,
 		RootDir:      buildRoot,
 		WorkDir:      workDir,
 		CacheDir:     cacheDir,
@@ -311,16 +348,19 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 	s.tracker.add(b)
 
 	// Persist the initial record so the build shows in history immediately (and
-	// survives a restart mid-build as a stale "running" entry).
+	// survives a restart mid-build as a stale in-flight entry).
 	if err := b.writeMeta(); err != nil {
 		logger.Logger().Warnf("build %s: writing initial meta: %v", id, err)
 	}
 
 	go s.runBuild(b, name, cmdArgs)
 
+	// Report the build's actual status rather than a hardcoded "running": the
+	// child may not be spawned yet, and a client that echoed "running" here would
+	// contradict what GET /builds returns a moment later.
 	writeJSON(w, http.StatusAccepted, buildAccepted{
 		BuildID: id,
-		Status:  string(statusRunning),
+		Status:  string(b.snapshot().status),
 		LogsURL: fmt.Sprintf("/api/v1/builds/%s/logs", id),
 	})
 }
@@ -328,9 +368,15 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 // cancelAccepted is the response to a successful cancel request. The build is
 // now cancelling; the terminal state (cancelled/failed) arrives later over SSE
 // once the ICT child has torn down and exited.
+//
+// Residual is set when the cancel was accepted but the signal could not be
+// delivered (cancellation-failure). The build is still reported as cancelling —
+// the watchdog will conclude it — but the caller gets the remediation detail
+// immediately rather than waiting for a terminal SSE event that may never come.
 type cancelAccepted struct {
-	BuildID string `json:"buildId"`
-	Status  string `json:"status"`
+	BuildID  string         `json:"buildId"`
+	Status   string         `json:"status"`
+	Residual *residualIssue `json:"residual,omitempty"`
 }
 
 // handleCancelBuild transitions a running build to cancelling and signals the
@@ -341,8 +387,20 @@ type cancelAccepted struct {
 // wait path, not here: this handler only requests the cancel and returns 202.
 func (s *Server) handleCancelBuild(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	b, ok := s.getBuild(id)
-	if !ok {
+	// Only a live, in-process build can be cancelled. getBuild would happily
+	// reconstruct a record from meta.json, but that copy has no process group and
+	// no runBuild goroutine behind it: cancelling it would mutate a throwaway
+	// struct and report a bogus 202. A build persisted as running whose server has
+	// since restarted falls in here — its ICT process (if any) is orphaned and
+	// must be dealt with on the host.
+	b, live := s.tracker.get(id)
+	if !live {
+		if _, onDisk := s.getBuild(id); onDisk {
+			writeError(w, http.StatusConflict, "NOT_CANCELLABLE",
+				"build has no live process on this server (it predates a restart); "+
+					"check the host for an orphaned build process")
+			return
+		}
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "build not found")
 		return
 	}
@@ -357,22 +415,104 @@ func (s *Server) handleCancelBuild(w http.ResponseWriter, r *http.Request) {
 	}
 	b.appendLog("• cancel requested — signalling build to stop and clean up")
 
-	if err := s.signalCancel(pgid); err != nil {
-		// The signal never reached the process group, so ICT may never start its
-		// teardown. Record a cancellation-failure with the underlying error so the
-		// UI can tell the user the kill itself failed (distinct from ICT running
-		// but leaving residue). The build stays in cancelling; if the child exits
-		// on its own the wait path still classifies it, otherwise it will hang as
-		// cancelling — which correctly reflects that we lost control of it.
-		detail := fmt.Sprintf("failed to signal build process group %d: %v", pgid, err)
-		b.setResidual(residualCancellation, detail)
-		b.appendLog("ERROR " + detail)
-		logger.Logger().Errorf("build %s: %s", id, detail)
-		writeJSON(w, http.StatusAccepted, cancelAccepted{BuildID: id, Status: string(statusCancelling)})
-		return
+	// pgid 0 means cmd.Start hasn't recorded the group yet; runBuild delivers the
+	// signal itself as soon as it can (setPgidCheckCancel reports it as pending),
+	// so don't treat that as a delivery failure here.
+	if pgid > 0 {
+		if err := s.signalCancel(pgid); err != nil {
+			// The signal never reached the process group, so ICT may never start its
+			// teardown. Record a cancellation-failure with the underlying error so the
+			// UI can tell the user the kill itself failed (distinct from ICT running
+			// but leaving residue), and return it in the response body — the build
+			// stays in cancelling, so a terminal SSE event may never arrive.
+			detail := fmt.Sprintf("failed to signal build process group %d: %v", pgid, err)
+			b.setResidual(residualCancellation, detail)
+			b.appendLog("ERROR " + detail)
+			logger.Logger().Errorf("build %s: %s", id, detail)
+			s.watchCancel(b) // still bound the cancelling state
+			writeJSON(w, http.StatusAccepted, cancelAccepted{
+				BuildID:  id,
+				Status:   string(statusCancelling),
+				Residual: &residualIssue{Kind: residualCancellation, Detail: detail},
+			})
+			return
+		}
 	}
 
+	// Bound the cancelling state: re-send TERM after a grace period and, past the
+	// hard deadline, conclude the build so the single-build slot is freed.
+	s.watchCancel(b)
+
 	writeJSON(w, http.StatusAccepted, cancelAccepted{BuildID: id, Status: string(statusCancelling)})
+}
+
+// Cancel watchdog timings. A cooperative ICT teardown (unmounting a chroot,
+// detaching loop devices) can legitimately take a while, so the grace period is
+// generous; the hard deadline exists only so a wedged build cannot hold the
+// single-build slot — and thus the whole compose feature — hostage until the
+// server restarts.
+const (
+	cancelGracePeriod = 2 * time.Minute
+	cancelHardDeadman = 5 * time.Minute
+)
+
+// watchCancel bounds the cancelling state for a build that has been signalled.
+//
+// It waits for the child to exit on its own (runBuild closes b.done). If the
+// grace period passes it re-sends SIGTERM once — the first signal can be missed
+// if it landed while the group was still being set up. If the hard deadline
+// passes it records a cancellation-failure, marks the build cancelled, and
+// releases the single-build slot so composing still works.
+//
+// We deliberately do not escalate to SIGKILL: killing ICT mid-teardown skips the
+// cleanup this whole feature exists to guarantee, and would need a wider root
+// `kill` grant. A build that ignores TERM is reported to the user as residue to
+// remediate by hand, which is the honest outcome.
+func (s *Server) watchCancel(b *build) {
+	go func() {
+		log := logger.Logger()
+		select {
+		case <-b.done:
+			return // exited within the grace period — the wait path classified it
+		case <-time.After(cancelGracePeriod):
+		}
+
+		if pgid := b.currentPgid(); pgid > 0 {
+			b.appendLog(fmt.Sprintf("• still cancelling after %s — re-sending SIGTERM", cancelGracePeriod))
+			if err := s.signalCancel(pgid); err != nil {
+				log.Warnf("build %s: re-signalling process group %d: %v", b.ID, pgid, err)
+			}
+		}
+
+		select {
+		case <-b.done:
+			return
+		case <-time.After(cancelHardDeadman - cancelGracePeriod):
+		}
+
+		s.concludeStalledCancel(b)
+	}()
+}
+
+// concludeStalledCancel records the terminal state for a build that never exited
+// after being cancelled. The build is marked cancelled with a
+// cancellation-failure residual (its process group may still hold mounts or loop
+// devices), the single-build slot is released so composing keeps working, and
+// b.done is closed to wake anything waiting on it.
+//
+// finish is single-shot, so if the child exited between the deadline expiring and
+// this call, the wait path's classification stands and we touch nothing else.
+func (s *Server) concludeStalledCancel(b *build) {
+	detail := fmt.Sprintf(
+		"build did not exit within %s of the cancel request; its process group (%d) may still be "+
+			"running with mounts or loop devices held", cancelHardDeadman, b.currentPgid())
+	b.setResidual(residualCancellation, detail)
+	b.appendLog("ERROR " + detail)
+	logger.Logger().Errorf("build %s: %s", b.ID, detail)
+	if b.finish(statusCancelled, discoverArtifacts(b.WorkDir), detail) {
+		s.releaseBuildSlot(b.ID)
+		b.closeDone()
+	}
 }
 
 // signalCancel delivers SIGTERM to the build's process group (negative pid).
@@ -463,11 +603,11 @@ func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 	// happens after cmd.Wait() observes the ICT child fully exit (post-teardown),
 	// or after a failed cmd.Start where no child was spawned. Either way the next
 	// compose can't start while mounts/loop devices may still be tearing down.
-	// Ordered to run after close(b.done) fires (defers run LIFO), so a waiter that
+	// Ordered to run after b.done is closed (defers run LIFO), so a waiter that
 	// unblocks on b.done and immediately re-POSTs still sees the slot as taken
 	// until this returns.
 	defer s.releaseBuildSlot(b.ID)
-	defer close(b.done)
+	defer b.closeDone()
 
 	// ICT builds require root (chroot, mounts), so the build runs under sudo, and
 	// from the repo root since ICT resolves config/osv/... relative to cwd. The
@@ -587,8 +727,17 @@ func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 // persists the buffered logs to a file (so past builds can offer a log download
 // without keeping logs in memory), then writes meta.json so the compose history
 // reflects the final outcome across restarts.
-func (b *build) finish(status buildStatus, arts []artifact, errMsg string) {
+//
+// It reports whether it recorded the terminal state. Recording is single-shot:
+// both runBuild's wait path and the cancel watchdog can conclude a build, and
+// whichever gets there first owns the outcome — so the watchdog can't relabel a
+// build that exited cleanly a moment earlier.
+func (b *build) finish(status buildStatus, arts []artifact, errMsg string) bool {
 	b.mu.Lock()
+	if isTerminal(b.status) {
+		b.mu.Unlock()
+		return false
+	}
 	b.status = status
 	b.artifacts = arts
 	b.errMsg = errMsg
@@ -610,6 +759,7 @@ func (b *build) finish(status buildStatus, arts []artifact, errMsg string) {
 	if err := b.writeMeta(); err != nil {
 		logger.Logger().Warnf("build %s: writing final meta: %v", b.ID, err)
 	}
+	return true
 }
 
 // exitCode returns the process exit code carried by a cmd.Wait error, or -1 if
@@ -651,25 +801,48 @@ func classifyExit(waitErr error, cancelRequested bool) buildStatus {
 	return statusFailed
 }
 
-// scanResidualCleanup looks for ICT's residual-cleanup ERROR lines — logged when
-// its teardown couldn't remove all mounts/loop devices, with a `mount | grep` /
-// `losetup -l` remediation hint. It returns the joined matching lines (trimmed of
-// the logger prefix) as the remediation detail, or "" if teardown was clean.
+// residualHeader is the marker ICT logs (at ERROR) when its backstop cleanup
+// couldn't release every resource. It is followed by one indented "  - <label>:
+// <error>" item per leftover resource, then a WARN line carrying the
+// `mount | grep` / `losetup -l` remediation hint. See the residual report in
+// cmd/image-composer-tool/build.go's backstop-cleanup defer.
+const residualHeader = "residual cleanup issues"
+
+// scanResidualCleanup extracts ICT's residual-cleanup report from a build's log
+// buffer. It returns the per-resource items (and the remediation hint that
+// follows them) with logger prefixes stripped, or "" when teardown was clean.
+//
+// The report is parsed as a block anchored on residualHeader rather than by
+// keyword-matching individual lines: the item labels are "chroot:<root>" and
+// "loop:<dev>" (see runctx registrations), so a leftover *mount* item carries no
+// keyword a line-by-line filter could latch onto, and the hint line is logged at
+// WARN so it wouldn't pass an ERROR gate either.
 func scanResidualCleanup(logs []string) string {
 	var hits []string
+	inReport := false
 	for _, line := range logs {
-		low := strings.ToLower(line)
-		if !strings.Contains(low, "error") {
+		msg := strings.TrimRight(stripLogPrefix(line), " \t")
+		if !inReport {
+			if strings.Contains(strings.ToLower(msg), residualHeader) {
+				inReport = true
+				// Keep the header itself: it carries the count, and it guarantees a
+				// non-empty detail even if the items never made it into the buffer.
+				hits = append(hits, strings.TrimSpace(msg))
+			}
 			continue
 		}
-		// Match the residual-cleanup signature: an error line that mentions leftover
-		// mounts / loop devices or the remediation commands ICT prints.
-		if strings.Contains(low, "losetup") ||
-			strings.Contains(low, "mount | grep") ||
-			strings.Contains(low, "leftover") ||
-			strings.Contains(low, "residual") ||
-			(strings.Contains(low, "loop") && strings.Contains(low, "device")) {
-			hits = append(hits, strings.TrimSpace(stripLogPrefix(line)))
+		// Inside the report: collect the indented "  - label: err" items, then the
+		// remediation hint that closes it. Anything else ends the block (the report
+		// is contiguous, so an unrelated line means ICT has moved on).
+		trimmed := strings.TrimSpace(msg)
+		switch {
+		case strings.HasPrefix(trimmed, "- "):
+			hits = append(hits, trimmed)
+		case strings.Contains(trimmed, "mount | grep") || strings.Contains(trimmed, "losetup -l"):
+			hits = append(hits, trimmed)
+			inReport = false
+		default:
+			inReport = false
 		}
 	}
 	return strings.Join(hits, "\n")

--- a/internal/api/builds.go
+++ b/internal/api/builds.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -27,9 +28,12 @@ import (
 type buildStatus string
 
 const (
-	statusRunning buildStatus = "running"
-	statusSuccess buildStatus = "success"
-	statusFailed  buildStatus = "failed"
+	statusNotStarted buildStatus = "not-started"
+	statusRunning    buildStatus = "running"
+	statusCancelling buildStatus = "cancelling"
+	statusCancelled  buildStatus = "cancelled"
+	statusSuccess    buildStatus = "success" // surfaced as "completed" in the UI
+	statusFailed     buildStatus = "failed"
 )
 
 // artifact describes one output file (image or SBOM).
@@ -62,6 +66,40 @@ type build struct {
 	logLines  []string // buffered log history for late log subscribers
 	artifacts []artifact
 	errMsg    string
+	// pgid is the process-group id of the running ICT build (0 until started).
+	// The build is spawned as its own group leader, so a cancel can signal the
+	// whole child tree (sudo → ICT → its helpers) rather than only the immediate
+	// child.
+	pgid int
+	// cancelRequested records that a user cancel was issued, so the terminal
+	// classification can prefer "cancelled" over a bare failure.
+	cancelRequested bool
+	// residual, when non-nil, describes teardown trouble that left the machine in
+	// a state a user may need to fix by hand: either the cancel signal itself
+	// failed (cancellation-failure) or ICT reported leftover mounts/loop devices
+	// during its own cleanup (cleanup-failure). Surfaced to the API/UI.
+	residual *residualIssue
+}
+
+// residualKind classifies why teardown may have left residue.
+type residualKind string
+
+const (
+	// residualCancellation: the cancel signal could not be delivered (e.g. the
+	// `sudo -n kill` call failed), so ICT may never have started its teardown.
+	residualCancellation residualKind = "cancellation-failure"
+	// residualCleanup: ICT ran but reported leftover mounts/loop devices at ERROR
+	// (with a `mount | grep` / `losetup -l` hint) — its own cleanup didn't fully
+	// succeed.
+	residualCleanup residualKind = "cleanup-failure"
+)
+
+// residualIssue carries enough detail for a user to remediate leftover state
+// manually. Detail holds the specific hint (the failing kill error, or the
+// mount/loop lines ICT logged).
+type residualIssue struct {
+	Kind   residualKind `json:"kind"`
+	Detail string       `json:"detail"`
 }
 
 // result is an immutable snapshot of a build's terminal state.
@@ -70,6 +108,7 @@ type result struct {
 	artifacts []artifact
 	errMsg    string
 	logFile   string
+	residual  *residualIssue
 }
 
 // snapshot returns the build's current status, artifacts, error, and log-file
@@ -81,7 +120,7 @@ func (b *build) snapshot() result {
 	defer b.mu.Unlock()
 	arts := make([]artifact, len(b.artifacts))
 	copy(arts, b.artifacts)
-	return result{status: b.status, artifacts: arts, errMsg: b.errMsg, logFile: b.LogFile}
+	return result{status: b.status, artifacts: arts, errMsg: b.errMsg, logFile: b.LogFile, residual: b.residual}
 }
 
 // buildTracker holds all builds for the process lifetime.
@@ -133,6 +172,41 @@ func (b *build) snapshotLogs() []string {
 	return out
 }
 
+// beginCancel marks the build as cancel-requested and transitions running →
+// cancelling. It reports whether the transition happened (false if the build is
+// not currently running — already terminal or already cancelling) and returns
+// the process-group id to signal. Idempotent: a second cancel on an
+// already-cancelling build returns cancelling=false so the handler can 409.
+func (b *build) beginCancel() (transitioned bool, pgid int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.status != statusRunning {
+		return false, b.pgid
+	}
+	b.cancelRequested = true
+	b.status = statusCancelling
+	return true, b.pgid
+}
+
+// wasCancelRequested reports whether a user cancel was issued for this build.
+func (b *build) wasCancelRequested() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.cancelRequested
+}
+
+// setResidual records a teardown-residue issue (cancellation-failure or
+// cleanup-failure) so the terminal snapshot can surface it to the UI. The first
+// issue recorded wins: a failed cancel signal (cancellation-failure) is the root
+// cause and shouldn't be overwritten by a later cleanup observation.
+func (b *build) setResidual(kind residualKind, detail string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.residual == nil {
+		b.residual = &residualIssue{Kind: kind, Detail: detail}
+	}
+}
+
 // --- request/response bodies ---
 
 type buildRequest struct {
@@ -157,6 +231,18 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := uuid.NewString()
+
+	// Claim the single-build slot before doing any setup. If a build is already
+	// in flight (including one still tearing down mounts/loops after a cancel or
+	// failure), reject with 409 so a second compose can't race the teardown. The
+	// slot is released by runBuild only after the ICT child fully exits; on the
+	// error paths below we release it explicitly since no child was spawned.
+	if ok, activeID := s.tryAcquireBuildSlot(id); !ok {
+		writeError(w, http.StatusConflict, "BUILD_IN_PROGRESS",
+			fmt.Sprintf("a build is already in progress (%s); only one compose runs at a time", activeID))
+		return
+	}
+
 	buildRoot := filepath.Join(s.cfg.WorkDir, "builds", id)
 	workDir := filepath.Join(buildRoot, "work")
 	cacheDir := filepath.Join(buildRoot, "cache")
@@ -164,6 +250,7 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 	// 0700: build logs and artifact metadata may be sensitive; keep them private.
 	for _, d := range []string{workDir, cacheDir} {
 		if err := os.MkdirAll(d, 0o700); err != nil {
+			s.releaseBuildSlot(id) // no child spawned; free the slot for the next start
 			writeError(w, http.StatusInternalServerError, "WORKDIR", "cannot create build work directory")
 			return
 		}
@@ -173,6 +260,7 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 	// return 400; server errors (e.g. writing the inline template) return 500.
 	templatePath, templateName, err := s.resolveBuildTemplate(&req, workDir)
 	if err != nil {
+		s.releaseBuildSlot(id) // no child spawned; free the slot for the next start
 		if errors.Is(err, errBadBuildRequest) {
 			writeError(w, http.StatusBadRequest, "NO_MATCH", err.Error())
 		} else {
@@ -220,6 +308,83 @@ func (s *Server) handleStartBuild(w http.ResponseWriter, r *http.Request) {
 		Status:  string(statusRunning),
 		LogsURL: fmt.Sprintf("/api/v1/builds/%s/logs", id),
 	})
+}
+
+// cancelAccepted is the response to a successful cancel request. The build is
+// now cancelling; the terminal state (cancelled/failed) arrives later over SSE
+// once the ICT child has torn down and exited.
+type cancelAccepted struct {
+	BuildID string `json:"buildId"`
+	Status  string `json:"status"`
+}
+
+// handleCancelBuild transitions a running build to cancelling and signals the
+// ICT process group with SIGTERM, letting ICT perform its own teardown (mounts,
+// loop devices) and exit. We do not reimplement a mount/loop reconciler here.
+//
+// Terminal classification and the single-build slot release happen on runBuild's
+// wait path, not here: this handler only requests the cancel and returns 202.
+func (s *Server) handleCancelBuild(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	b, ok := s.getBuild(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "build not found")
+		return
+	}
+
+	transitioned, pgid := b.beginCancel()
+	if !transitioned {
+		// Already terminal, or a cancel is already in flight. 409 so the caller
+		// knows the request didn't change anything.
+		writeError(w, http.StatusConflict, "NOT_CANCELLABLE",
+			"build is not running (already finished or cancelling)")
+		return
+	}
+	b.appendLog("• cancel requested — signalling build to stop and clean up")
+
+	if err := s.signalCancel(pgid); err != nil {
+		// The signal never reached the process group, so ICT may never start its
+		// teardown. Record a cancellation-failure with the underlying error so the
+		// UI can tell the user the kill itself failed (distinct from ICT running
+		// but leaving residue). The build stays in cancelling; if the child exits
+		// on its own the wait path still classifies it, otherwise it will hang as
+		// cancelling — which correctly reflects that we lost control of it.
+		detail := fmt.Sprintf("failed to signal build process group %d: %v", pgid, err)
+		b.setResidual(residualCancellation, detail)
+		b.appendLog("ERROR " + detail)
+		logger.Logger().Errorf("build %s: %s", id, detail)
+		writeJSON(w, http.StatusAccepted, cancelAccepted{BuildID: id, Status: string(statusCancelling)})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, cancelAccepted{BuildID: id, Status: string(statusCancelling)})
+}
+
+// signalCancel delivers SIGTERM to the build's process group (negative pid).
+// The child is its own group leader (Setpgid at spawn), so -pgid reaches the
+// whole tree (sudo → ICT → helpers), giving ICT the chance to tear down mounts
+// and loop devices before exiting.
+//
+// Cross-sudo caveat: the server runs non-root and the build runs under `sudo`,
+// so the process group is root-owned. A non-root process can't signal it, so
+// under --sudo we deliver the signal as root via `sudo -n kill`. This requires a
+// scoped sudoers rule for the kill (see serve.go's --sudo help). Without --sudo
+// (dev/root), we signal the group directly.
+func (s *Server) signalCancel(pgid int) error {
+	if pgid <= 0 {
+		return fmt.Errorf("no process group recorded for build")
+	}
+	if s.cfg.Sudo {
+		// `kill -TERM -<pgid>`: the leading `-` on the pid makes kill target the
+		// process group. -n never prompts; a missing sudoers rule fails fast.
+		out, err := exec.Command("sudo", "-n", "kill", "-TERM", fmt.Sprintf("-%d", pgid)).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+	// Direct group signal (dev/root): negative pid = process group.
+	return syscall.Kill(-pgid, syscall.SIGTERM)
 }
 
 // errBadBuildRequest marks resolution failures caused by client input (bad
@@ -279,6 +444,14 @@ func (s *Server) buildCommand(templatePath, workDir, cacheDir string) (name stri
 // buffer, and records the terminal status + artifacts.
 func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 	log := logger.Logger()
+	// Release the single-build slot only once this function returns — which
+	// happens after cmd.Wait() observes the ICT child fully exit (post-teardown),
+	// or after a failed cmd.Start where no child was spawned. Either way the next
+	// compose can't start while mounts/loop devices may still be tearing down.
+	// Ordered to run after close(b.done) fires (defers run LIFO), so a waiter that
+	// unblocks on b.done and immediately re-POSTs still sees the slot as taken
+	// until this returns.
+	defer s.releaseBuildSlot(b.ID)
 	defer close(b.done)
 
 	// ICT builds require root (chroot, mounts), so the build runs under sudo, and
@@ -292,6 +465,10 @@ func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 	b.appendLog("$ " + b.Command)
 
 	cmd := exec.Command(name, cmdArgs...)
+	// Run the build in its own process group so a later cancel can signal the
+	// whole child tree (sudo → ICT → helpers) with a single kill to -pgid, not
+	// just the immediate child.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Merge stdout+stderr into a single stream via one pipe writer shared by both
 	// fds. os/exec guards concurrent writes to the same *os.File writer with a
@@ -310,6 +487,12 @@ func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 		_ = pr.Close()
 		return
 	}
+	// Record the process-group id now that the child is running. With Setpgid the
+	// child is its own group leader, so the group id equals its pid. A cancel
+	// signals -pgid to reach the whole tree.
+	b.mu.Lock()
+	b.pgid = cmd.Process.Pid
+	b.mu.Unlock()
 	// Wait for the process in a goroutine and close the pipe writer when it
 	// exits, so the scanner below sees EOF. The exit error is delivered on
 	// waitCh (cmd.Wait is called exactly once, here).
@@ -335,8 +518,24 @@ func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 
 	waitErr := <-waitCh
 	if waitErr != nil {
-		log.Warnf("build %s failed: %v", b.ID, waitErr)
-		b.finish(statusFailed, nil, waitErr.Error())
+		// Classify the terminal state. A cancel was requested → the child was
+		// signalled, so map the signal-terminated / signal-code exits to cancelled;
+		// otherwise a non-zero exit is a genuine build failure. We gate on
+		// cancelRequested (not the code alone) because we wait on `sudo`, not ICT
+		// directly, and sudo doesn't always translate the child's exit cleanly.
+		status := classifyExit(waitErr, b.wasCancelRequested())
+		log.Warnf("build %s ended (%s): %v", b.ID, status, waitErr)
+		// If ICT ran its own teardown but reported leftover mounts/loop devices,
+		// surface that as a cleanup-failure so the UI can point the user at manual
+		// remediation. (A cancellation-failure — the signal itself failing — is
+		// recorded earlier, in the cancel handler, and takes precedence.)
+		if detail := scanResidualCleanup(b.snapshotLogs()); detail != "" {
+			b.setResidual(residualCleanup, detail)
+		}
+		// Surface any partial outputs left on disk so the UI can point at their
+		// location on a failed or cancelled compose.
+		partial := discoverArtifacts(b.WorkDir)
+		b.finish(status, partial, waitErr.Error())
 		return
 	}
 	if scanErr != nil {
@@ -382,6 +581,79 @@ func (b *build) finish(status buildStatus, arts []artifact, errMsg string) {
 	if err := b.writeMeta(); err != nil {
 		logger.Logger().Warnf("build %s: writing final meta: %v", b.ID, err)
 	}
+}
+
+// exitCode returns the process exit code carried by a cmd.Wait error, or -1 if
+// the error is not an *exec.ExitError (e.g. the process was never started).
+func exitCode(err error) int {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
+}
+
+// classifyExit maps a non-nil cmd.Wait error to a terminal status. When a cancel
+// was requested, an exit consistent with signal termination is treated as
+// cancelled; otherwise every non-zero exit is a failure.
+//
+// We watch a set of codes rather than only 130 because we wait on `sudo`, not
+// ICT directly: ICT's own SIGINT handler exits 130, but if it (or sudo) is
+// terminated by the signal instead we see 143 (128+SIGTERM) or 137 (128+SIGKILL),
+// and a signal-terminated child reports via WaitStatus.Signaled() with no code
+// at all. Any of these, under a requested cancel, is a clean cancellation.
+func classifyExit(waitErr error, cancelRequested bool) buildStatus {
+	if !cancelRequested {
+		return statusFailed
+	}
+	switch exitCode(waitErr) {
+	case 130, 143, 137: // 128 + SIGINT / SIGTERM / SIGKILL
+		return statusCancelled
+	}
+	// A child killed by a signal (not exiting with a code) surfaces as Signaled().
+	var ee *exec.ExitError
+	if errors.As(waitErr, &ee) {
+		if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			return statusCancelled
+		}
+	}
+	// Cancel was requested but the child failed for an unrelated reason before the
+	// signal took effect — report the real failure.
+	return statusFailed
+}
+
+// scanResidualCleanup looks for ICT's residual-cleanup ERROR lines — logged when
+// its teardown couldn't remove all mounts/loop devices, with a `mount | grep` /
+// `losetup -l` remediation hint. It returns the joined matching lines (trimmed of
+// the logger prefix) as the remediation detail, or "" if teardown was clean.
+func scanResidualCleanup(logs []string) string {
+	var hits []string
+	for _, line := range logs {
+		low := strings.ToLower(line)
+		if !strings.Contains(low, "error") {
+			continue
+		}
+		// Match the residual-cleanup signature: an error line that mentions leftover
+		// mounts / loop devices or the remediation commands ICT prints.
+		if strings.Contains(low, "losetup") ||
+			strings.Contains(low, "mount | grep") ||
+			strings.Contains(low, "leftover") ||
+			strings.Contains(low, "residual") ||
+			(strings.Contains(low, "loop") && strings.Contains(low, "device")) {
+			hits = append(hits, strings.TrimSpace(stripLogPrefix(line)))
+		}
+	}
+	return strings.Join(hits, "\n")
+}
+
+// stripLogPrefix trims the logger's leading "<ts>\t<LEVEL>\t<source>\t" fields
+// from a log line, leaving the message. Falls back to the whole line when the
+// line isn't tab-formatted.
+func stripLogPrefix(line string) string {
+	if i := strings.LastIndex(line, "\t"); i >= 0 {
+		return line[i+1:]
+	}
+	return line
 }
 
 // parseArtifacts extracts the artifact list from ICT's build output. ICT prints

--- a/internal/api/builds.go
+++ b/internal/api/builds.go
@@ -188,6 +188,21 @@ func (b *build) beginCancel() (transitioned bool, pgid int) {
 	return true, b.pgid
 }
 
+// setPgidCheckCancel records the running child's process-group id and reports,
+// atomically under the same lock, whether a cancel was already requested while
+// pgid was still unset (the start-race window). When pending is true the caller
+// must deliver the cancel signal now, since the earlier handleCancelBuild call
+// transitioned to cancelling but had no group to signal. Returns the recorded
+// pgid so the caller can signal without re-taking the lock.
+func (b *build) setPgidCheckCancel(pgid int) (recorded int, pending bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.pgid = pgid
+	// A cancel is pending for us to service only if one was requested and the
+	// build is still in the cancelling state (not already terminal).
+	return pgid, b.cancelRequested && b.status == statusCancelling
+}
+
 // wasCancelRequested reports whether a user cancel was issued for this build.
 func (b *build) wasCancelRequested() bool {
 	b.mu.Lock()
@@ -490,9 +505,23 @@ func (s *Server) runBuild(b *build, name string, cmdArgs []string) {
 	// Record the process-group id now that the child is running. With Setpgid the
 	// child is its own group leader, so the group id equals its pid. A cancel
 	// signals -pgid to reach the whole tree.
-	b.mu.Lock()
-	b.pgid = cmd.Process.Pid
-	b.mu.Unlock()
+	//
+	// A cancel can arrive in the window between the build being tracked as running
+	// (in handleStartBuild) and this point, when pgid was still 0. beginCancel
+	// would have transitioned to cancelling but signalCancel(0) could not signal
+	// anything. setPgidCheckCancel records the pgid and, atomically under b.mu,
+	// reports whether such an early cancel is pending so we can deliver the signal
+	// now that we finally have a group to target.
+	if pgid, pending := b.setPgidCheckCancel(cmd.Process.Pid); pending {
+		if err := s.signalCancel(pgid); err != nil {
+			detail := fmt.Sprintf("failed to signal build process group %d: %v", pgid, err)
+			b.setResidual(residualCancellation, detail)
+			b.appendLog("ERROR " + detail)
+			log.Errorf("build %s: %s", b.ID, detail)
+		} else {
+			b.appendLog("• cancel requested before start completed — signalling now")
+		}
+	}
 	// Wait for the process in a goroutine and close the pipe writer when it
 	// exits, so the scanner below sees EOF. The exit error is delivered on
 	// waitCh (cmd.Wait is called exactly once, here).
@@ -647,11 +676,14 @@ func scanResidualCleanup(logs []string) string {
 }
 
 // stripLogPrefix trims the logger's leading "<ts>\t<LEVEL>\t<source>\t" fields
-// from a log line, leaving the message. Falls back to the whole line when the
-// line isn't tab-formatted.
+// from a log line, leaving the message. The prefix is exactly three tab-
+// separated fields, so we split off the first three and keep the remainder
+// verbatim — including any tabs inside the message itself (LastIndex would drop
+// everything up to the message's own last tab). Falls back to the whole line
+// when the line has fewer than three tabs (not logger-formatted).
 func stripLogPrefix(line string) string {
-	if i := strings.LastIndex(line, "\t"); i >= 0 {
-		return line[i+1:]
+	if parts := strings.SplitN(line, "\t", 4); len(parts) == 4 {
+		return parts[3]
 	}
 	return line
 }

--- a/internal/api/builds_cancel_test.go
+++ b/internal/api/builds_cancel_test.go
@@ -4,9 +4,12 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -62,10 +65,15 @@ func TestClassifyExit(t *testing.T) {
 
 // --- residual-cleanup log scanning ---
 
+// The lines below mirror what ICT actually logs from the backstop-cleanup defer
+// in cmd/image-composer-tool/build.go: an ERROR header with the count, one
+// indented "  - <label>: <err>" item per leftover resource (labels come from the
+// runctx registrations — "chroot:<root>" and "loop:<dev>"), then a WARN hint.
+// The parser is anchored on that shape, so the fixture must keep it.
 func TestScanResidualCleanup(t *testing.T) {
 	clean := []string{
 		"2026-07-24\tINFO\tbuild.go:1\tstarting build",
-		"2026-07-24\tINFO\tbuild.go:2\tunmounting cleanly",
+		"2026-07-24\tINFO\tbuild.go:2\tcleanup complete",
 	}
 	if got := scanResidualCleanup(clean); got != "" {
 		t.Fatalf("clean teardown flagged residual: %q", got)
@@ -73,19 +81,49 @@ func TestScanResidualCleanup(t *testing.T) {
 
 	dirty := []string{
 		"2026-07-24\tINFO\tbuild.go:1\tstarting build",
-		"2026-07-24\tERROR\tcleanup.go:9\tleftover loop device /dev/loop3 — run `losetup -l`",
-		"2026-07-24\tERROR\tcleanup.go:9\tresidual mount remains — run `mount | grep builds/abc`",
+		"2026-07-24\tWARN\tbuild.go:2\tbuild cancelled by signal (context canceled), running backstop cleanup",
+		"2026-07-24\tERROR\tbuild.go:3\tresidual cleanup issues (2):",
+		"2026-07-24\tERROR\tbuild.go:4\t  - chroot:/var/tmp/ict/builds/abc/rootfs: unmounting /proc: device or resource busy",
+		"2026-07-24\tERROR\tbuild.go:5\t  - loop:/dev/loop3: detaching loop device: device or resource busy",
+		"2026-07-24\tWARN\tbuild.go:6\tsome resources may still be held; consider running 'mount | grep /var/tmp/ict/builds/abc' and 'losetup -l' to identify leftovers",
+		"2026-07-24\tINFO\tbuild.go:7\texiting",
 	}
 	got := scanResidualCleanup(dirty)
 	if got == "" {
-		t.Fatal("residual cleanup lines not detected")
+		t.Fatal("residual cleanup report not detected")
 	}
-	// The logger prefix is stripped, leaving the message.
-	if want := "leftover loop device"; !strings.Contains(got, want) {
-		t.Fatalf("residual detail %q missing %q", got, want)
+	// Every part of the report must survive: the header (carries the count), both
+	// items (a leftover *mount* item has no distinctive keyword, which is why the
+	// parser is block-based), and the remediation hint.
+	for _, want := range []string{
+		"residual cleanup issues (2):",
+		"- chroot:/var/tmp/ict/builds/abc/rootfs: unmounting /proc",
+		"- loop:/dev/loop3: detaching loop device",
+		"mount | grep /var/tmp/ict/builds/abc",
+		"losetup -l",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("residual detail missing %q:\n%s", want, got)
+		}
 	}
-	if strings.Contains(got, "INFO") {
-		t.Fatalf("residual detail %q should not include the INFO line", got)
+	// Lines outside the report block must not leak in, and logger prefixes are
+	// stripped.
+	for _, unwanted := range []string{"starting build", "exiting", "INFO", "ERROR\t"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("residual detail should not contain %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+// A report whose items never made it into the log buffer (truncation, or the
+// process dying mid-report) must still yield a non-empty detail: the header
+// alone tells the user something was left behind.
+func TestScanResidualCleanupHeaderOnly(t *testing.T) {
+	got := scanResidualCleanup([]string{
+		"2026-07-24\tERROR\tbuild.go:3\tresidual cleanup issues (1):",
+	})
+	if !strings.Contains(got, "residual cleanup issues (1):") {
+		t.Fatalf("header-only report lost: %q", got)
 	}
 }
 
@@ -170,6 +208,66 @@ func TestSetPgidCheckCancel(t *testing.T) {
 	}
 }
 
+// A cancel arriving before the child is spawned must be accepted: the build
+// already holds the single-build slot, so refusing it would leave the user with
+// no way to release it. beginCancel therefore also accepts not-started.
+func TestBeginCancelBeforeStart(t *testing.T) {
+	b := &build{ID: "pre", status: statusNotStarted, done: make(chan struct{})}
+	ok, pgid := b.beginCancel()
+	if !ok || pgid != 0 {
+		t.Fatalf("cancel on not-started build: ok=%v pgid=%d, want true/0", ok, pgid)
+	}
+	if s := b.snapshot(); s.status != statusCancelling {
+		t.Fatalf("status = %q, want cancelling", s.status)
+	}
+}
+
+// setPgidCheckCancel doubles as the not-started → running promotion, so a build
+// that was never cancelled reports running once its child is up.
+func TestSetPgidPromotesNotStarted(t *testing.T) {
+	b := &build{ID: "b", status: statusNotStarted, done: make(chan struct{})}
+	if pgid, pending := b.setPgidCheckCancel(4321); pgid != 4321 || pending {
+		t.Fatalf("pgid=%d pending=%v, want 4321/false", pgid, pending)
+	}
+	if s := b.snapshot(); s.status != statusRunning {
+		t.Fatalf("status = %q, want running", s.status)
+	}
+}
+
+// finish must be single-shot: the wait path and the cancel watchdog can both
+// reach a build, and the first terminal classification has to win — otherwise a
+// build that completed successfully could be relabelled cancelled (and the slot
+// released twice).
+func TestFinishSingleShot(t *testing.T) {
+	b := &build{ID: "b", status: statusRunning, done: make(chan struct{})}
+	if !b.finish(statusSuccess, []artifact{{Name: "img.raw"}}, "") {
+		t.Fatal("first finish reported false; want true (it recorded the outcome)")
+	}
+	if b.finish(statusCancelled, nil, "watchdog gave up") {
+		t.Fatal("second finish reported true; terminal state must be single-shot")
+	}
+	s := b.snapshot()
+	if s.status != statusSuccess {
+		t.Fatalf("status = %q, want success (first writer wins)", s.status)
+	}
+	if s.errMsg != "" || len(s.artifacts) != 1 {
+		t.Fatalf("second finish mutated the record: errMsg=%q artifacts=%v", s.errMsg, s.artifacts)
+	}
+}
+
+// closeDone must tolerate being called from both the wait path and the watchdog:
+// a double close(b.done) would panic and take the server down.
+func TestCloseDoneIdempotent(t *testing.T) {
+	b := &build{ID: "b", done: make(chan struct{})}
+	b.closeDone()
+	b.closeDone() // must not panic
+	select {
+	case <-b.done:
+	default:
+		t.Fatal("done not closed")
+	}
+}
+
 func TestSetResidualFirstWins(t *testing.T) {
 	b := &build{ID: "b", done: make(chan struct{})}
 	b.setResidual(residualCancellation, "kill failed")
@@ -230,6 +328,130 @@ func TestHandleCancelBuildRunningTransitions(t *testing.T) {
 	// The bogus pgid can't be signalled, so a cancellation-failure is recorded.
 	if snap.residual == nil || snap.residual.Kind != residualCancellation {
 		t.Fatalf("residual = %+v, want cancellation-failure", snap.residual)
+	}
+}
+
+// A build record that exists only on disk (persisted as running by a server that
+// has since restarted) has no process group and no wait goroutine behind it.
+// Cancelling it would mutate a throwaway struct and report a bogus 202, so the
+// handler must 409 and point the user at the host.
+func TestHandleCancelBuildOrphanedRecord(t *testing.T) {
+	s := newTestServer(t)
+	b := &build{
+		ID:      "orphan",
+		RootDir: filepath.Join(s.buildsRoot(), "orphan"),
+		status:  statusRunning,
+		done:    make(chan struct{}),
+	}
+	if err := os.MkdirAll(b.RootDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.writeMeta(); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately NOT added to the tracker: on-disk only, as after a restart.
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/builds/orphan/cancel", nil)
+	req.SetPathValue("id", "orphan")
+	rec := httptest.NewRecorder()
+	s.handleCancelBuild(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 for an on-disk-only build", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "no live process") {
+		t.Fatalf("body should explain the orphan: %s", rec.Body.String())
+	}
+}
+
+// A cancel whose signal fails must report the residual in the 202 body: the
+// build stays in cancelling and no terminal SSE event may ever arrive, so this is
+// the only prompt notification the UI gets.
+func TestHandleCancelBuildReportsResidualInResponse(t *testing.T) {
+	s := newTestServer(t)
+	b := &build{ID: "run", status: statusRunning, pgid: 2 << 30, done: make(chan struct{})}
+	s.tracker.add(b)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/builds/run/cancel", nil)
+	req.SetPathValue("id", "run")
+	rec := httptest.NewRecorder()
+	s.handleCancelBuild(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	var got cancelAccepted
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v (%s)", err, rec.Body.String())
+	}
+	if got.Residual == nil || got.Residual.Kind != residualCancellation {
+		t.Fatalf("response residual = %+v, want cancellation-failure", got.Residual)
+	}
+	if !strings.Contains(got.Residual.Detail, "failed to signal") {
+		t.Fatalf("residual detail lacks the underlying error: %q", got.Residual.Detail)
+	}
+}
+
+// --- cancel watchdog ---
+
+// A build that ignores the cancel must not hold the single-build slot forever.
+// concludeStalledCancel is the watchdog's hard-deadline action: it marks the
+// build cancelled with a cancellation-failure and frees the slot.
+func TestConcludeStalledCancelReleasesSlot(t *testing.T) {
+	s := newTestServer(t)
+	b := &build{ID: "wedged", status: statusCancelling, cancelRequested: true, pgid: 2 << 30, done: make(chan struct{})}
+	s.tracker.add(b)
+	if ok, _ := s.tryAcquireBuildSlot(b.ID); !ok {
+		t.Fatal("could not occupy the build slot")
+	}
+
+	s.concludeStalledCancel(b)
+
+	snap := b.snapshot()
+	if snap.status != statusCancelled {
+		t.Fatalf("status = %q, want cancelled", snap.status)
+	}
+	if snap.residual == nil || snap.residual.Kind != residualCancellation {
+		t.Fatalf("residual = %+v, want cancellation-failure", snap.residual)
+	}
+	if !strings.Contains(snap.errMsg, "did not exit") {
+		t.Fatalf("errMsg should say the build never exited: %q", snap.errMsg)
+	}
+	select {
+	case <-b.done:
+	default:
+		t.Fatal("done not closed; SSE subscribers would hang")
+	}
+	if ok, active := s.tryAcquireBuildSlot("next"); !ok {
+		t.Fatalf("slot still held by %q; a wedged cancel must not block new composes", active)
+	}
+}
+
+// If the child exits just after the hard deadline fires, the wait path's outcome
+// must stand: finish is single-shot, so the watchdog neither relabels the build
+// nor releases a slot it no longer owns.
+func TestConcludeStalledCancelLosesRaceToWaitPath(t *testing.T) {
+	s := newTestServer(t)
+	b := &build{ID: "raced", status: statusCancelling, cancelRequested: true, done: make(chan struct{})}
+	s.tracker.add(b)
+	// The wait path got there first.
+	if !b.finish(statusCancelled, nil, "") {
+		t.Fatal("setup: first finish should have recorded")
+	}
+	// A new build has since claimed the slot.
+	if ok, _ := s.tryAcquireBuildSlot("next"); !ok {
+		t.Fatal("setup: could not claim the slot for the next build")
+	}
+
+	s.concludeStalledCancel(b)
+
+	if snap := b.snapshot(); snap.errMsg != "" {
+		t.Fatalf("errMsg = %q, want empty (the wait path's clean outcome must stand)", snap.errMsg)
+	}
+	if ok, active := s.tryAcquireBuildSlot("third"); ok {
+		t.Fatal("watchdog released a slot owned by another build")
+	} else if active != "next" {
+		t.Fatalf("slot holder = %q, want next", active)
 	}
 }
 

--- a/internal/api/builds_cancel_test.go
+++ b/internal/api/builds_cancel_test.go
@@ -89,6 +89,24 @@ func TestScanResidualCleanup(t *testing.T) {
 	}
 }
 
+// TestStripLogPrefix verifies the logger's fixed 3-field prefix
+// (<ts>\t<LEVEL>\t<source>\t) is removed while tabs inside the message are
+// preserved — a message with an embedded tab must not be truncated.
+func TestStripLogPrefix(t *testing.T) {
+	if got := stripLogPrefix("12:00:00\tERROR\tcleanup.go:9\tleftover loop device"); got != "leftover loop device" {
+		t.Fatalf("prefix not stripped: %q", got)
+	}
+	// A message that itself contains a tab keeps everything after the 3rd tab.
+	line := "12:00:00\tERROR\tcleanup.go:9\tmount | grep foo\tand more"
+	if got := stripLogPrefix(line); got != "mount | grep foo\tand more" {
+		t.Fatalf("embedded tab truncated: %q", got)
+	}
+	// A non-logger line (fewer than 3 tabs) is returned unchanged.
+	if got := stripLogPrefix("bare message"); got != "bare message" {
+		t.Fatalf("non-prefixed line altered: %q", got)
+	}
+}
+
 // --- build.beginCancel / setResidual ---
 
 func TestBeginCancelTransitions(t *testing.T) {
@@ -114,6 +132,41 @@ func TestBeginCancelTransitions(t *testing.T) {
 	done := &build{ID: "d", status: statusFailed, done: make(chan struct{})}
 	if ok, _ := done.beginCancel(); ok {
 		t.Fatal("cancel on failed build transitioned; want false")
+	}
+}
+
+// TestSetPgidCheckCancel covers the start-race window: a cancel can arrive after
+// the build is tracked as running but before runBuild records the process-group
+// id. beginCancel transitions to cancelling with pgid still 0; setPgidCheckCancel
+// (called once the child is started) must record the real pgid and report that a
+// cancel is pending so the caller signals the group it finally has.
+func TestSetPgidCheckCancel(t *testing.T) {
+	// No cancel pending: records the pgid, reports pending=false.
+	b := &build{ID: "b", status: statusRunning, done: make(chan struct{})}
+	if pgid, pending := b.setPgidCheckCancel(1234); pgid != 1234 || pending {
+		t.Fatalf("no-cancel: pgid=%d pending=%v, want 1234/false", pgid, pending)
+	}
+	if s := b.snapshot(); s.status != statusRunning {
+		t.Fatalf("no-cancel status = %q, want running (unchanged)", s.status)
+	}
+
+	// Cancel arrived during the window (status=cancelling, pgid still 0):
+	// setPgidCheckCancel records the pgid and reports pending=true so runBuild
+	// delivers the deferred signal.
+	raced := &build{ID: "r", status: statusRunning, done: make(chan struct{})}
+	if ok, pgid := raced.beginCancel(); !ok || pgid != 0 {
+		t.Fatalf("beginCancel before pgid set: ok=%v pgid=%d, want true/0", ok, pgid)
+	}
+	pgid, pending := raced.setPgidCheckCancel(5678)
+	if pgid != 5678 || !pending {
+		t.Fatalf("raced cancel: pgid=%d pending=%v, want 5678/true", pgid, pending)
+	}
+
+	// A build that already reached a terminal state before the pgid was recorded
+	// must not report a pending cancel (nothing to signal).
+	term := &build{ID: "t", status: statusCancelled, cancelRequested: true, done: make(chan struct{})}
+	if _, pending := term.setPgidCheckCancel(9999); pending {
+		t.Fatal("terminal build reported a pending cancel; want false")
 	}
 }
 

--- a/internal/api/builds_cancel_test.go
+++ b/internal/api/builds_cancel_test.go
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// --- exit-code classification ---
+
+// signaledErr runs a child that terminates on the given signal and returns the
+// resulting *exec.ExitError, so classifyExit sees a real WaitStatus. `sh -c
+// 'kill -N $$'` makes the shell signal itself.
+func signaledErr(t *testing.T, sig string) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "kill -"+sig+" $$").Run()
+	if err == nil {
+		t.Fatalf("expected the child to be terminated by %s", sig)
+	}
+	return err
+}
+
+func TestClassifyExit(t *testing.T) {
+	// A non-zero exit that is NOT a cancel is always a failure, regardless of code.
+	failErr := exec.Command("sh", "-c", "exit 2").Run()
+	if got := classifyExit(failErr, false); got != statusFailed {
+		t.Fatalf("non-cancel exit 2: got %q, want failed", got)
+	}
+	if got := classifyExit(failErr, true); got != statusFailed {
+		t.Fatalf("cancel-requested exit 2 (unrelated failure): got %q, want failed", got)
+	}
+
+	// Signal-code exits under a requested cancel map to cancelled.
+	for _, code := range []int{130, 143, 137} {
+		err := exec.Command("sh", "-c", "exit "+strconv.Itoa(code)).Run()
+		if got := classifyExit(err, true); got != statusCancelled {
+			t.Fatalf("cancel-requested exit %d: got %q, want cancelled", code, got)
+		}
+		// Same code without a cancel request is a failure.
+		if got := classifyExit(err, false); got != statusFailed {
+			t.Fatalf("no-cancel exit %d: got %q, want failed", code, got)
+		}
+	}
+
+	// A child killed by a signal (Signaled(), no exit code) under a cancel maps to
+	// cancelled — this is the path where sudo/ICT is TERM/KILLed rather than
+	// exiting with a translated code.
+	sigErr := signaledErr(t, "TERM")
+	if got := classifyExit(sigErr, true); got != statusCancelled {
+		t.Fatalf("cancel-requested SIGTERM-killed child: got %q, want cancelled", got)
+	}
+	if got := classifyExit(sigErr, false); got != statusFailed {
+		t.Fatalf("no-cancel SIGTERM-killed child: got %q, want failed", got)
+	}
+}
+
+// --- residual-cleanup log scanning ---
+
+func TestScanResidualCleanup(t *testing.T) {
+	clean := []string{
+		"2026-07-24\tINFO\tbuild.go:1\tstarting build",
+		"2026-07-24\tINFO\tbuild.go:2\tunmounting cleanly",
+	}
+	if got := scanResidualCleanup(clean); got != "" {
+		t.Fatalf("clean teardown flagged residual: %q", got)
+	}
+
+	dirty := []string{
+		"2026-07-24\tINFO\tbuild.go:1\tstarting build",
+		"2026-07-24\tERROR\tcleanup.go:9\tleftover loop device /dev/loop3 — run `losetup -l`",
+		"2026-07-24\tERROR\tcleanup.go:9\tresidual mount remains — run `mount | grep builds/abc`",
+	}
+	got := scanResidualCleanup(dirty)
+	if got == "" {
+		t.Fatal("residual cleanup lines not detected")
+	}
+	// The logger prefix is stripped, leaving the message.
+	if want := "leftover loop device"; !strings.Contains(got, want) {
+		t.Fatalf("residual detail %q missing %q", got, want)
+	}
+	if strings.Contains(got, "INFO") {
+		t.Fatalf("residual detail %q should not include the INFO line", got)
+	}
+}
+
+// --- build.beginCancel / setResidual ---
+
+func TestBeginCancelTransitions(t *testing.T) {
+	b := &build{ID: "b", status: statusRunning, pgid: 4242, done: make(chan struct{})}
+
+	ok, pgid := b.beginCancel()
+	if !ok || pgid != 4242 {
+		t.Fatalf("first cancel: ok=%v pgid=%d, want true/4242", ok, pgid)
+	}
+	if s := b.snapshot(); s.status != statusCancelling {
+		t.Fatalf("status after cancel = %q, want cancelling", s.status)
+	}
+	if !b.wasCancelRequested() {
+		t.Fatal("cancelRequested not set")
+	}
+
+	// A second cancel on an already-cancelling build is rejected (idempotent).
+	if ok, _ := b.beginCancel(); ok {
+		t.Fatal("second cancel transitioned again; want false")
+	}
+
+	// A cancel on a terminal build is rejected.
+	done := &build{ID: "d", status: statusFailed, done: make(chan struct{})}
+	if ok, _ := done.beginCancel(); ok {
+		t.Fatal("cancel on failed build transitioned; want false")
+	}
+}
+
+func TestSetResidualFirstWins(t *testing.T) {
+	b := &build{ID: "b", done: make(chan struct{})}
+	b.setResidual(residualCancellation, "kill failed")
+	b.setResidual(residualCleanup, "leftover mount") // must not overwrite
+	s := b.snapshot()
+	if s.residual == nil || s.residual.Kind != residualCancellation {
+		t.Fatalf("residual = %+v, want first (cancellation-failure) to win", s.residual)
+	}
+}
+
+// --- cancel handler ---
+
+func TestHandleCancelBuildNotFound(t *testing.T) {
+	s := newTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/builds/nope/cancel", nil)
+	req.SetPathValue("id", "nope")
+	rec := httptest.NewRecorder()
+	s.handleCancelBuild(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleCancelBuildNotRunning(t *testing.T) {
+	s := newTestServer(t)
+	b := &build{ID: "done", status: statusSuccess, done: make(chan struct{})}
+	s.tracker.add(b)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/builds/done/cancel", nil)
+	req.SetPathValue("id", "done")
+	rec := httptest.NewRecorder()
+	s.handleCancelBuild(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestHandleCancelBuildRunningTransitions(t *testing.T) {
+	s := newTestServer(t) // Sudo=false → signalCancel uses syscall.Kill directly
+	// A build whose "process group" is our own harmless pgid: we don't want the
+	// cancel to actually kill the test process, so use a pgid that Kill will fail
+	// on cleanly (a very large, non-existent pid). The handler still transitions
+	// to cancelling and records a cancellation-failure when the signal fails.
+	b := &build{ID: "run", status: statusRunning, pgid: 2 << 30, done: make(chan struct{})}
+	s.tracker.add(b)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/builds/run/cancel", nil)
+	req.SetPathValue("id", "run")
+	rec := httptest.NewRecorder()
+	s.handleCancelBuild(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	snap := b.snapshot()
+	if snap.status != statusCancelling {
+		t.Fatalf("status after cancel = %q, want cancelling", snap.status)
+	}
+	// The bogus pgid can't be signalled, so a cancellation-failure is recorded.
+	if snap.residual == nil || snap.residual.Kind != residualCancellation {
+		t.Fatalf("residual = %+v, want cancellation-failure", snap.residual)
+	}
+}
+
+// --- single-build lock ---
+
+func TestSingleBuildSlot(t *testing.T) {
+	s := newTestServer(t)
+	if ok, _ := s.tryAcquireBuildSlot("a"); !ok {
+		t.Fatal("first acquire failed")
+	}
+	ok, active := s.tryAcquireBuildSlot("b")
+	if ok {
+		t.Fatal("second acquire succeeded while a build was active")
+	}
+	if active != "a" {
+		t.Fatalf("active build id = %q, want a", active)
+	}
+	// Releasing a non-owner is a no-op; the slot stays held by "a".
+	s.releaseBuildSlot("b")
+	if ok, _ := s.tryAcquireBuildSlot("c"); ok {
+		t.Fatal("acquire succeeded after a no-op release")
+	}
+	// The owner releases; the next build can start.
+	s.releaseBuildSlot("a")
+	if ok, _ := s.tryAcquireBuildSlot("c"); !ok {
+		t.Fatal("acquire failed after the owner released")
+	}
+}
+
+func TestHandleStartBuildRejectsConcurrent(t *testing.T) {
+	s := newTestServer(t)
+	// Occupy the slot as if a build were already running.
+	if ok, _ := s.tryAcquireBuildSlot("in-flight"); !ok {
+		t.Fatal("could not occupy the build slot")
+	}
+
+	body := `{"compose":{"vertical":"robotics","sku":"amr","platform":"wcl","os":"ubuntu24","imageType":"iso"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/builds", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleStartBuild(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (build in progress)", rec.Code)
+	}
+	// No second build should have been tracked.
+	if n := len(s.tracker.all()); n != 0 {
+		t.Fatalf("tracker has %d builds; a rejected start must not create one", n)
+	}
+}

--- a/internal/api/handlers_build_details.go
+++ b/internal/api/handlers_build_details.go
@@ -27,6 +27,8 @@ type buildDetails struct {
 	Summary     *composeSummary `json:"summary,omitempty"`
 	HasLogFile  bool            `json:"hasLogFile"` // a downloadable log file exists on disk
 	ErrMsg      string          `json:"errMsg,omitempty"`
+	Artifacts   []artifact      `json:"artifacts,omitempty"` // partial outputs on fail/cancel (with on-disk path)
+	Residual    *residualIssue  `json:"residual,omitempty"`  // teardown-residue warning for manual remediation
 }
 
 // handleBuildDetails returns the command and paths for a build so the UI can show
@@ -50,6 +52,8 @@ func (s *Server) handleBuildDetails(w http.ResponseWriter, r *http.Request) {
 		Summary:     b.Summary,
 		HasLogFile:  res.logFile != "" && fileExists(res.logFile),
 		ErrMsg:      res.errMsg,
+		Artifacts:   res.artifacts,
+		Residual:    res.residual,
 	})
 }
 

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -27,6 +27,9 @@ type buildMeta struct {
 	Artifacts []artifact      `json:"artifacts,omitempty"`
 	ErrMsg    string          `json:"errMsg,omitempty"`
 	LogFile   string          `json:"logFile,omitempty"`
+	// Residual outlives the process on purpose: leftover mounts and loop devices
+	// survive a server restart, so the remediation hint must too.
+	Residual *residualIssue `json:"residual,omitempty"`
 }
 
 // metaPath returns the meta.json path for a build root directory.
@@ -52,6 +55,7 @@ func (b *build) writeMeta() error {
 		Artifacts: res.artifacts,
 		ErrMsg:    res.errMsg,
 		LogFile:   res.logFile,
+		Residual:  res.residual,
 	}
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -83,6 +87,7 @@ func buildFromMeta(rootDir string, m buildMeta) *build {
 		status:    buildStatus(m.Status),
 		artifacts: m.Artifacts,
 		errMsg:    m.ErrMsg,
+		residual:  m.Residual,
 	}
 	return b
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -21,6 +21,7 @@ func (s *Server) routes() *http.ServeMux {
 
 	// Build path (implemented in builds.go)
 	mux.HandleFunc("POST /api/v1/builds", s.handleStartBuild)
+	mux.HandleFunc("POST /api/v1/builds/{id}/cancel", s.handleCancelBuild)
 	mux.HandleFunc("GET /api/v1/builds", s.handleListBuilds)
 	mux.HandleFunc("GET /api/v1/builds/{id}/logs", s.handleBuildLogs)
 	mux.HandleFunc("GET /api/v1/builds/{id}/artifacts", s.handleBuildArtifacts)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
@@ -31,6 +32,37 @@ type Server struct {
 	cfg      Config
 	manifest *Manifest
 	tracker  *buildTracker
+
+	// buildMu serializes compose starts so at most one build runs at a time.
+	// activeBuildID names the in-flight build (empty when idle). The slot is held
+	// from the moment handleStartBuild spawns the child until runBuild observes
+	// the ICT process fully exit (post-teardown), so a second compose can't start
+	// while mounts/loop devices from the previous one may still be tearing down.
+	buildMu       sync.Mutex
+	activeBuildID string
+}
+
+// tryAcquireBuildSlot claims the single-build slot for id. It returns false (and
+// the id currently holding the slot) if a build is already in flight, so the
+// caller can reject the concurrent start.
+func (s *Server) tryAcquireBuildSlot(id string) (ok bool, activeID string) {
+	s.buildMu.Lock()
+	defer s.buildMu.Unlock()
+	if s.activeBuildID != "" {
+		return false, s.activeBuildID
+	}
+	s.activeBuildID = id
+	return true, ""
+}
+
+// releaseBuildSlot frees the single-build slot. It is a no-op if id is not the
+// current holder (defensive: only the owning build should release it).
+func (s *Server) releaseBuildSlot(id string) {
+	s.buildMu.Lock()
+	defer s.buildMu.Unlock()
+	if s.activeBuildID == id {
+		s.activeBuildID = ""
+	}
 }
 
 // New constructs a Server, loading and validating the embedded manifest.

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -89,10 +89,23 @@ func (s *Server) handleBuildLogs(w http.ResponseWriter, r *http.Request) {
 					"artifacts": arts,
 				})
 			} else {
-				sendEvent(w, "error", map[string]any{
-					"status":  string(statusFailed),
-					"message": res.errMsg,
-				})
+				// Report the real terminal status (failed or cancelled) rather than
+				// a hardcoded "failed", so the UI can show the correct badge. Include
+				// any partial artifacts (with on-disk location) and a residual-teardown
+				// warning so the UI can point the user at manual remediation.
+				arts := res.artifacts
+				if arts == nil {
+					arts = []artifact{}
+				}
+				payload := map[string]any{
+					"status":    string(res.status),
+					"message":   res.errMsg,
+					"artifacts": arts,
+				}
+				if res.residual != nil {
+					payload["residual"] = res.residual
+				}
+				sendEvent(w, "error", payload)
 			}
 			flusher.Flush()
 			return

--- a/web/README.md
+++ b/web/README.md
@@ -23,22 +23,35 @@ under `sudo`. Run everything from the **repository root**.
 
 ### 1. Grant a scoped, passwordless sudo rule
 
-The server invokes the ICT binary (and `cat`, to stream root-owned artifacts) via
-`sudo -n`. Grant a NOPASSWD rule scoped to exactly those commands — do **not**
-give the service blanket sudo. The path must be the **absolute** path to the
-binary you build in step 2 (the server resolves it to an absolute path, and
-`sudo` matches the rule literally).
+The server invokes the ICT binary (and `cat`, to stream root-owned artifacts, and
+`kill`, to cancel a running build) via `sudo -n`. Grant NOPASSWD rules scoped to
+exactly those commands — do **not** give the service blanket sudo. The path must
+be the **absolute** path to the binary you build in step 2 (the server resolves
+it to an absolute path, and `sudo` matches the rule literally).
 
 ```bash
 echo "$(whoami) ALL=(root) NOPASSWD: $(pwd)/build/image-composer-tool build *" \
   | sudo tee /etc/sudoers.d/ict-webui
 echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/cat $(pwd)/webui-workspace/builds/*" \
   | sudo tee -a /etc/sudoers.d/ict-webui
+echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/kill -TERM -[0-9]*" \
+  | sudo tee -a /etc/sudoers.d/ict-webui
 sudo chmod 440 /etc/sudoers.d/ict-webui
 
 # Verify (should print "sudo OK"):
 sudo -n "$(pwd)/build/image-composer-tool" build --help >/dev/null && echo "sudo OK"
 ```
+
+> **Cancellation & security posture.** The build runs as a root-owned process
+> group (so ICT can tear down its own mounts and loop devices on SIGTERM). The
+> server is non-root and cannot signal that group directly across the `sudo`
+> boundary, so **Cancel** delivers the signal as root via `sudo -n kill -TERM
+> -<pgid>`. The third rule above authorizes exactly that: a scoped root `kill`,
+> restricted to `-TERM` and to signalling a process **group** (the leading `-`
+> before the pid). Adjust the `kill` path (e.g. `/bin/kill`) to match your distro
+> — run `command -v kill`. Omit this rule and cancellation will fail with a
+> *cancellation-failure* (the signal can't be delivered); the UI surfaces that
+> distinctly from a *cleanup-failure* (ICT ran but left residue).
 
 ### 2. Build the frontend, embed it, and build the binary
 

--- a/web/README.md
+++ b/web/README.md
@@ -46,12 +46,28 @@ sudo -n "$(pwd)/build/image-composer-tool" build --help >/dev/null && echo "sudo
 > group (so ICT can tear down its own mounts and loop devices on SIGTERM). The
 > server is non-root and cannot signal that group directly across the `sudo`
 > boundary, so **Cancel** delivers the signal as root via `sudo -n kill -TERM
-> -<pgid>`. The third rule above authorizes exactly that: a scoped root `kill`,
-> restricted to `-TERM` and to signalling a process **group** (the leading `-`
-> before the pid). Adjust the `kill` path (e.g. `/bin/kill`) to match your distro
-> — run `command -v kill`. Omit this rule and cancellation will fail with a
-> *cancellation-failure* (the signal can't be delivered); the UI surfaces that
-> distinctly from a *cleanup-failure* (ICT ran but left residue).
+> -<pgid>`. The third rule above authorizes that. Adjust the `kill` path (e.g.
+> `/bin/kill`) to match your distro — run `command -v kill`. Omit this rule and
+> cancellation will fail with a *cancellation-failure* (the signal can't be
+> delivered); the UI surfaces that distinctly from a *cleanup-failure* (ICT ran
+> but left residue).
+>
+> **Read this before pasting the rule.** The target process group id isn't known
+> until a build starts, so sudoers cannot constrain *which* group is signalled —
+> `-[0-9]*` matches any pgid. Understand what you are granting the service user:
+>
+> - `kill -TERM -1` as root — SIGTERM to **every process on the host**, i.e. a
+>   full-system shutdown-equivalent, available to anyone who can run commands as
+>   the service user.
+> - SIGTERM to any other process group on the box, including the server's own.
+>
+> The signal is restricted to `-TERM` (no `-KILL`, no arbitrary signal), and the
+> service is expected to run as a dedicated, non-login user on a build host — but
+> this is a real privilege escalation from "may run one build command" and should
+> be accepted deliberately, not by default. If that is too broad for your
+> environment, either run the server as root on an isolated build host (no `kill`
+> rule needed — the `--sudo` path is skipped and the group is signalled directly)
+> or omit the rule and accept that Cancel reports a cancellation-failure.
 
 ### 2. Build the frontend, embed it, and build the binary
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from './api/client'
+import { isActiveStatus, type BuildStatus } from './api/types'
 import { useStore } from './store'
 import { BasicPage } from './components/BasicPage'
 import { BuildImagePage } from './components/BuildImagePage'
 
 type LoadState = 'loading' | 'ready' | 'error'
 type View = 'basic' | 'advanced' | 'builds'
-type BuildStatus = 'idle' | 'running' | 'success' | 'failed'
 
 export default function App() {
   const setManifest = useStore((s) => s.setManifest)
@@ -16,6 +16,7 @@ export default function App() {
   const [view, setView] = useState<View>('basic')
   const [buildId, setBuildId] = useState<string | null>(null)
   const [retrying, setRetrying] = useState(false)
+  const [retryError, setRetryError] = useState<string | null>(null)
   const [buildStatus, setBuildStatus] = useState<BuildStatus>('idle')
 
   const selection = useStore((s) => s.selection)
@@ -39,18 +40,20 @@ export default function App() {
 
   useEffect(load, [load])
 
-  // On load, adopt any already-running build from the server so the UI reflects
-  // it after a refresh: disables the Compose button and shows the nav indicator
+  // On load, adopt any in-flight build from the server so the UI reflects it
+  // after a refresh: disables the Compose button and shows the nav indicator
   // (otherwise buildStatus resets to 'idle' and a duplicate build could start).
+  // A build mid-cancel still holds the server's single-build slot, so adopt those
+  // too — otherwise Compose looks available and the start would 409.
   useEffect(() => {
     if (state !== 'ready') return
     api
       .listBuilds()
       .then((builds) => {
-        const running = builds.find((b) => b.status === 'running')
-        if (running) {
-          setBuildId(running.id)
-          setBuildStatus('running')
+        const active = builds.find((b) => isActiveStatus(b.status))
+        if (active) {
+          setBuildId(active.id)
+          setBuildStatus(active.status as BuildStatus)
         }
       })
       .catch(() => {})
@@ -64,12 +67,21 @@ export default function App() {
 
   const onBuildStatusChange = (s: BuildStatus) => setBuildStatus(s)
 
+  // Retry the last selection as a fresh compose. The start can legitimately fail
+  // — most importantly with 409 while the previous build's teardown still holds
+  // the server's single-build slot — so the optimistic 'running' must be rolled
+  // back and the reason shown, or the nav indicator would spin forever on a build
+  // that never started.
   const onRetry = useCallback(async () => {
     setRetrying(true)
+    setRetryError(null)
     setBuildStatus('running')
     try {
       const accepted = await api.startBuild(selectionRef.current)
       setBuildId(accepted.buildId)
+    } catch (e) {
+      setRetryError((e as Error).message)
+      setBuildStatus('failed')
     } finally {
       setRetrying(false)
     }
@@ -134,7 +146,7 @@ export default function App() {
           <div hidden={view !== 'basic'}>
             <BasicPage
               onBuildStarted={onBuildStarted}
-              buildInProgress={buildStatus === 'running'}
+              buildInProgress={isActiveStatus(buildStatus)}
             />
           </div>
           <div hidden={view !== 'builds'}>
@@ -142,6 +154,7 @@ export default function App() {
               buildId={buildId}
               onRetry={onRetry}
               retrying={retrying}
+              retryError={retryError}
               onStatusChange={onBuildStatusChange}
             />
           </div>
@@ -151,13 +164,23 @@ export default function App() {
   )
 }
 
+// One entry per non-idle build state. Typed as an exhaustive Record so adding a
+// state to BuildStatus is a compile error here rather than a blank indicator.
+const indicatorStyles: Record<
+  Exclude<BuildStatus, 'idle'>,
+  { color: string; pulse: boolean; label: string }
+> = {
+  'not-started': { color: 'bg-yellow-400', pulse: true, label: 'Compose starting' },
+  running: { color: 'bg-yellow-400', pulse: true, label: 'Compose in progress' },
+  cancelling: { color: 'bg-amber-500', pulse: true, label: 'Cancelling compose' },
+  cancelled: { color: 'bg-slate-400', pulse: false, label: 'Compose cancelled' },
+  success: { color: 'bg-green-400', pulse: false, label: 'Compose completed' },
+  failed: { color: 'bg-red-500', pulse: false, label: 'Compose failed' },
+}
+
 function BuildIndicator({ status, onClick }: { status: BuildStatus; onClick: () => void }) {
   if (status === 'idle') return null
-  const cfg = {
-    running: { color: 'bg-yellow-400', pulse: true,  label: 'Compose in progress' },
-    success: { color: 'bg-green-400',  pulse: false, label: 'Compose completed' },
-    failed:  { color: 'bg-red-500',    pulse: false, label: 'Compose failed' },
-  }[status]
+  const cfg = indicatorStyles[status]
   return (
     <button
       onClick={onClick}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   ComposeResponse,
   BuildAccepted,
   BuildDetails,
+  CancelAccepted,
   HistoryItem,
   Artifact,
 } from './types'
@@ -51,9 +52,12 @@ export const api = {
 
   // Cancel an in-flight build. Returns 202 with the cancelling status; the
   // terminal state (cancelled/failed) then arrives over SSE. 409 if the build is
-  // not running (already finished, or a cancel is already in flight).
+  // not running (already finished, or a cancel is already in flight). A 202 whose
+  // body carries `residual` means the cancel was accepted but the signal could
+  // not be delivered — the caller must surface that, since no terminal SSE event
+  // may follow.
   cancelBuild: (buildId: string) =>
-    jsonFetch<{ buildId: string; status: string }>(`/builds/${buildId}/cancel`, {
+    jsonFetch<CancelAccepted>(`/builds/${buildId}/cancel`, {
       method: 'POST',
     }),
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -49,10 +49,13 @@ export const api = {
   listBuilds: () =>
     jsonFetch<{ builds: HistoryItem[] }>('/builds').then((r) => r.builds),
 
-  // Cancel an in-flight build. The endpoint arrives with Story 3; until then the
-  // backend returns 404 and the caller surfaces that as a cancel failure.
+  // Cancel an in-flight build. Returns 202 with the cancelling status; the
+  // terminal state (cancelled/failed) then arrives over SSE. 409 if the build is
+  // not running (already finished, or a cancel is already in flight).
   cancelBuild: (buildId: string) =>
-    jsonFetch<void>(`/builds/${buildId}/cancel`, { method: 'POST' }),
+    jsonFetch<{ buildId: string; status: string }>(`/builds/${buildId}/cancel`, {
+      method: 'POST',
+    }),
 
   // Build command + resolved paths for the troubleshoot panel.
   buildDetails: (buildId: string) =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -83,6 +83,16 @@ export interface Artifact {
   size?: string
 }
 
+// Teardown-residue warning surfaced when a cancelled/failed build may have left
+// the machine in a state needing manual cleanup. kind distinguishes a
+// cancellation-failure (the cancel signal couldn't be delivered) from a
+// cleanup-failure (ICT ran but reported leftover mounts/loop devices). detail
+// carries the remediation hint (the failing kill error, or ICT's mount/loop lines).
+export interface ResidualIssue {
+  kind: 'cancellation-failure' | 'cleanup-failure'
+  detail: string
+}
+
 // Reproducibility/troubleshooting metadata for a build: the exact command that
 // ran, the resolved template (+ a download URL), and the per-build directories.
 export interface BuildDetails {
@@ -96,6 +106,10 @@ export interface BuildDetails {
   summary?: ComposeSummary
   hasLogFile: boolean
   errMsg?: string
+  // Partial outputs left on disk after a fail/cancel (with on-disk path).
+  artifacts?: Artifact[]
+  // Teardown-residue warning, when cleanup left something behind.
+  residual?: ResidualIssue
 }
 
 // One row in the compose history list.
@@ -108,7 +122,8 @@ export interface HistoryItem {
 }
 
 export interface BuildComplete {
-  status: 'success' | 'failed'
+  status: 'success' | 'failed' | 'cancelled'
   artifacts?: Artifact[]
   message?: string
+  residual?: ResidualIssue
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -93,6 +93,26 @@ export interface ResidualIssue {
   detail: string
 }
 
+// The server's six build states, verbatim (internal/api/builds.go). Shared by
+// every component that reports or renders a build's lifecycle so a new state
+// can't be handled in one place and silently dropped in another. 'idle' is a
+// UI-only state meaning "no build owns the session right now".
+export type BuildStatus =
+  | 'idle'
+  | 'not-started'
+  | 'running'
+  | 'cancelling'
+  | 'cancelled'
+  | 'success'
+  | 'failed'
+
+// isActiveStatus reports whether a build is still in flight — the server holds
+// the single-build slot in exactly these states, so this is what gates starting
+// another compose and what drives history polling.
+export function isActiveStatus(s: string): boolean {
+  return s === 'not-started' || s === 'running' || s === 'cancelling'
+}
+
 // Reproducibility/troubleshooting metadata for a build: the exact command that
 // ran, the resolved template (+ a download URL), and the per-build directories.
 export interface BuildDetails {
@@ -119,6 +139,15 @@ export interface HistoryItem {
   template: string
   createdAt: string
   summary?: ComposeSummary
+}
+
+// Response to POST /builds/{id}/cancel. residual is present when the cancel was
+// accepted but the signal could not be delivered — the build stays 'cancelling',
+// so this is the only place that failure surfaces promptly.
+export interface CancelAccepted {
+  buildId: string
+  status: string
+  residual?: ResidualIssue
 }
 
 export interface BuildComplete {

--- a/web/src/components/BuildImagePage.tsx
+++ b/web/src/components/BuildImagePage.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import { api } from '../api/client'
-import type { HistoryItem } from '../api/types'
+import { isActiveStatus, type BuildStatus, type HistoryItem } from '../api/types'
 import { BuildView } from './BuildView'
 import { HistorySidebar } from './HistorySidebar'
-
-type BuildStatus = 'idle' | 'running' | 'success' | 'failed'
 
 interface BuildImagePageProps {
   // The active (most recently started) build, owned by App. Null until the
@@ -12,10 +10,19 @@ interface BuildImagePageProps {
   buildId: string | null
   onRetry: () => Promise<void>
   retrying: boolean
+  // Why the last retry failed (e.g. a 409 while the previous build is still
+  // tearing down), or null. Owned by App, which issues the start.
+  retryError: string | null
   onStatusChange: (s: BuildStatus) => void
 }
 
-export function BuildImagePage({ buildId, onRetry, retrying, onStatusChange }: BuildImagePageProps) {
+export function BuildImagePage({
+  buildId,
+  onRetry,
+  retrying,
+  retryError,
+  onStatusChange,
+}: BuildImagePageProps) {
   const [history, setHistory] = useState<HistoryItem[]>([])
   // Which build is shown on the right. Defaults to the active build; clicking a
   // history row overrides it.
@@ -44,19 +51,21 @@ export function BuildImagePage({ buildId, onRetry, retrying, onStatusChange }: B
     }
   }, [buildId, refresh])
 
-  // Poll while any build is still running so the sidebar reflects live status.
-  const anyRunning = history.some((h) => h.status === 'running')
+  // Poll while any build is still in flight so the sidebar reflects live status.
+  // 'cancelling' counts: the row's status changes again when teardown finishes.
+  const anyActive = history.some((h) => isActiveStatus(h.status))
   useEffect(() => {
-    if (!anyRunning) return
+    if (!anyActive) return
     const t = setInterval(refresh, 3000)
     return () => clearInterval(t)
-  }, [anyRunning, refresh])
+  }, [anyActive, refresh])
 
-  // The active build's terminal status drives the nav indicator; a past build's
-  // status must not clobber it. Also refresh history when the active build ends.
+  // The active build's status drives the nav indicator; a past build's status
+  // must not clobber it. Also refresh history whenever the active build reaches a
+  // terminal state, so its sidebar row stops showing the in-flight status.
   const handleStatusChange = (s: BuildStatus) => {
     if (selectedId === buildId) onStatusChange(s)
-    if (s === 'success' || s === 'failed') refresh()
+    if (!isActiveStatus(s) && s !== 'idle') refresh()
   }
 
   return (
@@ -71,6 +80,7 @@ export function BuildImagePage({ buildId, onRetry, retrying, onStatusChange }: B
               buildId={selectedId}
               onRetry={onRetry}
               retrying={retrying}
+              retryError={retryError}
               onStatusChange={handleStatusChange}
               isActive={selectedId === buildId}
             />

--- a/web/src/components/BuildView.tsx
+++ b/web/src/components/BuildView.tsx
@@ -1,25 +1,39 @@
 import { useEffect, useRef, useState } from 'react'
 import { api } from '../api/client'
-import type { Artifact, BuildDetails, ResidualIssue } from '../api/types'
+import type { Artifact, BuildDetails, BuildStatus, ResidualIssue } from '../api/types'
 import { BuildProgress } from './BuildProgress'
-
-type BuildStatus = 'idle' | 'running' | 'success' | 'failed'
 
 interface BuildViewProps {
   buildId: string
   onRetry: () => Promise<void>
   retrying: boolean
+  // Why the last retry failed (owned by App, which issues the start), or null.
+  retryError: string | null
   onStatusChange: (s: BuildStatus) => void
   // The active build streams live logs. A history build (isActive=false) shows a
   // downloadable log file + artifacts instead of a live log text area.
   isActive: boolean
 }
 
-// Full MVP-1 build lifecycle. "loading" is a transient state while a history
-// build's persisted data is fetched; the others are the actual build states.
-type Status = 'loading' | 'running' | 'cancelling' | 'cancelled' | 'success' | 'failed'
+// Full build lifecycle as rendered here: the server's six states plus "loading",
+// a transient while a history build's persisted data is fetched.
+type Status =
+  | 'loading'
+  | 'not-started'
+  | 'running'
+  | 'cancelling'
+  | 'cancelled'
+  | 'success'
+  | 'failed'
 
-export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive }: BuildViewProps) {
+export function BuildView({
+  buildId,
+  onRetry,
+  retrying,
+  retryError,
+  onStatusChange,
+  isActive,
+}: BuildViewProps) {
   const [logs, setLogs] = useState<string[]>([])
   const [status, setStatus] = useState<Status>(isActive ? 'running' : 'loading')
   const [artifacts, setArtifacts] = useState<Artifact[]>([])
@@ -58,7 +72,10 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
       ])
         .then(([d, arts, logText]) => {
           setStatus((d.status as Status) ?? 'success')
-          if (d.status === 'failed') setErrorMsg(d.errMsg ?? '')
+          // A cancel that was never delivered leaves the build stuck in
+          // 'cancelling' with the failure recorded as residue, so show the reason
+          // for both terminal failures and that stalled state.
+          if (d.status === 'failed' || d.status === 'cancelling') setErrorMsg(d.errMsg ?? '')
           if (d.residual) setResidual(d.residual)
           // Prefer the discovered artifact list; fall back to any partial outputs
           // recorded on the details (present after a fail/cancel).
@@ -87,11 +104,14 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
       if (res) setResidual(res)
       onStatusChange('failed')
     }
+    // Report 'cancelled' rather than 'idle': the parent needs the real terminal
+    // state to refresh the history row and to show the cancelled nav indicator.
+    // Composing is re-enabled because 'cancelled' is not an active status.
     const finishCancelled = (arts?: Artifact[], res?: ResidualIssue) => {
       setStatus('cancelled')
       if (arts && arts.length > 0) setArtifacts(arts)
       if (res) setResidual(res)
-      onStatusChange('idle')
+      onStatusChange('cancelled')
     }
 
     const connect = () => {
@@ -171,17 +191,27 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
   const copyCommand = () => details && navigator.clipboard.writeText(details.command)
 
   // Request cancellation. Optimistically flip to the cancelling transient so the
-  // button disables immediately; the terminal state (cancelled/failed) arrives
-  // over SSE. If the request itself fails, surface it and revert to running so
-  // the user can retry the cancel.
+  // button disables immediately; the terminal state (cancelled/failed) normally
+  // arrives over SSE.
+  //
+  // Two failure shapes need distinct handling:
+  //  - The request itself failed (network, 409): nothing was cancelled, so revert
+  //    to running and let the user retry.
+  //  - The request was accepted (202) but carries a residual: the signal could not
+  //    be delivered, so the build stays in cancelling and no terminal event may
+  //    ever arrive. Render the residue now — this is the cancellation-failure the
+  //    user has to remediate by hand.
   const cancel = async () => {
     setCancelError('')
     setStatus('cancelling')
+    onStatusChange('cancelling')
     try {
-      await api.cancelBuild(buildId)
+      const res = await api.cancelBuild(buildId)
+      if (res.residual) setResidual(res.residual)
     } catch (err) {
       setCancelError(err instanceof Error ? err.message : 'cancel request failed')
       setStatus('running')
+      onStatusChange('running')
     }
   }
 
@@ -190,9 +220,10 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
       <div className="mb-2 flex items-center gap-3">
         <h2 className="text-sm font-semibold text-[#00285a]">Compose Status</h2>
         <StatusBadge status={status} />
-        {/* Cancel — available while the active build is running. Disabled during
-            the cancelling transient (request in flight / awaiting teardown). */}
-        {isActive && (status === 'running' || status === 'cancelling') && (
+        {/* Cancel — available while the active build is in flight, including the
+            pre-spawn window (the server queues the signal). Disabled during the
+            cancelling transient (request in flight / awaiting teardown). */}
+        {isActive && (status === 'not-started' || status === 'running' || status === 'cancelling') && (
           <button
             className="ml-auto rounded border border-red-400 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={status === 'cancelling'}
@@ -218,6 +249,15 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
         </div>
       )}
 
+      {/* A retry that the server refused — most often 409 while the previous
+          build is still tearing down. Without this the Retry button would look
+          like it did nothing. */}
+      {retryError && (
+        <div className="mb-2 rounded bg-red-50 p-2 text-xs text-red-700">
+          Could not start a new compose: {retryError}
+        </div>
+      )}
+
       {/* Phase stepper — shown for the active (streaming) build. History builds
           have no live phase data, so it's omitted there. The active stage is
           marked red on both failure and cancellation. */}
@@ -229,7 +269,16 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
         />
       )}
 
-      {status === 'cancelling' && (
+      {status === 'not-started' && (
+        <div className="mb-2 rounded bg-slate-100 p-2 text-xs text-slate-700">
+          Starting compose — launching the build process.
+        </div>
+      )}
+
+      {/* While cancelling, the normal message is "teardown in progress". If a
+          residual is already recorded the signal never landed, so say that
+          instead of implying an orderly cleanup is underway. */}
+      {status === 'cancelling' && !residual && (
         <div className="mb-2 rounded bg-amber-50 p-2 text-xs text-amber-800">
           Cancelling compose — signalling the build to stop and clean up (unmounting,
           detaching loop devices). This may take a moment.
@@ -485,6 +534,7 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
 function StatusBadge({ status }: { status: Status }) {
   const cls: Record<Status, string> = {
     loading: 'bg-slate-200 text-slate-600',
+    'not-started': 'bg-slate-200 text-slate-600',
     running: 'bg-amber-100 text-amber-800',
     cancelling: 'bg-amber-100 text-amber-800',
     cancelled: 'bg-slate-200 text-slate-700',
@@ -493,6 +543,7 @@ function StatusBadge({ status }: { status: Status }) {
   }
   const label: Record<Status, string> = {
     loading: 'Loading…',
+    'not-started': 'Starting…',
     running: 'Composing…',
     cancelling: 'Cancelling…',
     cancelled: '⊘ Cancelled',

--- a/web/src/components/BuildView.tsx
+++ b/web/src/components/BuildView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { api } from '../api/client'
-import type { Artifact, BuildDetails } from '../api/types'
+import type { Artifact, BuildDetails, ResidualIssue } from '../api/types'
 import { BuildProgress } from './BuildProgress'
 
 type BuildStatus = 'idle' | 'running' | 'success' | 'failed'
@@ -24,6 +24,8 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
   const [status, setStatus] = useState<Status>(isActive ? 'running' : 'loading')
   const [artifacts, setArtifacts] = useState<Artifact[]>([])
   const [errorMsg, setErrorMsg] = useState<string>('')
+  const [residual, setResidual] = useState<ResidualIssue | null>(null)
+  const [cancelError, setCancelError] = useState<string>('')
   const [details, setDetails] = useState<BuildDetails | null>(null)
   const [detailsOpen, setDetailsOpen] = useState(false)
   const [phase, setPhase] = useState<string>('preparing')
@@ -35,6 +37,8 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
     setStatus(isActive ? 'running' : 'loading')
     setArtifacts([])
     setErrorMsg('')
+    setResidual(null)
+    setCancelError('')
     setDetails(null)
     setDetailsOpen(false)
     setPhase(isActive ? 'preparing' : 'done')
@@ -55,7 +59,10 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
         .then(([d, arts, logText]) => {
           setStatus((d.status as Status) ?? 'success')
           if (d.status === 'failed') setErrorMsg(d.errMsg ?? '')
-          setArtifacts(arts)
+          if (d.residual) setResidual(d.residual)
+          // Prefer the discovered artifact list; fall back to any partial outputs
+          // recorded on the details (present after a fail/cancel).
+          setArtifacts(arts.length > 0 ? arts : (d.artifacts ?? []))
           if (logText) setLogs(logText.split('\n'))
         })
         .catch(() => setStatus('failed'))
@@ -73,10 +80,18 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
       api.buildDetails(buildId).then(setDetails).catch(() => {})
       api.buildArtifacts(buildId).then(setArtifacts).catch(() => {})
     }
-    const finishFailed = (msg?: string) => {
+    const finishFailed = (msg?: string, arts?: Artifact[], res?: ResidualIssue) => {
       setStatus('failed')
       if (msg) setErrorMsg(msg)
+      if (arts && arts.length > 0) setArtifacts(arts)
+      if (res) setResidual(res)
       onStatusChange('failed')
+    }
+    const finishCancelled = (arts?: Artifact[], res?: ResidualIssue) => {
+      setStatus('cancelled')
+      if (arts && arts.length > 0) setArtifacts(arts)
+      if (res) setResidual(res)
+      onStatusChange('idle')
     }
 
     const connect = () => {
@@ -99,8 +114,7 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
         const data = JSON.parse((e as MessageEvent).data)
         es?.close()
         if (data.status === 'cancelled') {
-          setStatus('cancelled')
-          onStatusChange('idle')
+          finishCancelled(data.artifacts, data.residual)
         } else {
           setArtifacts(data.artifacts ?? [])
           finishSuccess()
@@ -110,14 +124,14 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
         const raw = (e as MessageEvent).data
         es?.close()
         if (raw) {
-          // Server-sent terminal error: the build genuinely failed/cancelled.
+          // Server-sent terminal error: the build genuinely failed/cancelled. It
+          // carries any partial artifacts and a residual-teardown warning too.
           try {
             const data = JSON.parse(raw)
             if (data.status === 'cancelled') {
-              setStatus('cancelled')
-              onStatusChange('idle')
+              finishCancelled(data.artifacts, data.residual)
             } else {
-              finishFailed(data.message)
+              finishFailed(data.message, data.artifacts, data.residual)
             }
           } catch {
             finishFailed()
@@ -131,7 +145,8 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
           .buildDetails(buildId)
           .then((d) => {
             if (d.status === 'success') finishSuccess()
-            else if (d.status === 'failed') finishFailed(d.errMsg)
+            else if (d.status === 'failed') finishFailed(d.errMsg, d.artifacts, d.residual)
+            else if (d.status === 'cancelled') finishCancelled(d.artifacts, d.residual)
             else if (!closed) setTimeout(connect, 1000) // still running → reconnect
           })
           .catch(() => finishFailed())
@@ -155,12 +170,37 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
   const copyPath = (path: string) => navigator.clipboard.writeText(path)
   const copyCommand = () => details && navigator.clipboard.writeText(details.command)
 
+  // Request cancellation. Optimistically flip to the cancelling transient so the
+  // button disables immediately; the terminal state (cancelled/failed) arrives
+  // over SSE. If the request itself fails, surface it and revert to running so
+  // the user can retry the cancel.
+  const cancel = async () => {
+    setCancelError('')
+    setStatus('cancelling')
+    try {
+      await api.cancelBuild(buildId)
+    } catch (err) {
+      setCancelError(err instanceof Error ? err.message : 'cancel request failed')
+      setStatus('running')
+    }
+  }
+
   return (
     <div className="mt-6">
       <div className="mb-2 flex items-center gap-3">
         <h2 className="text-sm font-semibold text-[#00285a]">Compose Status</h2>
         <StatusBadge status={status} />
-        {/* Cancel button wired in Story 3 (build cancellation + cleanup) */}
+        {/* Cancel — available while the active build is running. Disabled during
+            the cancelling transient (request in flight / awaiting teardown). */}
+        {isActive && (status === 'running' || status === 'cancelling') && (
+          <button
+            className="ml-auto rounded border border-red-400 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={status === 'cancelling'}
+            onClick={cancel}
+          >
+            {status === 'cancelling' ? 'Cancelling…' : '✕ Cancel compose'}
+          </button>
+        )}
         {(status === 'failed' || status === 'cancelled') && (
           <button
             className="ml-auto rounded border border-[#0071c5] px-3 py-1 text-xs font-medium text-[#0071c5] hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50"
@@ -172,14 +212,66 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
         )}
       </div>
 
+      {cancelError && (
+        <div className="mb-2 rounded bg-red-50 p-2 text-xs text-red-700">
+          Cancel request failed: {cancelError}
+        </div>
+      )}
+
       {/* Phase stepper — shown for the active (streaming) build. History builds
-          have no live phase data, so it's omitted there. */}
+          have no live phase data, so it's omitted there. The active stage is
+          marked red on both failure and cancellation. */}
       {isActive && (
-        <BuildProgress phase={phase} install={install} failed={status === 'failed'} />
+        <BuildProgress
+          phase={phase}
+          install={install}
+          failed={status === 'failed' || status === 'cancelled'}
+        />
+      )}
+
+      {status === 'cancelling' && (
+        <div className="mb-2 rounded bg-amber-50 p-2 text-xs text-amber-800">
+          Cancelling compose — signalling the build to stop and clean up (unmounting,
+          detaching loop devices). This may take a moment.
+        </div>
       )}
 
       {status === 'failed' && errorMsg && (
-        <div className="mb-2 rounded bg-red-50 p-2 text-xs text-red-700">Compose failed: {errorMsg}</div>
+        <div className="mb-2 rounded bg-red-50 p-2 text-xs text-red-700">
+          Compose failed{failureStage(phase) ? ` at ${failureStage(phase)}` : ''}: {errorMsg}
+        </div>
+      )}
+
+      {status === 'cancelled' && (
+        <div className="mb-2 rounded bg-slate-100 p-2 text-xs text-slate-700">
+          Compose cancelled. The build was stopped and its mounts/loop devices were
+          torn down.
+        </div>
+      )}
+
+      {/* Teardown-residue warning: distinguish a cancellation-failure (the signal
+          didn't reach the build) from a cleanup-failure (ICT ran but left mounts /
+          loop devices behind), with the detail needed to remediate by hand. */}
+      {residual && (
+        <div className="mb-2 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-800">
+          <p className="font-semibold">
+            {residual.kind === 'cancellation-failure'
+              ? 'Cancellation failure — the build could not be signalled to stop.'
+              : 'Cleanup failure — teardown left resources behind.'}
+          </p>
+          <p className="mt-1">
+            Manual remediation may be required. Check for leftover mounts and loop
+            devices under the build work directory:
+          </p>
+          <pre className="mt-1 overflow-x-auto rounded bg-red-100 p-1.5 font-mono text-[11px]">
+            {details?.workDir
+              ? `mount | grep ${details.workDir}\nlosetup -l`
+              : 'mount | grep webui-workspace/builds/<id>\nlosetup -l'}
+          </pre>
+          <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-all rounded bg-red-100 p-1.5 font-mono text-[11px]">
+            {residual.detail}
+          </pre>
+        </div>
       )}
 
       {/* Collapsible troubleshoot panel: the exact command, the resolved template
@@ -334,7 +426,15 @@ export function BuildView({ buildId, onRetry, retrying, onStatusChange, isActive
 
       {artifacts.length > 0 && (
         <div className="mt-4">
-          <h3 className="mb-2 text-sm font-semibold text-[#00285a]">Artifacts</h3>
+          <h3 className="mb-2 text-sm font-semibold text-[#00285a]">
+            {status === 'failed' || status === 'cancelled' ? 'Partial artifacts' : 'Artifacts'}
+          </h3>
+          {(status === 'failed' || status === 'cancelled') && (
+            <p className="mb-2 text-xs text-slate-500">
+              These outputs were left on disk when the compose stopped early — they
+              are incomplete. Their on-disk location is shown below.
+            </p>
+          )}
           <table className="w-full border-collapse text-sm">
             <thead>
               <tr className="bg-[#e6f2fa] text-left">
@@ -419,6 +519,20 @@ function DownloadIcon({ className }: { className?: string }) {
       <line x1="12" y1="15" x2="12" y2="3" />
     </svg>
   )
+}
+
+// failureStage maps the last-known phase id to a human label so a failure can
+// name the stage it stopped at (ICT provides the reason; this provides the
+// stage). Returns '' for the terminal/unknown phases where a stage name adds
+// nothing.
+function failureStage(phase: string): string {
+  const labels: Record<string, string> = {
+    preparing: 'the Preparing stage',
+    packages: 'the package resolution/download stage',
+    installing: 'the package install stage',
+    generating: 'image generation',
+  }
+  return labels[phase] ?? ''
 }
 
 // Clean a raw log line for display:

--- a/web/src/components/HistorySidebar.tsx
+++ b/web/src/components/HistorySidebar.tsx
@@ -55,16 +55,21 @@ function combinationLabel(it: HistoryItem): string {
   return parts.join(' / ')
 }
 
+// One dot per server-side build state. Cancelling and cancelled need their own
+// colours: without them a cancelled build looked identical to an unknown status
+// and a cancel in progress looked like a finished one.
+const dotStyles: Record<string, string> = {
+  'not-started': 'bg-yellow-400 animate-pulse',
+  running: 'bg-yellow-400 animate-pulse',
+  cancelling: 'bg-amber-500 animate-pulse',
+  cancelled: 'bg-slate-400',
+  success: 'bg-green-400',
+  failed: 'bg-red-500',
+}
+
 function StatusDot({ status }: { status: string }) {
-  const cls =
-    status === 'running'
-      ? 'bg-yellow-400 animate-pulse'
-      : status === 'success'
-        ? 'bg-green-400'
-        : status === 'failed'
-          ? 'bg-red-500'
-          : 'bg-slate-300'
-  return <span className={`h-2 w-2 shrink-0 rounded-full ${cls}`} />
+  const cls = dotStyles[status] ?? 'bg-slate-300'
+  return <span title={status} className={`h-2 w-2 shrink-0 rounded-full ${cls}`} />
 }
 
 // relativeTime renders a compact "just now / 5m ago / 2h ago / 3d ago" label.


### PR DESCRIPTION
#### Merge Checklist

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description

Build lifecycle control: status, cancellation & guaranteed cleanup.

Adds a full six-state build lifecycle (not-started, running, cancelling, cancelled, success, failed) with user-driven cancellation and residual-cleanup reporting.

**Backend:**
- Spawn ICT in its own process group (`Setpgid`) so a cancel signals the whole child tree (sudo → ICT → helpers).
- `POST /builds/{id}/cancel`: running → cancelling, delivers SIGTERM to the group (via `sudo -n kill -TERM -<pgid>` under `--sudo`, direct otherwise), letting ICT run its own teardown and exit. Returns 202.
- Exit classification gated on cancel-requested: 130/143/137 and signal-terminated exits → cancelled; any other non-zero → failed.
- Single-build lock: one compose at a time; the slot is released only after the ICT child fully exits (post-teardown), so a second compose can't race cleanup.
- Residual reporting: cancellation-failure (signal never landed) vs cleanup-failure (ICT logged leftover mounts/loop devices), surfaced in build details + SSE.
- Partial artifacts surfaced with on-disk location on failed/cancelled composes.

**Frontend:**
- Cancel button + cancelling transient state; renders all six states.
- Surfaces failing stage/reason on failure and the residual remediation hint.

**Docs:** `web/README.md` documents the new scoped sudoers `kill` rule and the cross-sudo cancellation security posture.

Depends on ICT SIGTERM-handler/teardown/exit-130 support (open-edge-platform#763).

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

- **Unit tests** (`internal/api/builds_cancel_test.go`): exit-code classification, residual-cleanup log parsing, cancel-handler transitions (404/409/202), single-build lock, concurrent-start rejection. `go test ./internal/api/... ./cmd/image-composer-tool/...` passes; `go vet` and `gofmt` clean; frontend `tsc --noEmit` clean.
- **Integration** via a fake ICT that traps SIGTERM: verified clean cancel (running → cancelling → cancelled, exit 130, clean teardown), cancel with residual (cleanup-failure box with `losetup`/`mount` hints), genuine failure with partial artifact, single-build 409, and the SSE terminal payload (status/residual/artifacts). All exercised end-to-end in the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
