### PR TITLE
fix(logs): correct "Succesfully" typo in debug messages

### DIFF
--- a/internal/image/imageos/imageos.go
+++ b/internal/image/imageos/imageos.go
@@ -1434,7 +1434,7 @@ func buildImageUKI(installRoot string, template *config.ImageTemplate) error {
 		if err != nil {
 			return fmt.Errorf("failed to prepare ESP directory: %w", err)
 		}
-		log.Debugf("Succesfully Creating EspPath:", espDir)
+		log.Debugf("Successfully Creating EspPath:", espDir)
 
 		outputPath := filepath.Join(espDir, "EFI", "Linux", "linux.efi")
 		log.Debugf("UKI Path:", outputPath)

--- a/internal/image/imagesecure/imagesecure.go
+++ b/internal/image/imagesecure/imagesecure.go
@@ -46,19 +46,19 @@ func configOverlay(installRoot string) error {
 	if err != nil {
 		return fmt.Errorf("failed to prepare ESP directory: %w", err)
 	}
-	log.Debugf("Succesfully Creating Overlay Path:", ovlyDir)
+	log.Debugf("Successfully Creating Overlay Path:", ovlyDir)
 
 	err = updateImageFstab(installRoot, overlayDirs)
 	if err != nil {
 		return fmt.Errorf("failed to update fstab: %w", err)
 	}
-	log.Debugf("Succesfully Updating fstab for overlay")
+	log.Debugf("Successfully Updating fstab for overlay")
 
 	err = createOverlayMntSvc(installRoot, overlayDirs)
 	if err != nil {
 		return fmt.Errorf("failed to create overlay mounting service: %w", err)
 	}
-	log.Debugf("Succesfully Created overlay mounting service")
+	log.Debugf("Successfully Created overlay mounting service")
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Four `log.Debugf` calls in the overlay and UKI build paths spelled "Succesfully" — the messages appear verbatim in debug logs.
- No behavior change; log strings only.

## Files touched
- `internal/image/imagesecure/imagesecure.go` — 3 occurrences in `configOverlay`
- `internal/image/imageos/imageos.go` — 1 occurrence in `buildImageUKI`

## Test plan
- [ ] `earthly +lint`
- [ ] `earthly +test-quick`

_Sample PR to validate write access; happy to close if not wanted._