### PR TITLE
feat(overlay): wire overlay mode for Debian and reject it on create-o…

### DIFF
--- a/cmd/image-composer-tool/build.go
+++ b/cmd/image-composer-tool/build.go
@@ -278,9 +278,25 @@ func executeBuild(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	p, err := InitProvider(template.Target.OS, template.Target.Dist, template.Target.Arch)
+	p, err := initProvider(template.Target.OS, template.Target.Dist, template.Target.Arch)
 	if err != nil {
 		buildErr = fmt.Errorf("initializing provider failed: %v", err)
+		goto post
+	}
+
+	// Reject an overlay-mode template on a create-only provider before any work
+	// starts. A provider without an overlay branch would silently fall through to
+	// the create-mode pipeline, and template merging has already stripped the
+	// create-mode default package set from an overlay template (the baseline is
+	// expected to supply it) — so the build would either fail deep inside the
+	// image-assembly stages or emit an image missing its base toolchain, with the
+	// baseline never read at all. Fail here with an actionable message instead.
+	if template.IsOverlayMode() &&
+		!provider.SupportsOverlay(p, template.Target.Dist, template.Target.Arch) {
+		buildErr = fmt.Errorf("overlay mode (baseline.mode: %q) is not supported for target %s/%s/%s: "+
+			"this provider only supports create-mode builds; remove the baseline and overlayPolicy "+
+			"sections to build from scratch, or target a provider with overlay support",
+			config.BaselineModeOverlay, template.Target.OS, template.Target.Dist, template.Target.Arch)
 		goto post
 	}
 
@@ -310,7 +326,16 @@ post:
 		restorePostRun()
 		restorePostShell()
 		postCancel()
-		if postErr != nil {
+		// Some providers' PostProcess (azl, emt, rcd) return the exact buildErr value
+		// they were handed back to the caller once cleanup succeeded. Relabelling that
+		// as "post-processing failed" would misattribute the original build failure to
+		// cleanup, so suppress only that passthrough. The comparison is by identity,
+		// NOT errors.Is: overlay.Builder.Postprocess returns errors.Join(buildErr,
+		// cleanupErr) when cleanup fails after a failed build, and errors.Is would walk
+		// that joined tree, match buildErr and silently drop the cleanup failure —
+		// hiding a leaked mount/loop device. Identity matches the passthrough exactly
+		// while still surfacing any error the provider added to buildErr.
+		if postErr != nil && postErr != buildErr { //nolint:errorlint // identity is intentional; see above
 			// In --no-cache mode the deferred cleanup would otherwise remove the unique
 			// workspace on return, discarding a successfully built image. Preserve it so
 			// the image (and any state needed for recovery) survives a PostProcess failure.
@@ -423,6 +448,12 @@ func displayImageBuildTiming(imageType string, template *config.ImageTemplate) {
 		convertImageFileToFinishDuration,
 	)
 }
+
+// initProvider is the seam executeBuild resolves its provider through. It points
+// at InitProvider in production; tests substitute a fake so the phases that run
+// before any provider work — notably the overlay-capability gate — are
+// exercisable without the network and disk I/O the real Init performs.
+var initProvider = InitProvider
 
 func InitProvider(os, dist, arch string) (provider.Provider, error) {
 	var p provider.Provider

--- a/cmd/image-composer-tool/build_overlay_gate_test.go
+++ b/cmd/image-composer-tool/build_overlay_gate_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/provider"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
+)
+
+// gateFakeProvider is a create-only provider: it deliberately does NOT implement
+// provider.OverlayCapable, so provider.SupportsOverlay reports false for it. It
+// records whether the phases the capability gate is supposed to prevent were
+// entered, and lets a test dictate what PostProcess returns.
+type gateFakeProvider struct {
+	os, dist, arch string
+
+	preEntered   bool
+	buildEntered bool
+	postEntered  bool
+
+	postBuildErr error // buildErr as PostProcess received it
+	postResult   func(buildErr error) error
+}
+
+func (f *gateFakeProvider) Name(dist, arch string) string {
+	return system.GetProviderId(f.os, dist, arch)
+}
+
+func (f *gateFakeProvider) Init(dist, arch string) error { return nil }
+
+func (f *gateFakeProvider) PreProcess(t *config.ImageTemplate) error {
+	f.preEntered = true
+	return nil
+}
+
+func (f *gateFakeProvider) BuildImage(t *config.ImageTemplate) error {
+	f.buildEntered = true
+	return nil
+}
+
+func (f *gateFakeProvider) PostProcess(t *config.ImageTemplate, buildErr error) error {
+	f.postEntered = true
+	f.postBuildErr = buildErr
+	if f.postResult != nil {
+		return f.postResult(buildErr)
+	}
+	return buildErr // azl/emt/rcd-style passthrough on successful cleanup
+}
+
+// compile-time guard: the fake must stay create-only for these tests to mean
+// anything. If provider.OverlayCapable is ever satisfied incidentally (e.g. a
+// SupportsOverlay method is added to the Provider interface itself), this test
+// file should fail to express its intent loudly rather than silently pass.
+func TestGateFakeProviderIsCreateOnly(t *testing.T) {
+	var p provider.Provider = &gateFakeProvider{}
+	if _, ok := p.(provider.OverlayCapable); ok {
+		t.Fatal("gateFakeProvider must not implement provider.OverlayCapable")
+	}
+	if provider.SupportsOverlay(p, "ubuntu24", "x86_64") {
+		t.Fatal("provider.SupportsOverlay must report false for a create-only provider")
+	}
+}
+
+// withFakeProvider swaps the initProvider seam for the duration of a test so the
+// capability gate can be exercised without the network and disk I/O the real
+// provider Init performs.
+func withFakeProvider(t *testing.T, f *gateFakeProvider) {
+	t.Helper()
+	orig := initProvider
+	initProvider = func(os, dist, arch string) (provider.Provider, error) {
+		f.os, f.dist, f.arch = os, dist, arch
+		return f, nil
+	}
+	t.Cleanup(func() { initProvider = orig })
+}
+
+// createOverlayTestTemplate writes a minimal overlay-mode template targeting the
+// given OS/dist/arch, with a real (empty) file as the baseline source so template
+// loading and validation succeed and the build reaches the capability gate.
+func createOverlayTestTemplate(t *testing.T, osName, dist, arch string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	baseline := filepath.Join(tmpDir, "baseline.raw")
+	if err := os.WriteFile(baseline, []byte("not-a-real-image"), 0o644); err != nil {
+		t.Fatalf("failed to create baseline stub: %v", err)
+	}
+
+	templatePath := filepath.Join(tmpDir, "overlay-template.yml")
+	templateContent := "image:\n" +
+		"  name: \"overlay-test-image\"\n" +
+		"  version: \"1.0.0\"\n" +
+		"\n" +
+		"target:\n" +
+		"  os: \"" + osName + "\"\n" +
+		"  dist: \"" + dist + "\"\n" +
+		"  arch: \"" + arch + "\"\n" +
+		"  imageType: \"raw\"\n" +
+		"\n" +
+		"baseline:\n" +
+		"  mode: overlay\n" +
+		"  source:\n" +
+		"    path: \"" + baseline + "\"\n" +
+		"    format: raw\n" +
+		"\n" +
+		"systemConfig:\n" +
+		"  packages:\n" +
+		"    - \"bash\"\n"
+
+	if err := os.WriteFile(templatePath, []byte(templateContent), 0o644); err != nil {
+		t.Fatalf("failed to create overlay test template: %v", err)
+	}
+	return templatePath
+}
+
+// TestExecuteBuild_OverlayOnCreateOnlyProviderFailsFast asserts the capability
+// gate in executeBuild rejects an overlay-mode template aimed at a provider that
+// does not implement provider.OverlayCapable, with an actionable message, and
+// crucially that it does so BEFORE entering the provider's PreProcess/BuildImage.
+// Without the gate the build would fall through to the create-mode pipeline on a
+// package list that template merging already stripped, producing either a failure
+// deep in image assembly or an image missing its base toolchain.
+func TestExecuteBuild_OverlayOnCreateOnlyProviderFailsFast(t *testing.T) {
+	defer resetBuildFlags()
+
+	fake := &gateFakeProvider{}
+	withFakeProvider(t, fake)
+
+	tmpl := createOverlayTestTemplate(t, "ubuntu", "ubuntu24", "x86_64")
+
+	cmd := createBuildCommand()
+	err := executeBuild(cmd, []string{tmpl})
+	if err == nil {
+		t.Fatal("expected executeBuild to fail for an overlay template on a create-only provider")
+	}
+
+	// The message must name overlay mode and point at a remedy — this is the
+	// user-facing contract that replaces the silent create-mode fallback.
+	for _, want := range []string{"overlay mode", "only supports create-mode"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q; got: %v", want, err)
+		}
+	}
+
+	// The whole point of the gate is that no build work starts.
+	if fake.preEntered {
+		t.Error("PreProcess was entered; the gate must reject before pre-processing")
+	}
+	if fake.buildEntered {
+		t.Error("BuildImage was entered; the gate must reject before the build")
+	}
+
+	// PostProcess still runs (via the goto post path) so cleanup is not skipped,
+	// and it must receive the gate's error as the incoming buildErr.
+	if !fake.postEntered {
+		t.Error("PostProcess was not entered; cleanup must still run after the gate rejects")
+	}
+	if fake.postBuildErr == nil {
+		t.Error("PostProcess should have received the gate error as buildErr")
+	}
+}
+
+// TestExecuteBuild_PostProcessErrorClassification covers how executeBuild
+// classifies what PostProcess returns. The distinction matters because two
+// providers behave differently on a failed build:
+//
+//   - azl/emt/rcd hand the exact buildErr value straight back once cleanup
+//     succeeded; relabelling that as "post-processing failed" would misattribute
+//     a build failure to cleanup.
+//   - overlay.Builder.Postprocess returns errors.Join(buildErr, cleanupErr) when
+//     cleanup fails after a failed build, so the caller sees both the root cause
+//     and the leaked mount/loop device.
+//
+// An errors.Is check cannot tell these apart: it walks the joined tree, matches
+// buildErr and drops the cleanup failure. Identity comparison distinguishes them.
+func TestExecuteBuild_PostProcessErrorClassification(t *testing.T) {
+	t.Run("identical buildErr passthrough is not relabelled as post-processing failure", func(t *testing.T) {
+		defer resetBuildFlags()
+
+		fake := &gateFakeProvider{
+			// azl/emt/rcd behavior: return the received buildErr unchanged.
+			postResult: func(buildErr error) error { return buildErr },
+		}
+		withFakeProvider(t, fake)
+
+		tmpl := createOverlayTestTemplate(t, "ubuntu", "ubuntu24", "x86_64")
+		err := executeBuild(createBuildCommand(), []string{tmpl})
+		if err == nil {
+			t.Fatal("expected the underlying build error to be returned")
+		}
+		if strings.Contains(err.Error(), "post-processing failed") {
+			t.Errorf("passthrough buildErr must not be relabelled as a post-processing failure; got: %v", err)
+		}
+		// The original cause must survive intact.
+		if !strings.Contains(err.Error(), "overlay mode") {
+			t.Errorf("expected the original build error to be surfaced; got: %v", err)
+		}
+	})
+
+	t.Run("joined build and cleanup error surfaces the cleanup failure", func(t *testing.T) {
+		defer resetBuildFlags()
+
+		cleanupErr := errors.New("leaked loop device /dev/loop7")
+		fake := &gateFakeProvider{
+			// overlay.Builder.Postprocess behavior on build-failed + cleanup-failed.
+			postResult: func(buildErr error) error {
+				return errors.Join(buildErr, fmt.Errorf("overlay postprocess: cleanup failed: %w", cleanupErr))
+			},
+		}
+		withFakeProvider(t, fake)
+
+		tmpl := createOverlayTestTemplate(t, "ubuntu", "ubuntu24", "x86_64")
+		err := executeBuild(createBuildCommand(), []string{tmpl})
+		if err == nil {
+			t.Fatal("expected an error combining the build failure and the cleanup failure")
+		}
+		// This is the assertion that fails against an errors.Is check: the joined
+		// error would be treated as "just the build error" and returned unlabelled,
+		// hiding the leak.
+		if !strings.Contains(err.Error(), "post-processing failed") {
+			t.Errorf("a joined build+cleanup error must be surfaced as a post-processing failure; got: %v", err)
+		}
+		if !errors.Is(err, cleanupErr) {
+			t.Errorf("the cleanup error must remain matchable via errors.Is; got: %v", err)
+		}
+	})
+}

--- a/docs/user-guide/architecture/image-composer-tool-templates.md
+++ b/docs/user-guide/architecture/image-composer-tool-templates.md
@@ -240,7 +240,8 @@ For a complete Ubuntu 24 WSL example, see
 Selects how the image is assembled. If omitted, the build defaults to **create**
 mode (build the image from scratch, the behavior described everywhere else in
 this reference). Set `mode: overlay` to instead layer packages onto an existing
-baseline RAW disk image without rebuilding it.
+baseline disk image without rebuilding it. The baseline may be a RAW image or a
+qcow2/vhd/vhdx image, which is converted to RAW before the overlay runs.
 
 | Field | Type | Required | Valid Values | Description |
 |-------|------|----------|--------------|-------------|
@@ -249,15 +250,15 @@ baseline RAW disk image without rebuilding it.
 
 #### `baseline.source`
 
-Identifies the baseline RAW image. Exactly one of `path` or `url` must be set.
+Identifies the baseline image. Exactly one of `path` or `url` must be set.
 The source is copied into the build workspace first and is **never modified in
 place**.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `path` | string | one of `path`/`url` | Local filesystem path to the baseline RAW image (no URI scheme) |
-| `url` | string | one of `path`/`url` | `https://` URL of the baseline RAW image; downloaded over TLS before the overlay runs (plain `http` is rejected) |
-| `format` | string | No | Baseline image format. Only `raw` is supported (default `raw`) |
+| `path` | string | one of `path`/`url` | Local filesystem path to the baseline image (no URI scheme) |
+| `url` | string | one of `path`/`url` | `https://` URL of the baseline image; downloaded over TLS before the overlay runs (plain `http` is rejected) |
+| `format` | string | No | Baseline image format: `raw`, `qcow2`, `vhd` or `vhdx` (default `raw`). Non-raw formats are converted to RAW before the overlay runs |
 
 ```yaml
 baseline:
@@ -267,8 +268,10 @@ baseline:
     format: raw
 ```
 
-> **Note:** Overlay mode is currently wired end-to-end for the **Ubuntu**
-> provider. The overlay build is **strictly additive**: packages (and their
+> **Note:** Overlay mode is currently wired end-to-end for the **Ubuntu** and
+> **Debian** providers. Targeting a provider without overlay support fails the
+> build immediately with a clear message rather than silently falling back to a
+> create-mode build. The overlay build is **strictly additive**: packages (and their
 > transitive dependencies not already present in the baseline) are installed
 > into the baseline root, the initramfs is regenerated for the added packages,
 > and an optional grow-only resize can enlarge the image to a larger

--- a/internal/provider/debian13/debian13.go
+++ b/internal/provider/debian13/debian13.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/config"
 	"github.com/open-edge-platform/image-composer-tool/internal/image/initrdmaker"
 	"github.com/open-edge-platform/image-composer-tool/internal/image/isomaker"
+	"github.com/open-edge-platform/image-composer-tool/internal/image/overlay"
 	"github.com/open-edge-platform/image-composer-tool/internal/image/rawmaker"
 	"github.com/open-edge-platform/image-composer-tool/internal/image/wsl2maker"
 	"github.com/open-edge-platform/image-composer-tool/internal/ospackage/debutils"
@@ -31,6 +32,11 @@ var log = logger.Logger()
 type debian13 struct {
 	repoCfgs  []debutils.RepoConfig
 	chrootEnv chroot.ChrootEnvInterface
+	// overlayBuilder holds the overlay-mode build lifecycle when the template is
+	// in overlay mode. It is created in PreProcess and reused across BuildImage and
+	// PostProcess so the single baseline mount spans all three phases. It is nil for
+	// ordinary create-mode builds, which take the unchanged maker path.
+	overlayBuilder *overlay.Builder
 }
 
 func Register(targetOs, targetDist, targetArch string) error {
@@ -48,6 +54,13 @@ func Register(targetOs, targetDist, targetArch string) error {
 // Name returns the unique name of the provider
 func (p *debian13) Name(dist, arch string) string {
 	return system.GetProviderId(OsName, dist, arch)
+}
+
+// SupportsOverlay implements provider.OverlayCapable: every Debian target routes
+// overlay-mode templates through the overlay pipeline (see overlayPreProcess,
+// overlayBuildImage and overlayPostProcess).
+func (p *debian13) SupportsOverlay(_, _ string) bool {
+	return true
 }
 
 // Init will initialize the provider, fetching repo configuration
@@ -76,6 +89,13 @@ func (p *debian13) Init(dist, arch string) error {
 }
 
 func (p *debian13) PreProcess(template *config.ImageTemplate) error {
+	// Overlay mode takes a separate, baseline-driven pipeline that keeps a single
+	// mount lifecycle open across preprocess and build; create mode falls through
+	// to the unchanged package-download + chroot-init flow below.
+	if template.IsOverlayMode() {
+		return p.overlayPreProcess(template)
+	}
+
 	// Generate apt sources file from packageRepositories
 	if err := template.GenerateAptSourcesFromRepositories(); err != nil {
 		return fmt.Errorf("failed to generate apt sources from repositories: %w", err)
@@ -105,6 +125,10 @@ func (p *debian13) PreProcess(template *config.ImageTemplate) error {
 func (p *debian13) BuildImage(template *config.ImageTemplate) error {
 	if template == nil {
 		return fmt.Errorf("template cannot be nil")
+	}
+
+	if template.IsOverlayMode() {
+		return p.overlayBuildImage(template)
 	}
 
 	log.Infof("Building image: %s", template.GetImageName())
@@ -224,11 +248,88 @@ func (p *debian13) buildIsoImage(template *config.ImageTemplate) error {
 }
 
 func (p *debian13) PostProcess(template *config.ImageTemplate, err error) error {
+	if template.IsOverlayMode() {
+		return p.overlayPostProcess(template, err)
+	}
+
 	if err := p.chrootEnv.CleanupChrootEnv(template.Target.OS,
 		template.Target.Dist, template.Target.Arch); err != nil {
 		return fmt.Errorf("failed to cleanup chroot environment: %w", err)
 	}
 	return nil
+}
+
+// overlayPreProcess runs the overlay-mode preprocess phase: it creates the overlay
+// Builder (which gates on overlay mode) and runs its Preprocess, which copies and
+// mounts the baseline, inspects it, resolves the requested packages, and runs the
+// preflight policy gate. The Builder is retained on the provider so BuildImage and
+// PostProcess reuse the same open mount lifecycle.
+func (p *debian13) overlayPreProcess(template *config.ImageTemplate) error {
+	builder, err := overlay.NewBuilder(template)
+	if err != nil {
+		return fmt.Errorf("failed to create overlay builder: %w", err)
+	}
+	p.overlayBuilder = builder
+
+	if err := builder.Preprocess(); err != nil {
+		return fmt.Errorf("overlay pre-processing failed: %w", err)
+	}
+	return nil
+}
+
+// overlayBuildImage runs the overlay-mode build phase against the baseline mounted
+// in preprocess: install the approved package plan, regenerate the initramfs for
+// added packages (never the bootloader), and apply any grow-only resize.
+func (p *debian13) overlayBuildImage(template *config.ImageTemplate) error {
+	if p.overlayBuilder == nil {
+		return fmt.Errorf("overlay build invoked without a preprocessed overlay builder")
+	}
+	log.Infof("Building overlay image: %s", template.GetImageName())
+	if err := p.overlayBuilder.Build(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// overlayPostProcess runs the overlay-mode postprocess phase: generate the SBOM,
+// emit the final RAW artifact, and ALWAYS unmount/detach the baseline. buildErr is
+// threaded in so a failed build still triggers the full cleanup chain. When
+// preprocess never created a builder (it failed early), there is nothing to clean.
+func (p *debian13) overlayPostProcess(template *config.ImageTemplate, buildErr error) error {
+	if p.overlayBuilder == nil {
+		return nil
+	}
+	// Clear the retained builder once postprocess has run (success or failure) so it
+	// cannot be accidentally reused across builds and its retained state (paths,
+	// plan, report, mount lifecycle) can be garbage-collected promptly.
+	builder := p.overlayBuilder
+	defer func() { p.overlayBuilder = nil }()
+	if err := builder.Postprocess(buildErr); err != nil {
+		return fmt.Errorf("overlay post-processing failed: %w", err)
+	}
+
+	// The overlay pipeline does not run through the create-mode maker/chroot stages
+	// that populate the template build timers, so print the overlay's own per-stage
+	// timing table. Only on a clean build — a failed run's partial timings would be
+	// misleading. The generic build-timing table (all zeros for overlay) is skipped
+	// upstream in the same success path.
+	if buildErr == nil {
+		printOverlayTiming(builder.Timings())
+	}
+	return nil
+}
+
+// printOverlayTiming renders the overlay Builder's per-stage timings as a timing
+// table. It is a no-op when no stages were recorded.
+func printOverlayTiming(timings []overlay.StageTiming) {
+	if len(timings) == 0 {
+		return
+	}
+	rows := make([]display.TimingRow, 0, len(timings))
+	for _, t := range timings {
+		rows = append(rows, display.TimingRow{Stage: t.Stage, Duration: t.Duration})
+	}
+	display.PrintTimingTable("Overlay Build Timings", rows)
 }
 
 func (p *debian13) installHostDependency() error {

--- a/internal/provider/debian13/debian13_test.go
+++ b/internal/provider/debian13/debian13_test.go
@@ -2196,3 +2196,57 @@ func TestBuildUserRepoListFieldMapping(t *testing.T) {
 		t.Errorf("ID: expected %q, got %q", expectedID, r.ID)
 	}
 }
+
+// TestDebian13OverlayCapable asserts the provider advertises overlay support via
+// provider.OverlayCapable. Without it, build's capability gate rejects overlay
+// templates for every Debian target, and template merging has already stripped
+// the create-mode default package set — so a regression here is silent.
+func TestDebian13OverlayCapable(t *testing.T) {
+	var _ provider.OverlayCapable = (*debian13)(nil) // Compile-time capability check
+
+	debian := &debian13{}
+	if !provider.SupportsOverlay(debian, "debian13", "amd64") {
+		t.Error("Expected debian13 provider to report overlay support")
+	}
+}
+
+// TestDebian13OverlayBuildImageWithoutPreprocess asserts BuildImage refuses to run
+// an overlay build when PreProcess never established the baseline mount lifecycle,
+// rather than falling through to the create-mode maker path.
+func TestDebian13OverlayBuildImageWithoutPreprocess(t *testing.T) {
+	debian := &debian13{}
+	template := createTestImageTemplate()
+	template.Baseline = &config.Baseline{
+		Mode:   config.BaselineModeOverlay,
+		Source: &config.BaselineSource{Path: "/nonexistent/baseline.raw"},
+	}
+
+	err := debian.BuildImage(template)
+	if err == nil {
+		t.Fatal("Expected an error when overlay BuildImage runs without a preprocessed builder")
+	}
+	if !strings.Contains(err.Error(), "without a preprocessed overlay builder") {
+		t.Errorf("Expected preprocessed-builder error, got: %v", err)
+	}
+}
+
+// TestDebian13OverlayPostProcessWithoutBuilder asserts overlay postprocess is a
+// no-op when preprocess failed early and never created a builder — it must not
+// fall through to create-mode chroot cleanup that was never set up.
+func TestDebian13OverlayPostProcessWithoutBuilder(t *testing.T) {
+	debian := &debian13{}
+	template := createTestImageTemplate()
+	template.Baseline = &config.Baseline{
+		Mode:   config.BaselineModeOverlay,
+		Source: &config.BaselineSource{Path: "/nonexistent/baseline.raw"},
+	}
+
+	if err := debian.PostProcess(template, nil); err != nil {
+		t.Errorf("Expected nil from overlay PostProcess with no builder, got: %v", err)
+	}
+
+	// Same on the failure path: a build error must not turn cleanup into an error.
+	if err := debian.PostProcess(template, fmt.Errorf("build failed")); err != nil {
+		t.Errorf("Expected nil from overlay PostProcess with no builder on error path, got: %v", err)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,30 @@ type Provider interface {
 	PostProcess(template *config.ImageTemplate, err error) error
 }
 
+// OverlayCapable is implemented by providers that route overlay-mode templates
+// (baseline.mode: overlay) through the overlay pipeline in all three phases.
+//
+// Overlay mode is not a no-op for a provider that ignores it: template merging
+// strips the create-mode default package set from an overlay template (the
+// baseline is expected to already provide it), so a provider without an overlay
+// branch would build a create-mode image from a crippled package list instead of
+// layering onto the baseline. Declaring the capability explicitly lets the build
+// entry point reject that combination up front rather than emit a broken image.
+type OverlayCapable interface {
+	Provider
+
+	// SupportsOverlay reports whether this provider implements the overlay-mode
+	// pipeline for the given target.
+	SupportsOverlay(dist, arch string) bool
+}
+
+// SupportsOverlay reports whether p can build overlay-mode templates for the
+// given target. Providers that do not implement OverlayCapable are create-only.
+func SupportsOverlay(p Provider, dist, arch string) bool {
+	capable, ok := p.(OverlayCapable)
+	return ok && capable.SupportsOverlay(dist, arch)
+}
+
 var (
 	providers = make(map[string]Provider)
 )

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -52,6 +52,17 @@ func (m *MockProvider) PostProcess(template *config.ImageTemplate, err error) er
 	return nil
 }
 
+// MockOverlayProvider embeds MockProvider and adds the OverlayCapable method so
+// the capability probe can be exercised for both answers.
+type MockOverlayProvider struct {
+	MockProvider
+	supports bool
+}
+
+func (m *MockOverlayProvider) SupportsOverlay(_, _ string) bool {
+	return m.supports
+}
+
 // Helper function to create a test ImageTemplate
 func createTestImageTemplate() *config.ImageTemplate {
 	return &config.ImageTemplate{
@@ -465,4 +476,45 @@ func TestProviderWorkflow(t *testing.T) {
 			t.Errorf("Call %d: expected %s, got %s", i, expected, callLog[i])
 		}
 	}
+}
+
+// TestSupportsOverlay covers the capability probe: a provider that does not
+// implement OverlayCapable is create-only, and one that does answers for itself.
+func TestSupportsOverlay(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider Provider
+		want     bool
+	}{
+		{
+			name:     "provider without OverlayCapable is create-only",
+			provider: &MockProvider{},
+			want:     false,
+		},
+		{
+			name:     "OverlayCapable provider reporting support",
+			provider: &MockOverlayProvider{supports: true},
+			want:     true,
+		},
+		{
+			name:     "OverlayCapable provider declining support",
+			provider: &MockOverlayProvider{supports: false},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SupportsOverlay(tt.provider, "azl3", "amd64"); got != tt.want {
+				t.Errorf("SupportsOverlay() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOverlayCapableInterface is a compile-time check that the mock satisfies
+// both interfaces, so OverlayCapable stays a superset of Provider.
+func TestOverlayCapableInterface(t *testing.T) {
+	var _ Provider = (*MockOverlayProvider)(nil)
+	var _ OverlayCapable = (*MockOverlayProvider)(nil)
 }

--- a/internal/provider/ubuntu/ubuntu.go
+++ b/internal/provider/ubuntu/ubuntu.go
@@ -56,6 +56,13 @@ func (p *ubuntu) Name(dist, arch string) string {
 	return system.GetProviderId(OsName, dist, arch)
 }
 
+// SupportsOverlay implements provider.OverlayCapable: every Ubuntu target routes
+// overlay-mode templates through the overlay pipeline (see overlayPreProcess,
+// overlayBuildImage and overlayPostProcess).
+func (p *ubuntu) SupportsOverlay(_, _ string) bool {
+	return true
+}
+
 // Init will initialize the provider, fetching repo configuration
 func (p *ubuntu) Init(dist, arch string) error {
 

--- a/internal/provider/ubuntu/ubuntu_test.go
+++ b/internal/provider/ubuntu/ubuntu_test.go
@@ -2569,3 +2569,15 @@ func TestBuildUserRepoListSkipsPathOnlyRepos(t *testing.T) {
 		t.Errorf("expected codename %q, got %q", "noble", result[0].Codename)
 	}
 }
+
+// TestUbuntuOverlayCapable asserts the provider advertises overlay support via
+// provider.OverlayCapable, which is what build's capability gate probes before
+// letting an overlay-mode template through.
+func TestUbuntuOverlayCapable(t *testing.T) {
+	var _ provider.OverlayCapable = (*ubuntu)(nil) // Compile-time capability check
+
+	u := &ubuntu{}
+	if !provider.SupportsOverlay(u, "ubuntu24", "amd64") {
+		t.Error("Expected ubuntu provider to report overlay support")
+	}
+}


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

An overlay-mode template (`baseline.mode: overlay`) targeting Debian silently built a **create-mode** image: `internal/provider/debian13` had no overlay branch, so all three phases fell through to the maker path.

That is worse than a no-op. Template merging strips the create-mode default package set from an overlay template on the assumption the baseline supplies it — so the build ran from scratch with a crippled package list, never read the baseline at all, and died deep in image assembly while configuring the UKI.

Two changes, so this cannot recur silently for any provider:

**1. Debian overlay support** — `debian13` now routes overlay-mode templates through the overlay pipeline in `PreProcess`, `BuildImage` and `PostProcess`, mirroring the ubuntu provider. A single baseline mount lifecycle spans all three phases.

**2. Explicit capability, checked up front** — new `provider.OverlayCapable` interface (`SupportsOverlay(dist, arch)`) plus a `provider.SupportsOverlay` probe. Providers that do not implement it are create-only by definition. `build.go` now rejects an overlay template on a create-only provider *before any work starts*, with an actionable message naming the target and telling the user how to proceed:

```
overlay mode (baseline.mode: "overlay") is not supported for target <os>/<dist>/<arch>:
this provider only supports create-mode builds; remove the baseline and overlayPolicy
sections to build from scratch, or target a provider with overlay support
```

**Drive-by fix (pre-existing mislabelling)** — `azl`, `emt` and `rcd` `PostProcess` return the `buildErr` they were handed, which the caller re-wrapped as `"post-processing failed"`, misattributing a build failure to cleanup. Only a `postErr` that is not the *exact* incoming `buildErr` value is now treated as a cleanup failure.

The comparison is by identity (`postErr != buildErr`) rather than `errors.Is`, deliberately: `overlay.Builder.Postprocess` returns `errors.Join(buildErr, cleanupErr)` when cleanup fails after a failed build, so the caller sees both the root cause and the leaked mount/loop device. `errors.Is` would walk that joined tree, match `buildErr`, and silently drop the cleanup failure on exactly the "build failed **and** cleanup also failed" path. Identity matches the azl/emt/rcd passthrough precisely while still surfacing anything a provider added.

**Docs** — record Debian alongside Ubuntu as overlay-capable, and correct the baseline format row, which claimed `raw` was the only supported format when `qcow2`, `vhd` and `vhdx` are converted to raw before the overlay runs.

No behaviour change for existing create-mode builds, and none for Ubuntu overlay builds beyond declaring the capability it already had.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

**Unit tests** — `go test ./internal/provider/...`, covering:

| Test | Covers |
| --- | --- |
| `TestDebian13OverlayCapable` | debian13 satisfies `OverlayCapable` and reports overlay support for its targets |
| `TestDebian13OverlayBuildImageWithoutPreprocess` | `BuildImage` in overlay mode fails cleanly when the baseline mount lifecycle was never started |
| `TestDebian13OverlayPostProcessWithoutBuilder` | `PostProcess` in overlay mode is safe when no overlay builder exists |
| `TestSupportsOverlay` | the `SupportsOverlay` probe: capable provider, create-only provider, unsupported target |
| `TestOverlayCapableInterface` | `OverlayCapable` embeds `Provider`, so a capable provider is still usable everywhere |
| `TestUbuntuOverlayCapable` | ubuntu declares the capability it already implemented (no regression) |
| `TestExecuteBuild_OverlayOnCreateOnlyProviderFailsFast` | cmd-level: an overlay template on a create-only provider makes `executeBuild` fail with the actionable message, and neither `PreProcess` nor `BuildImage` is entered |
| `TestExecuteBuild_PostProcessErrorClassification` | cmd-level: an identical-`buildErr` passthrough is not relabelled as a post-process failure, while a joined `errors.Join(buildErr, cleanupErr)` (the overlay cleanup-failure contract) is surfaced with both the root cause and the leaked-device error preserved |

**Manual** — an overlay-mode Debian 13 template (`baseline.mode: overlay`, qcow2 baseline) that previously fell through to the create-mode maker path and died while configuring the UKI now routes through the overlay pipeline, with a single baseline mount lifecycle spanning `PreProcess` → `BuildImage` → `PostProcess`.

**Rejection path** — the same overlay template against a create-only provider now fails immediately with the message above, before any workspace or image work begins, instead of degrading to a create-mode build.


