### PR TITLE
Implement POST /templates/validate with field-level errors

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -262,7 +262,7 @@ func TestHandleValidateTemplateValid(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Valid == nil || !*resp.Valid {
+	if !resp.Valid {
 		t.Errorf("valid = %v, want true (body: %s)", resp.Valid, rr.Body)
 	}
 	if resp.Errors != nil && len(*resp.Errors) != 0 {
@@ -283,17 +283,17 @@ func TestHandleValidateTemplateInvalidIs200(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Valid == nil || *resp.Valid {
+	if resp.Valid {
 		t.Fatalf("valid = %v, want false", resp.Valid)
 	}
 	if resp.Errors == nil || len(*resp.Errors) == 0 {
 		t.Fatal("expected field-level errors")
 	}
 	for _, e := range *resp.Errors {
-		if e.Path == nil || *e.Path == "" {
+		if e.Path == "" {
 			t.Errorf("issue missing field path: %+v", e)
 		}
-		if e.Message == nil || *e.Message == "" {
+		if e.Message == "" {
 			t.Errorf("issue missing message: %+v", e)
 		}
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -214,16 +214,16 @@ func TestHandleComposeInvalidTemplate(t *testing.T) {
 
 // --- advanced-mode stubs (contract-only; replaced in later PRs) ---
 
-// The three Advanced-mode endpoints are wired to the generated interface but not
-// yet implemented — each returns 501 with the standard error envelope. This
-// guards the PR-1 contract-only behavior; the PRs that implement each endpoint
-// replace its assertion here.
+// The remaining Advanced-mode endpoints are wired to the generated interface but
+// not yet implemented — each returns 501 with the standard error envelope. This
+// guards the contract-only behavior; the PRs that implement each endpoint replace
+// its assertion here. (POST /templates/validate is implemented — see
+// TestHandleValidateTemplate.)
 func TestHandleAdvancedStubsNotImplemented(t *testing.T) {
 	s, _ := newTestServer(t)
 	cases := []struct {
 		name, method, path, body string
 	}{
-		{"validate", http.MethodPost, "/api/v1/templates/validate", `{"yaml":"image:\n  name: x\n"}`},
 		{"package-repos", http.MethodGet, "/api/v1/package-repos", ""},
 		{"packages-search", http.MethodGet, "/api/v1/packages/search?q=doc&os=ubuntu24", ""},
 	}
@@ -245,6 +245,66 @@ func TestHandleAdvancedStubsNotImplemented(t *testing.T) {
 				t.Errorf("error envelope = %+v, want code NOT_IMPLEMENTED with message", eb.Error)
 			}
 		})
+	}
+}
+
+// --- validate template ---
+
+// A valid template returns 200 with valid=true and no errors.
+func TestHandleValidateTemplateValid(t *testing.T) {
+	s, _ := newTestServer(t)
+	body := `{"yaml":"image:\n  name: my-image\n  version: \"1.0\"\ntarget:\n  os: ubuntu\n  dist: ubuntu24\n  arch: x86_64\n  imageType: raw\n"}`
+	rr := s.do(httptest.NewRequest(http.MethodPost, "/api/v1/templates/validate", strings.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rr.Code, rr.Body)
+	}
+	var resp httpapi.ValidationResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Valid == nil || !*resp.Valid {
+		t.Errorf("valid = %v, want true (body: %s)", resp.Valid, rr.Body)
+	}
+	if resp.Errors != nil && len(*resp.Errors) != 0 {
+		t.Errorf("expected no errors, got %+v", *resp.Errors)
+	}
+}
+
+// An invalid template is a SUCCESSFUL call: 200 with valid=false and one issue
+// per bad field, each carrying a usable path — not a 4xx.
+func TestHandleValidateTemplateInvalidIs200(t *testing.T) {
+	s, _ := newTestServer(t)
+	body := `{"yaml":"image:\n  name: \"-bad\"\n  version: \"1.0\"\ntarget:\n  os: not-an-os\n  imageType: qcow2\n"}`
+	rr := s.do(httptest.NewRequest(http.MethodPost, "/api/v1/templates/validate", strings.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a failed validation is a successful call); body: %s", rr.Code, rr.Body)
+	}
+	var resp httpapi.ValidationResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Valid == nil || *resp.Valid {
+		t.Fatalf("valid = %v, want false", resp.Valid)
+	}
+	if resp.Errors == nil || len(*resp.Errors) == 0 {
+		t.Fatal("expected field-level errors")
+	}
+	for _, e := range *resp.Errors {
+		if e.Path == nil || *e.Path == "" {
+			t.Errorf("issue missing field path: %+v", e)
+		}
+		if e.Message == nil || *e.Message == "" {
+			t.Errorf("issue missing message: %+v", e)
+		}
+	}
+}
+
+// A malformed request body (not the template — the JSON envelope) is a 400.
+func TestHandleValidateTemplateBadJSON(t *testing.T) {
+	s, _ := newTestServer(t)
+	rr := s.do(httptest.NewRequest(http.MethodPost, "/api/v1/templates/validate", strings.NewReader(`{`)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rr.Code, rr.Body)
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -106,10 +106,21 @@ func (s *Server) SearchPackages(w http.ResponseWriter, _ *http.Request, _ httpap
 
 // ValidateTemplate handles POST /templates/validate.
 //
-// Not yet implemented: contract-only for now (see ListPackageRepos). The
-// field-level validation logic lands in a later PR. Returns 501 until then.
-func (s *Server) ValidateTemplate(w http.ResponseWriter, _ *http.Request) {
-	writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "template validation is not yet implemented")
+// A failed validation is a successful call: invalid templates return 200 with
+// valid=false and one issue per problem. Only a malformed request body or an
+// empty template yields a 4xx.
+func (s *Server) ValidateTemplate(w http.ResponseWriter, r *http.Request) {
+	var req httpapi.ValidateTemplateJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid JSON body")
+		return
+	}
+	res, err := s.svc.ValidateTemplate(req.Yaml)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, fromValidationResult(res))
 }
 
 // writeServiceError maps a service error onto the JSON error envelope. Domain

--- a/internal/api/mapping.go
+++ b/internal/api/mapping.go
@@ -121,11 +121,10 @@ func fromComposeResult(r *service.ComposeResult) httpapi.ComposeResponse {
 
 // fromValidationResult maps the service's structured validation result onto the
 // contract type. errors/warnings are omitempty in the spec, so empty slices map
-// to nil rather than []; valid is always sent.
+// to nil rather than []; valid is required, so it is always sent.
 func fromValidationResult(r *service.ValidationResult) httpapi.ValidationResponse {
-	valid := r.Valid
 	return httpapi.ValidationResponse{
-		Valid:    &valid,
+		Valid:    r.Valid,
 		Errors:   fromValidationIssues(r.Errors),
 		Warnings: fromValidationIssues(r.Warnings),
 	}
@@ -137,11 +136,10 @@ func fromValidationIssues(issues []service.ValidationIssue) *[]httpapi.Validatio
 	}
 	out := make([]httpapi.ValidationIssue, len(issues))
 	for i, iss := range issues {
-		sev := httpapi.ValidationIssueSeverity(iss.Severity)
 		out[i] = httpapi.ValidationIssue{
-			Path:     optStr(iss.Path),
-			Message:  optStr(iss.Message),
-			Severity: &sev,
+			Path:     iss.Path,
+			Message:  iss.Message,
+			Severity: httpapi.ValidationIssueSeverity(iss.Severity),
 		}
 	}
 	return &out

--- a/internal/api/mapping.go
+++ b/internal/api/mapping.go
@@ -119,6 +119,34 @@ func fromComposeResult(r *service.ComposeResult) httpapi.ComposeResponse {
 	}
 }
 
+// fromValidationResult maps the service's structured validation result onto the
+// contract type. errors/warnings are omitempty in the spec, so empty slices map
+// to nil rather than []; valid is always sent.
+func fromValidationResult(r *service.ValidationResult) httpapi.ValidationResponse {
+	valid := r.Valid
+	return httpapi.ValidationResponse{
+		Valid:    &valid,
+		Errors:   fromValidationIssues(r.Errors),
+		Warnings: fromValidationIssues(r.Warnings),
+	}
+}
+
+func fromValidationIssues(issues []service.ValidationIssue) *[]httpapi.ValidationIssue {
+	if len(issues) == 0 {
+		return nil
+	}
+	out := make([]httpapi.ValidationIssue, len(issues))
+	for i, iss := range issues {
+		sev := httpapi.ValidationIssueSeverity(iss.Severity)
+		out[i] = httpapi.ValidationIssue{
+			Path:     optStr(iss.Path),
+			Message:  optStr(iss.Message),
+			Severity: &sev,
+		}
+	}
+	return &out
+}
+
 func fromBuildAccepted(a *service.BuildAccepted) httpapi.BuildAccepted {
 	return httpapi.BuildAccepted{
 		BuildId: a.BuildID,

--- a/internal/api/service/validate.go
+++ b/internal/api/service/validate.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config/validate"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/security"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ValidationIssue is one problem found in a template, tied to a field path.
+type ValidationIssue struct {
+	Path     string
+	Message  string
+	Severity string // "error" or "warning"
+}
+
+// ValidationResult is the outcome of validating a template. Valid is true when
+// there are no error-severity issues. A syntactically broken document (bad YAML)
+// still yields Valid=false with a single issue — never a service error, since a
+// failed validation is a successful call.
+type ValidationResult struct {
+	Valid    bool
+	Errors   []ValidationIssue
+	Warnings []ValidationIssue
+}
+
+// ValidateTemplate validates a complete template YAML and returns a structured,
+// field-level result. It reports problems rather than failing: a malformed or
+// invalid template is a successful call with Valid=false. The only *Error it
+// returns is for input the caller could not have intended to validate (empty
+// body).
+//
+// The verdict mirrors what building the same YAML would reach. A build writes
+// the YAML to disk and runs ICT's LoadAndMergeTemplate, which validates it as a
+// user (minimal) template — the same subschema and the same post-schema semantic
+// checks this method runs via validate.ValidateUserTemplateIssues. So a template
+// that validates here builds without a validation failure, and one that fails
+// here fails the build for the same reason, only reported field-by-field.
+func (s *Service) ValidateTemplate(templateYAML string) (*ValidationResult, error) {
+	if len(templateYAML) == 0 {
+		return nil, newError(http.StatusBadRequest, "BAD_REQUEST", "template yaml is required")
+	}
+
+	jsonData, converr := yamlToJSONForValidation(templateYAML)
+	if converr != "" {
+		// Not parseable as a template document: report as a single invalid result,
+		// not a server/client error. The user still gets actionable feedback.
+		return &ValidationResult{
+			Valid:  false,
+			Errors: []ValidationIssue{{Message: converr, Severity: validate.SeverityError}},
+		}, nil
+	}
+
+	issues := validate.ValidateUserTemplateIssues(jsonData)
+
+	res := &ValidationResult{Valid: true}
+	for _, iss := range issues {
+		vi := ValidationIssue{Path: iss.Path, Message: iss.Message, Severity: iss.Severity}
+		if iss.Severity == validate.SeverityWarning {
+			res.Warnings = append(res.Warnings, vi)
+			continue
+		}
+		res.Valid = false
+		res.Errors = append(res.Errors, vi)
+	}
+	return res, nil
+}
+
+// yamlToJSONForValidation converts template YAML to the JSON bytes the schema
+// validators consume, applying the same string-safety limits the build path
+// applies in parseYAMLTemplate. On failure it returns an empty []byte and a
+// human-readable reason (the two are mutually exclusive) — the reason becomes a
+// validation issue rather than an error, so bad YAML is reported, not thrown.
+func yamlToJSONForValidation(templateYAML string) ([]byte, string) {
+	var raw interface{}
+	if err := yaml.Unmarshal([]byte(templateYAML), &raw); err != nil {
+		return nil, "invalid YAML: " + err.Error()
+	}
+	if raw == nil {
+		return nil, "template is empty"
+	}
+	if err := security.ValidateStructStrings(&raw, security.DefaultLimits()); err != nil {
+		return nil, "invalid template: " + err.Error()
+	}
+	jsonData, err := json.Marshal(raw)
+	if err != nil {
+		return nil, "invalid template: " + err.Error()
+	}
+	return jsonData, ""
+}

--- a/internal/api/service/validate.go
+++ b/internal/api/service/validate.go
@@ -6,6 +6,7 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config/validate"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/security"
@@ -43,7 +44,11 @@ type ValidationResult struct {
 // that validates here builds without a validation failure, and one that fails
 // here fails the build for the same reason, only reported field-by-field.
 func (s *Service) ValidateTemplate(templateYAML string) (*ValidationResult, error) {
-	if len(templateYAML) == 0 {
+	// A body that is empty or only whitespace carries no template to validate;
+	// treat it as a malformed request (400), not a validation verdict. Trimming
+	// first means "\n" and "   " are rejected the same way "" is, rather than
+	// falling through to a "template is empty" 200 issue.
+	if strings.TrimSpace(templateYAML) == "" {
 		return nil, newError(http.StatusBadRequest, "BAD_REQUEST", "template yaml is required")
 	}
 

--- a/internal/api/service/validate_test.go
+++ b/internal/api/service/validate_test.go
@@ -85,15 +85,19 @@ func TestValidateTemplate_MalformedYAMLIsInvalidNotError(t *testing.T) {
 	}
 }
 
-// An empty body is the one input that is a client error: there is nothing to
-// validate, so it is a 400 rather than a (meaningless) invalid result.
+// An empty or whitespace-only body is the one input that is a client error:
+// there is nothing to validate, so it is a 400 rather than a (meaningless)
+// invalid result. Whitespace-only must be rejected the same way as "" — not
+// fall through to a "template is empty" 200 issue.
 func TestValidateTemplate_EmptyIsBadRequest(t *testing.T) {
-	_, err := newValidateService().ValidateTemplate("")
-	var se *Error
-	if !errors.As(err, &se) {
-		t.Fatalf("expected *Error, got %v", err)
-	}
-	if se.Status != http.StatusBadRequest {
-		t.Errorf("status = %d, want 400", se.Status)
+	for _, in := range []string{"", "\n", "   ", "  \n\t "} {
+		_, err := newValidateService().ValidateTemplate(in)
+		var se *Error
+		if !errors.As(err, &se) {
+			t.Fatalf("input %q: expected *Error, got %v", in, err)
+		}
+		if se.Status != http.StatusBadRequest {
+			t.Errorf("input %q: status = %d, want 400", in, se.Status)
+		}
 	}
 }

--- a/internal/api/service/validate_test.go
+++ b/internal/api/service/validate_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+const validUserTemplate = `image:
+  name: my-image
+  version: "1.0"
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+`
+
+// ValidateTemplate needs no manifest/config/ICT — it only exercises the schema
+// validators, so a zero-value Service is sufficient.
+func newValidateService() *Service { return &Service{} }
+
+func TestValidateTemplate_Valid(t *testing.T) {
+	res, err := newValidateService().ValidateTemplate(validUserTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Valid {
+		t.Fatalf("expected valid, got invalid with errors: %+v", res.Errors)
+	}
+	if len(res.Errors) != 0 {
+		t.Errorf("expected no errors, got %+v", res.Errors)
+	}
+}
+
+func TestValidateTemplate_InvalidReportsFieldPaths(t *testing.T) {
+	const bad = `image:
+  name: "-bad-name"
+  version: "1.0"
+target:
+  os: not-an-os
+  imageType: qcow2
+`
+	res, err := newValidateService().ValidateTemplate(bad)
+	if err != nil {
+		t.Fatalf("invalid template must not error (it is a successful call): %v", err)
+	}
+	if res.Valid {
+		t.Fatal("expected invalid")
+	}
+	if len(res.Errors) < 3 {
+		t.Fatalf("expected several field errors, got %d: %+v", len(res.Errors), res.Errors)
+	}
+	wantPaths := map[string]bool{"image.name": false, "target.os": false, "target.imageType": false}
+	for _, e := range res.Errors {
+		if _, ok := wantPaths[e.Path]; ok {
+			wantPaths[e.Path] = true
+		}
+		if e.Message == "" || e.Severity != "error" {
+			t.Errorf("issue %+v: want non-empty message and severity=error", e)
+		}
+	}
+	for p, seen := range wantPaths {
+		if !seen {
+			t.Errorf("expected an error for field path %q", p)
+		}
+	}
+}
+
+// Malformed YAML is reported as an invalid result, not a service error — a
+// failed validation is still a successful call.
+func TestValidateTemplate_MalformedYAMLIsInvalidNotError(t *testing.T) {
+	res, err := newValidateService().ValidateTemplate("image: [unterminated\n")
+	if err != nil {
+		t.Fatalf("malformed YAML must not return an error: %v", err)
+	}
+	if res.Valid {
+		t.Fatal("expected invalid for malformed YAML")
+	}
+	if len(res.Errors) != 1 {
+		t.Fatalf("expected a single parse issue, got %+v", res.Errors)
+	}
+}
+
+// An empty body is the one input that is a client error: there is nothing to
+// validate, so it is a 400 rather than a (meaningless) invalid result.
+func TestValidateTemplate_EmptyIsBadRequest(t *testing.T) {
+	_, err := newValidateService().ValidateTemplate("")
+	var se *Error
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *Error, got %v", err)
+	}
+	if se.Status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", se.Status)
+	}
+}

--- a/internal/config/validate/issues.go
+++ b/internal/config/validate/issues.go
@@ -37,10 +37,13 @@ const (
 // structured list of issues instead of a single wrapped error. A nil/empty
 // result means the template is valid.
 //
-// It mirrors ValidateUserTemplateJSON exactly — the same schema subschema plus
-// the same post-schema semantic checks — so the verdict here matches what a
-// build of the same template would reach, reported field-by-field rather than as
-// one string. Kept alongside (not replacing) ValidateUserTemplateJSON so CLI
+// It runs the same checks as ValidateUserTemplateJSON — the same schema
+// subschema plus the same post-schema semantic checks (auto-expand, FDE) — so
+// the pass/fail verdict here matches what a build of the same template would
+// reach. It differs deliberately in one way: where ValidateUserTemplateJSON
+// stops at the first failure, this keeps going and collects every problem, since
+// the point is to show the user all their field errors at once rather than one
+// per round-trip. Kept alongside (not replacing) ValidateUserTemplateJSON so CLI
 // callers that only need pass/fail are unaffected.
 func ValidateUserTemplateIssues(data []byte) []Issue {
 	var issues []Issue
@@ -72,10 +75,12 @@ func ValidateUserTemplateIssues(data []byte) []Issue {
 }
 
 // isJSONObject reports whether data is a JSON object, the only shape the
-// semantic checks can inspect.
+// semantic checks can inspect. The non-nil guard matters: json.Unmarshal of the
+// literal `null` succeeds into a nil map, so without it a `null` document would
+// be treated as an object and fall into the semantic checks.
 func isJSONObject(data []byte) bool {
 	var doc map[string]interface{}
-	return json.Unmarshal(data, &doc) == nil
+	return json.Unmarshal(data, &doc) == nil && doc != nil
 }
 
 // schemaErrorIssues turns the error from ValidateAgainstSchema into field-level

--- a/internal/config/validate/issues.go
+++ b/internal/config/validate/issues.go
@@ -1,0 +1,126 @@
+package validate
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config/schema"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// Issue is a single validation problem tied to a field path. It is the
+// structured counterpart to the errors returned by ValidateUserTemplateJSON /
+// ValidateImageTemplateJSON: instead of one formatted string, callers that need
+// to point at individual fields (the web UI's inline validation) get one Issue
+// per problem, each carrying the JSON path of the offending value.
+type Issue struct {
+	// Path is the dotted field path of the offending value (e.g. "target.os",
+	// "disk.partitions.0.type"). Empty when the problem is document-wide (for
+	// example a value that isn't a valid template object at all).
+	Path string
+	// Message describes the problem in human-readable form.
+	Message string
+	// Severity is "error" or "warning". All issues are errors today; the field
+	// exists so warnings can be added without a signature change.
+	Severity string
+}
+
+// SeverityError and SeverityWarning are the valid Issue.Severity values.
+const (
+	SeverityError   = "error"
+	SeverityWarning = "warning"
+)
+
+// ValidateUserTemplateIssues validates a user (minimal) template and returns a
+// structured list of issues instead of a single wrapped error. A nil/empty
+// result means the template is valid.
+//
+// It mirrors ValidateUserTemplateJSON exactly — the same schema subschema plus
+// the same post-schema semantic checks — so the verdict here matches what a
+// build of the same template would reach, reported field-by-field rather than as
+// one string. Kept alongside (not replacing) ValidateUserTemplateJSON so CLI
+// callers that only need pass/fail are unaffected.
+func ValidateUserTemplateIssues(data []byte) []Issue {
+	var issues []Issue
+
+	if err := ValidateAgainstSchema(imageSchemaName, schema.ImageTemplateSchema, data, userRef); err != nil {
+		issues = append(issues, schemaErrorIssues(err)...)
+	}
+
+	// Post-schema semantic checks. These return a single error each (not a schema
+	// tree), so map each to one issue anchored at the field it concerns.
+	if err := validateAutoExpandLastPartitionConstraints(data, false); err != nil {
+		issues = append(issues, Issue{Path: "disk", Message: err.Error(), Severity: SeverityError})
+	}
+	if err := validateFDEConstraints(data); err != nil {
+		issues = append(issues, Issue{Path: "systemConfig.fde.passphraseFile", Message: err.Error(), Severity: SeverityError})
+	}
+
+	return issues
+}
+
+// schemaErrorIssues turns the error from ValidateAgainstSchema into field-level
+// issues. On a schema validation failure it unwraps the underlying
+// *jsonschema.ValidationError and walks its Causes, emitting one issue per leaf
+// (the most specific problems) using InstanceLocation as the path. Any other
+// error (malformed JSON, or an internal schema-load failure) has no field path,
+// so it becomes a single pathless issue.
+func schemaErrorIssues(err error) []Issue {
+	var ve *jsonschema.ValidationError
+	if !errors.As(err, &ve) {
+		return []Issue{{Message: err.Error(), Severity: SeverityError}}
+	}
+
+	leaves := collectLeafErrors(ve, nil)
+	if len(leaves) == 0 {
+		// Defensive: a ValidationError with no nested causes. Use the root itself.
+		return []Issue{{Path: pointerToPath(ve.InstanceLocation), Message: ve.Message, Severity: SeverityError}}
+	}
+
+	issues := make([]Issue, 0, len(leaves))
+	seen := make(map[string]bool, len(leaves))
+	for _, leaf := range leaves {
+		iss := Issue{Path: pointerToPath(leaf.InstanceLocation), Message: leaf.Message, Severity: SeverityError}
+		// The conditional (allOf/if-then/anyOf) branches in the schema can surface
+		// the same (path, message) more than once; report each once.
+		key := iss.Path + "\x00" + iss.Message
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		issues = append(issues, iss)
+	}
+	return issues
+}
+
+// collectLeafErrors returns the leaf errors of a jsonschema validation tree —
+// the nodes with no further causes, which carry the most specific field path and
+// message. Intermediate nodes only say "some sub-schema failed", so the leaves
+// are what a user can act on.
+func collectLeafErrors(ve *jsonschema.ValidationError, acc []*jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if len(ve.Causes) == 0 {
+		return append(acc, ve)
+	}
+	for _, c := range ve.Causes {
+		acc = collectLeafErrors(c, acc)
+	}
+	return acc
+}
+
+// pointerToPath converts a JSON Pointer (jsonschema's InstanceLocation, e.g.
+// "/target/os" or "/disk/partitions/0/type") into a dotted field path
+// ("target.os", "disk.partitions.0.type") for display. The empty pointer (the
+// whole document) maps to "". Handles the JSON Pointer escapes ~1 (/) and ~0 (~).
+func pointerToPath(ptr string) string {
+	if ptr == "" || ptr == "/" {
+		return ""
+	}
+	tokens := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
+	for i, t := range tokens {
+		t = strings.ReplaceAll(t, "~1", "/")
+		t = strings.ReplaceAll(t, "~0", "~")
+		tokens[i] = t
+	}
+	return strings.Join(tokens, ".")
+}

--- a/internal/config/validate/issues.go
+++ b/internal/config/validate/issues.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -48,6 +49,16 @@ func ValidateUserTemplateIssues(data []byte) []Issue {
 		issues = append(issues, schemaErrorIssues(err)...)
 	}
 
+	// The semantic checks below unmarshal into map[string]interface{}, so a
+	// document that isn't a JSON object makes both fail on the unmarshal itself.
+	// The schema check above has already reported that ("expected object, but got
+	// array"); running them anyway would append two more issues pointing at
+	// unrelated fields (disk, systemConfig.fde.passphraseFile) that the input
+	// never mentioned. Bail out instead — the caller has the real problem.
+	if !isJSONObject(data) {
+		return issues
+	}
+
 	// Post-schema semantic checks. These return a single error each (not a schema
 	// tree), so map each to one issue anchored at the field it concerns.
 	if err := validateAutoExpandLastPartitionConstraints(data, false); err != nil {
@@ -58,6 +69,13 @@ func ValidateUserTemplateIssues(data []byte) []Issue {
 	}
 
 	return issues
+}
+
+// isJSONObject reports whether data is a JSON object, the only shape the
+// semantic checks can inspect.
+func isJSONObject(data []byte) bool {
+	var doc map[string]interface{}
+	return json.Unmarshal(data, &doc) == nil
 }
 
 // schemaErrorIssues turns the error from ValidateAgainstSchema into field-level

--- a/internal/config/validate/issues_test.go
+++ b/internal/config/validate/issues_test.go
@@ -129,6 +129,9 @@ func TestValidateUserTemplateIssues_NonObjectDocument(t *testing.T) {
 		"bare string":  "hello\n",
 		"bare number":  "42\n",
 		"bare boolean": "true\n",
+		// null decodes into a nil map, which isJSONObject must not mistake for an
+		// object — otherwise it would slip into the semantic checks.
+		"null": "null\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			issues := ValidateUserTemplateIssues(toJSON(t, y))

--- a/internal/config/validate/issues_test.go
+++ b/internal/config/validate/issues_test.go
@@ -117,6 +117,37 @@ systemConfig:
 	}
 }
 
+// A document that isn't a JSON object at all (a YAML list, or a bare scalar) must
+// produce exactly the one issue that describes the real problem. The semantic
+// checks unmarshal into a map, so before isJSONObject gated them they each failed
+// on their own unmarshal and appended an issue blaming `disk` and
+// `systemConfig.fde.passphraseFile` — fields the input never mentioned. In the UI
+// those render as inline errors on unrelated form controls.
+func TestValidateUserTemplateIssues_NonObjectDocument(t *testing.T) {
+	for name, y := range map[string]string{
+		"yaml list":    "- a\n- b\n",
+		"bare string":  "hello\n",
+		"bare number":  "42\n",
+		"bare boolean": "true\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			issues := ValidateUserTemplateIssues(toJSON(t, y))
+			if len(issues) != 1 {
+				t.Fatalf("got %d issues, want exactly 1: %+v", len(issues), issues)
+			}
+			// The single issue is document-wide, so it carries no field path.
+			if issues[0].Path != "" {
+				t.Errorf("path = %q, want \"\" (document-level)", issues[0].Path)
+			}
+			for _, iss := range issues {
+				if iss.Path == "disk" || iss.Path == "systemConfig.fde.passphraseFile" {
+					t.Errorf("issue blames unrelated field %q: %s", iss.Path, iss.Message)
+				}
+			}
+		})
+	}
+}
+
 func TestPointerToPath(t *testing.T) {
 	cases := map[string]string{
 		"":                        "",

--- a/internal/config/validate/issues_test.go
+++ b/internal/config/validate/issues_test.go
@@ -1,0 +1,142 @@
+package validate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// toJSON converts a YAML template body to the JSON bytes the validators consume,
+// mirroring the build path (yaml -> interface{} -> json).
+func toJSON(t *testing.T, y string) []byte {
+	t.Helper()
+	var raw interface{}
+	if err := yaml.Unmarshal([]byte(y), &raw); err != nil {
+		t.Fatalf("yaml unmarshal: %v", err)
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	return data
+}
+
+// pathsOf collects the Path of every issue for order-independent assertions.
+func pathsOf(issues []Issue) map[string]string {
+	m := make(map[string]string, len(issues))
+	for _, iss := range issues {
+		m[iss.Path] = iss.Message
+	}
+	return m
+}
+
+func TestValidateUserTemplateIssues_Valid(t *testing.T) {
+	// Minimal valid user template: image{name,version} + target{os,dist,arch,imageType}.
+	y := `image:
+  name: my-image
+  version: "1.0"
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+`
+	issues := ValidateUserTemplateIssues(toJSON(t, y))
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues, got %d: %+v", len(issues), issues)
+	}
+}
+
+func TestValidateUserTemplateIssues_MultipleFieldErrors(t *testing.T) {
+	// Four distinct problems: bad image.name pattern, os not in enum, imageType
+	// not in enum, and target missing dist+arch.
+	y := `image:
+  name: "-bad-name"
+  version: "1.0"
+target:
+  os: not-an-os
+  imageType: qcow2
+`
+	issues := ValidateUserTemplateIssues(toJSON(t, y))
+	if len(issues) == 0 {
+		t.Fatal("expected issues, got none")
+	}
+	got := pathsOf(issues)
+	for _, want := range []string{"image.name", "target.os", "target.imageType", "target"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("missing issue for path %q; got paths %v", want, keys(got))
+		}
+	}
+	// Every issue is an error severity with a non-empty, human-readable message.
+	for _, iss := range issues {
+		if iss.Severity != SeverityError {
+			t.Errorf("issue %+v: severity = %q, want %q", iss, iss.Severity, SeverityError)
+		}
+		if iss.Message == "" {
+			t.Errorf("issue for path %q has empty message", iss.Path)
+		}
+	}
+}
+
+func TestValidateUserTemplateIssues_MissingRequiredTopLevel(t *testing.T) {
+	// No image, no target: both required at the document root.
+	issues := ValidateUserTemplateIssues(toJSON(t, `metadata: {}`))
+	if len(issues) == 0 {
+		t.Fatal("expected issues for missing required fields, got none")
+	}
+	found := false
+	for _, iss := range issues {
+		if iss.Path == "" { // whole-document "missing properties: 'image', 'target'"
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a document-level issue for missing image/target; got %+v", issues)
+	}
+}
+
+func TestValidateUserTemplateIssues_SemanticFDE(t *testing.T) {
+	// Schema-valid, but the FDE semantic check fails: enabled with no passphrase.
+	y := `image:
+  name: my-image
+  version: "1.0"
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+systemConfig:
+  fde:
+    enabled: true
+`
+	issues := ValidateUserTemplateIssues(toJSON(t, y))
+	got := pathsOf(issues)
+	if _, ok := got["systemConfig.fde.passphraseFile"]; !ok {
+		t.Errorf("expected FDE passphrase issue; got paths %v", keys(got))
+	}
+}
+
+func TestPointerToPath(t *testing.T) {
+	cases := map[string]string{
+		"":                        "",
+		"/":                       "",
+		"/target/os":              "target.os",
+		"/disk/partitions/0/type": "disk.partitions.0.type",
+		"/a~1b":                   "a/b", // ~1 -> /
+		"/a~0b":                   "a~b", // ~0 -> ~
+	}
+	for in, want := range cases {
+		if got := pointerToPath(in); got != want {
+			t.Errorf("pointerToPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/utils/security/inputcheck.go
+++ b/internal/utils/security/inputcheck.go
@@ -88,6 +88,12 @@ func walkValue(v reflect.Value, path string, lim Limits, seen map[uintptr]bool) 
 		seen[ptr] = true
 		return walkValue(v.Elem(), path, lim, seen)
 
+	case reflect.Interface:
+		if v.IsNil() {
+			return nil
+		}
+		return walkValue(v.Elem(), path, lim, seen)
+
 	case reflect.Struct:
 		t := v.Type()
 		for i := 0; i < v.NumField(); i++ {

--- a/internal/utils/security/inputcheck_test.go
+++ b/internal/utils/security/inputcheck_test.go
@@ -126,6 +126,38 @@ func TestValidateStructStrings_SliceAndMap(t *testing.T) {
 	}
 }
 
+// YAML/JSON decoded into interface{} nests values as map[string]interface{} and
+// []interface{}, so every leaf string sits behind a reflect.Interface. Without an
+// Interface case in walkValue the traversal stopped at the first such value and
+// silently validated nothing — an oversized or NUL-bearing string slipped through.
+// This mirrors how config.parseYAMLTemplate and Service.ValidateTemplate feed
+// decoded template data in (&interface{}).
+func TestValidateStructStrings_DecodedInterfaceTree(t *testing.T) {
+	lim := DefaultLimits()
+	doc := map[string]interface{}{
+		"image": map[string]interface{}{
+			"name":    "ok",
+			"aliases": []interface{}{"a", "b"},
+		},
+	}
+	if err := ValidateStructStrings(&doc, lim); err != nil {
+		t.Fatalf("valid decoded tree rejected: %v", err)
+	}
+
+	// Oversized string behind two interface hops must be rejected.
+	doc["image"].(map[string]interface{})["name"] = strings.Repeat("A", lim.MaxString+1)
+	if err := ValidateStructStrings(&doc, lim); err == nil {
+		t.Fatal("expected oversized string in decoded tree to be rejected")
+	}
+
+	// NUL inside an []interface{} element must be rejected too.
+	doc["image"].(map[string]interface{})["name"] = "ok"
+	doc["image"].(map[string]interface{})["aliases"] = []interface{}{"a", "bad\x00"}
+	if err := ValidateStructStrings(&doc, lim); err == nil {
+		t.Fatal("expected NUL in interface slice element to be rejected")
+	}
+}
+
 func TestValidateStructStrings_PointerCycle(t *testing.T) {
 	type Node struct {
 		Value string


### PR DESCRIPTION
## What

Replaces the `POST /templates/validate` 501 stub with a real implementation that returns **one issue per problem, each with the offending field's path** — so the Advanced tab can show inline, in-place errors.

```json
POST /templates/validate  { "yaml": "<template>" }
200 { "valid": false, "errors": [
  { "path": "image.name",       "message": "does not match pattern ...", "severity": "error" },
  { "path": "target.os",        "message": "value must be one of ...",   "severity": "error" },
  { "path": "target.imageType", "message": "value must be one of ...",   "severity": "error" },
  { "path": "target",           "message": "missing properties: 'dist', 'arch'", "severity": "error" }
]}
```

## Stacked on #800

Based on `advanced-mode-spec-stubs` (PR #800), which added the spec + generated `ValidationResponse`/`ValidationIssue` types this builds on. **Review/merge #800 first**; this diff shows only PR 2's changes. I'll rebase onto `main` once #800 lands.

## How

- **`internal/config/validate/issues.go`** — new `ValidateUserTemplateIssues`, added *alongside* the existing error-returning validators so CLI callers are unchanged. On a schema failure it unwraps the underlying `*jsonschema.ValidationError` with `errors.As` and walks the nested `Causes`, emitting the **leaf** errors (the most specific ones) with `InstanceLocation` converted to a dotted field path. **No string-parsing of the formatted message** — that was called out as fragile. It then runs the same post-schema semantic checks (auto-expand, FDE) the build runs.
- **`internal/api/service/validate.go`** — `ValidateTemplate` converts the YAML the same way the build does (`yaml → interface{} → json`, with the same string-safety limits) and returns a structured result.
- **`internal/api/mapping.go` / `handlers.go`** — map the result to `ValidationResponse`; the handler encodes it.

## The key correctness property

The verdict here **mirrors what building the same YAML would reach**. A `{yaml}` build writes the template to disk and runs ICT's `LoadAndMergeTemplate`, which validates it as a *user (minimal) template* — the same subschema and the same semantic checks this endpoint runs. So a template that validates here builds without a validation failure, and one that fails here fails the build for the same reason, only reported field-by-field.

## Contract: a failed validation is a successful call

- Invalid template → **200** with `valid: false` + issues (not a 4xx).
- Malformed YAML → 200 `valid: false` with a single parse issue (reported, not thrown).
- **4xx only** for a malformed request envelope or an empty template.

## Tests

- `internal/config/validate/issues_test.go` — multi-field-error unwrapping (asserts distinct paths `image.name`, `target.os`, `target.imageType`, `target`), the valid case, missing-required-top-level (document-level issue), the FDE semantic check, and `pointerToPath` (incl. `~0`/`~1` escapes).
- `internal/api/service/validate_test.go` — valid/invalid result semantics, malformed-YAML-is-invalid-not-error, empty-is-400.
- `internal/api/api_test.go` — handler returns 200 (not 4xx) for invalid templates with usable paths; 400 on bad JSON envelope. Removed `validate` from the 501-stub test (now implemented).

## Verification

- `go generate ./internal/api/http` idempotent; `go build`, `go vet`, `go test` — pass
- gofmt clean; golangci-lint v1.64.2 — 0 issues
- Overall coverage 72.6% (gate 69.9%); new code well-covered
- `npm run build` — pass