### PR TITLE
feat(manifest): add PTL platform for Robotics AMR

### DIFF
--- a/internal/api/data/manifest.yaml
+++ b/internal/api/data/manifest.yaml
@@ -29,6 +29,14 @@ combinations:
     imageType: iso
     template: ubuntu24-x86_64-robotics-jazzy-iso.yml
 
+  # Planned, no template yet — the UI grays this out (not buildable).
+  - vertical: robotics
+    sku: robotics-jazzy-ubuntu24
+    platform: ptl
+    os: ubuntu24
+    imageType: iso
+    template: ""
+
   - vertical: fed-aero
     sku: edge-node-infra-bkc
     platform: ptl


### PR DESCRIPTION
## Summary

Follow-up to #789 (Basic-mode exhaustive combination matrix with grayed-out unavailable entries).

In #789 review it was noted that the manifest listed **Robotics AMR** on **WCL** while the table referenced **PTL**. Per review guidance, this adds **PTL in addition to WCL** for Robotics AMR (`robotics-jazzy-ubuntu24`) rather than replacing WCL.

## Details

No PTL-specific robotics template exists yet, so the new combination follows the established planned-but-not-ready pattern: an empty `template` field. The UI still lists PTL under Robotics AMR (keeping the matrix exhaustive) but grays it out and prevents selection/build until a template is authored.

The existing `ptl` label is already present in `platforms:`, so the dropdown renders correctly.

## Testing

- `go test ./internal/api/` passes, including `TestEmbeddedManifestUnavailableCombinations` which verifies every empty-template combination is unresolvable (so it stays grayed out) and that every combination's SKU/OS has a display label.