### PR TITLE
Fix/web UI history and iso docs

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -32,6 +32,16 @@ action fails). See step 2 for the full frontend+binary build; the short version:
 go build -o ./build/image-composer-tool ./cmd/image-composer-tool/
 ```
 
+> **ISO images require the `live-installer` binary.** Build it before starting
+> an ISO build from the UI, otherwise ISO composes fail immediately with a
+> missing-prerequisite error:
+>
+> ```bash
+> go build -buildmode=pie -o ./build/live-installer ./cmd/live-installer
+> ```
+>
+> If you use `earthly +build`, both binaries are built automatically.
+
 ### 2. Grant scoped, passwordless sudo rules (automated)
 
 The server performs exactly three privileged operations via `sudo -n`: **build**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,7 +49,7 @@ export default function App() {
     if (state !== 'ready') return
     api
       .listBuilds()
-      .then((builds) => {
+      .then(({ builds }) => {
         const active = builds.find((b) => isActiveStatus(b.status))
         if (active) {
           setBuildId(active.id)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,12 @@ import type {
 const BASE = '/api/v1'
 
 async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await jsonFetchRaw(path, init)
+  return res.json() as Promise<T>
+}
+
+// jsonFetchRaw is jsonFetch but returns the raw Response so callers can inspect headers.
+async function jsonFetchRaw(path: string, init?: RequestInit): Promise<Response> {
   const res = await fetch(BASE + path, {
     ...init,
     headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
@@ -28,7 +34,7 @@ async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
     }
     throw new Error(msg)
   }
-  return res.json() as Promise<T>
+  return res
 }
 
 export const api = {
@@ -47,8 +53,15 @@ export const api = {
     }),
 
   // Compose history, newest-first (merges live builds + on-disk meta records).
-  listBuilds: () =>
-    jsonFetch<{ builds: HistoryItem[] }>('/builds').then((r) => r.builds),
+  // Also returns the server↔browser clock offset for correcting elapsed-time labels.
+  listBuilds: async (): Promise<{ builds: HistoryItem[]; clockOffsetMs: number }> => {
+    const res = await jsonFetchRaw('/builds')
+    const dateHeader = res.headers.get('Date')
+    const serverNow = dateHeader ? new Date(dateHeader).getTime() : NaN
+    const clockOffsetMs = Number.isFinite(serverNow) ? serverNow - Date.now() : 0
+    const body = (await res.json()) as { builds: HistoryItem[] }
+    return { builds: body.builds, clockOffsetMs }
+  },
 
   // Cancel an in-flight build. Returns 202 with the cancelling status; the
   // terminal state (cancelled/failed) then arrives over SSE. 409 if the build is

--- a/web/src/components/BuildImagePage.tsx
+++ b/web/src/components/BuildImagePage.tsx
@@ -34,10 +34,12 @@ export function BuildImagePage({
   // Which build is shown on the right. Defaults to the active build; clicking a
   // history row overrides it.
   const [selectedId, setSelectedId] = useState<string | null>(buildId)
+  const [clockOffsetMs, setClockOffsetMs] = useState(0)
 
   const refresh = useCallback(() => {
-    return api.listBuilds().then((builds) => {
+    return api.listBuilds().then(({ builds, clockOffsetMs }) => {
       setHistory(builds)
+      setClockOffsetMs(clockOffsetMs)
       return builds
     }).catch(() => [] as HistoryItem[])
   }, [])
@@ -80,7 +82,12 @@ export function BuildImagePage({
       <h1 className="mb-4 text-2xl font-bold text-[#00285a]">Compose Image</h1>
       {selectedId ? (
         <div className="flex gap-4">
-          <HistorySidebar items={history} selectedId={selectedId} onSelect={setSelectedId} />
+          <HistorySidebar
+            items={history}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+            clockOffsetMs={clockOffsetMs}
+          />
           <div className="min-w-0 flex-1">
             <BuildView
               key={selectedId}

--- a/web/src/components/HistorySidebar.tsx
+++ b/web/src/components/HistorySidebar.tsx
@@ -1,14 +1,26 @@
+import { useEffect, useState } from 'react'
 import type { HistoryItem } from '../api/types'
 
 interface HistorySidebarProps {
   items: HistoryItem[]
   selectedId: string | null
   onSelect: (id: string) => void
+  clockOffsetMs?: number
 }
 
 // Left-hand compose history list inside the Compose Image tab. Newest first;
 // each row shows a status dot, template name, and vertical · relative time.
-export function HistorySidebar({ items, selectedId, onSelect }: HistorySidebarProps) {
+export function HistorySidebar({
+  items,
+  selectedId,
+  onSelect,
+  clockOffsetMs = 0,
+}: HistorySidebarProps) {
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    const t = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(t)
+  }, [])
   return (
     <div className="w-64 shrink-0 border-r border-slate-200 pr-3">
       <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
@@ -34,7 +46,7 @@ export function HistorySidebar({ items, selectedId, onSelect }: HistorySidebarPr
                   <span className="truncate font-medium">{combinationLabel(it)}</span>
                 </div>
                 <div className="mt-0.5 pl-3 text-[11px] text-slate-400">
-                  {relativeTime(it.createdAt)}
+                  {relativeTime(it.createdAt, nowMs + clockOffsetMs)}
                 </div>
               </button>
             </li>
@@ -73,10 +85,10 @@ function StatusDot({ status }: { status: string }) {
 }
 
 // relativeTime renders a compact "just now / 5m ago / 2h ago / 3d ago" label.
-function relativeTime(iso: string): string {
+function relativeTime(iso: string, nowMs: number): string {
   const then = new Date(iso).getTime()
   if (Number.isNaN(then)) return ''
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000))
+  const secs = Math.max(0, Math.floor((nowMs - then) / 1000))
   if (secs < 60) return 'just now'
   const mins = Math.floor(secs / 60)
   if (mins < 60) return `${mins}m ago`

--- a/web/src/components/HistorySidebar.tsx
+++ b/web/src/components/HistorySidebar.tsx
@@ -18,9 +18,10 @@ export function HistorySidebar({
 }: HistorySidebarProps) {
   const [nowMs, setNowMs] = useState(() => Date.now())
   useEffect(() => {
+    if (items.length === 0) return
     const t = setInterval(() => setNowMs(Date.now()), 1000)
     return () => clearInterval(t)
-  }, [])
+  }, [items.length])
   return (
     <div className="w-64 shrink-0 border-r border-slate-200 pr-3">
       <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">


### PR DESCRIPTION
1. The Compose Image history sidebar displayed a bogus elapsed time (e.g. "7m ago")
the moment a new build started, instead of "just now".

Root cause: 
Elapsed time was computed as Date.now() - new Date(createdAt), but
createdAt is set with the server clock while Date.now() is the browser
clock. Any skew between the two shows up as fake elapsed time on brand-new
builds. Secondarily, the label only re-rendered on the 3s history poll and
stopped once no build was active, so it did not tick.

Fix:
api.listBuilds() reads the server Date response header and returns an
additional clockOffsetMs = serverNow - Date.now().
BuildImagePage stores the offset on every history refresh and threads it
into HistorySidebar.
HistorySidebar accepts clockOffsetMs, runs a 1 Hz ticker so labels
advance in real time, and clamps negative offsets to 0.

2. Document live-installer prerequisite for ISO builds
web/README.md instructed users to build only image-composer-tool, but ISO
builds also require the live-installer binary. Without it, an ISO compose
triggered from the Web UI fails immediately with a missing-prerequisite error
(cmd/image-composer-tool/build.go:273).

Added the standard go build -buildmode=pie -o ./build/live-installer ./cmd/live-installer
step alongside the ICT binary build in section 1 of web/README.md, using the
same call-out phrasing already used in the root README.md and
docs/user-guide/get-started/usage-guide.md.