### PR TITLE
fix(config): drop stale kernel.version pin from the ubuntu24 OS defaults

### DIFF
--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-unattended-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-unattended-x86_64.yml
@@ -67,7 +67,6 @@ systemConfig:
 
   kernel:
     name: kernel
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 systemd.log_level=debug rd.debug"
     packages:
       - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -64,7 +64,6 @@ systemConfig:
 
   kernel:
     name: kernel
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 systemd.log_level=debug rd.debug"
     packages:
       - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-aarch64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-aarch64.yml
@@ -68,7 +68,6 @@ systemConfig:
       final: /etc/apt/sources.list.d/ubuntu-noble.list
 
   kernel:
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-x86_64.yml
@@ -78,7 +78,6 @@ systemConfig:
       final: /etc/apt/sources.list.d/ubuntu-noble.list
 
   kernel:
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic-hwe-24.04

--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -96,6 +96,8 @@
 
 **Fixed**
 
+- `fix(config)`: drop stale `kernel.version` pin from the ubuntu24 OS defaults: ubuntu24 builds failed in pre-processing with `kernel version mismatch: requires kernel version "6.17", but available versions are: [6.8.0-31.31 7.0.0-28.28~24.04.1]`. Four default configs under `config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/` (`default-raw-x86_64.yml`, `default-raw-aarch64.yml`, `default-initrd-x86_64.yml`, `default-initrd-unattended-x86_64.yml`) pinned `kernel.version: "6.17"` alongside the rolling metapackage `linux-image-generic-hwe-24.04`, and Ubuntu noble no longer ships 6.17. Any template without its own `kernel.version` inherited the stale pin, so `ubuntu24-x86_64-minimal-initrd.yml` and `ubuntu24-x86_64-dkms-demo.yml` failed even though the templates themselves were already clean. #765 removed this antipattern from the 12 affected user templates but did not cover the OS defaults, which is why the failure recurred; `image-templates/robotics-demo-ubuntu24-x86_64.yml` was also missed there and is fixed here. Dropping the pin lets `apt` resolve whatever the metapackage currently points to — no pin, nothing to go stale. Templates that pin a concrete kernel package (for example `linux-image-6.11.0-17-generic`, `linux-image-6.12-intel`) are unaffected.
+
 - `fix(ubuntu)`: `AllowPackages` not propagated to debutils.Repository (#480): The `allowPackages` list in user-provided package repository configuration was silently dropped instead of being passed through to the DEB package resolver.
 
 - `fix(inspect)`: ext4 filesystem misdetection in image inspect (#484): The image inspect command was incorrectly classifying some ext4 partitions as a different filesystem type.

--- a/image-templates/robotics-demo-ubuntu24-x86_64.yml
+++ b/image-templates/robotics-demo-ubuntu24-x86_64.yml
@@ -151,7 +151,6 @@ systemConfig:
     - ros-jazzy-demo-nodes-py
 
   kernel:
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic-hwe-24.04


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

ubuntu24 builds fail in pre-processing, while downloading image packages:

```
ERROR debutils/download.go:988  kernel version mismatch: requires kernel version "6.17",
                                but available versions are: [6.8.0-31.31 7.0.0-28.28~24.04.1]
```

Four default configs under `config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/` pin
`kernel.version: "6.17"` alongside the **rolling** metapackage `linux-image-generic-hwe-24.04`, and
Ubuntu noble no longer ships 6.17 — the HWE series has rolled past it. `archive.ubuntu.com` currently
offers, for that metapackage:

| Pocket | Version |
|---|---|
| `noble` (GA) | `6.8.0-31.31` |
| `noble-updates` | `7.0.0-28.28~24.04.1` |

which is the error message verbatim.

##### Why templates that look clean still failed

A template inherits the default's `kernel` block whenever it does not set `kernel.version` itself, so
the stale pin reached templates that had already been fixed:

| Reproducer | Where the 6.17 came from |
|---|---|
| `ubuntu24-x86_64-minimal-initrd.yml` | declares **no** `kernel` block → `default-initrd-x86_64.yml` |
| `ubuntu24-x86_64-dkms-demo.yml` | declares a `kernel` block with **no** `version` → `default-raw-x86_64.yml` |
| `default-initrd-x86_64.yml` | built directly |

##### Relation to #765

**#765 removed exactly this antipattern from the 12 affected user templates but never touched the OS
defaults.** That is the whole of this bug, and the reason the failure returned for a fourth time
after #494 (6.14→6.17), #669 (6.17→7.0) and #761 (6.17→6.8). #765's own body lists
`ubuntu24-x86_64-dkms-demo.yml` as fixed — it was, at the template layer only.

`image-templates/robotics-demo-ubuntu24-x86_64.yml` was also missed by #765 and carries the same
`6.17` + rolling-metapackage pairing, so it is fixed here too.

#### The fix

Drop the `version:` line; keep the metapackage. `KernelVersion == ""` makes `matchesKernelVersion`
short-circuit (`internal/ospackage/debutils/resolver.go:1392-1395`) and skips the mismatch guard
(`internal/ospackage/debutils/download.go:1019`), so `apt` resolves whatever the metapackage currently
points to. No pin, nothing to go stale.

**Deliberately no replacement version.** Substituting a new number is what produced the previous three
iterations of this fix. Templates that pin a *concrete* kernel package
(`linux-image-6.11.0-17-generic`, `linux-image-6.12-intel`, `linux-image-6.18-intel`) genuinely mean it
and are untouched.

5 files, 5 deleted lines, plus one release note.

#### Still carrying the same pattern, left out of scope

Both resolve against today's archive, so neither is failing — but both are one roll from the identical
break, and are worth a follow-up:

- The three ubuntu26 defaults (`default-raw-x86_64.yml`, `default-raw-aarch64.yml`,
  `default-initrd-x86_64.yml`) pin `7.0` with rolling `linux-image-generic`.
- `image-templates/ubuntu24-x86_64-fde-raw.yml` pins `6.8.0-31.31` with the rolling HWE metapackage.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

The reported reproducers were **built**, not just resolved:

| Reproducer | Result | `kernel version mismatch` count |
|---|---|---|
| `ubuntu24-x86_64-minimal-initrd.yml` | ✅ built — `minimal-os-image-ubuntu-24.04.img`, 3m22s | **0** |
| `default-initrd-x86_64.yml` (direct) | ✅ built — `minimal-os-image-ubuntu-24.04.img`, 2m58s | **0** |
| `ubuntu24-x86_64-dkms-demo.yml` | clears the reported failure, fails further on — see below | **0** |

The resolver now selects `linux-headers-7.0.0-28-generic`, confirming the pin is no longer
constraining it.

**A second, distinct defect is behind this one.** `dkms-demo` gets past the kernel mismatch and then
fails at package install:

```
Error! Bad return status for module build on kernel: 7.0.0-28-generic (x86_64)
installed v4l2loopback-dkms package post-installation script subprocess returned error exit status 10
```

`v4l2loopback-dkms 0.12.7` does not compile against kernel 7.0. This is **not a regression from this
change** — on `main` the build dies earlier at the mismatch and never reaches the DKMS stage, so this
fix *uncovers* it rather than causing it. Two defects were stacked behind one error message; this PR
fixes the reported one and leaves the DKMS incompatibility for a separate change.

Also run: `go build ./cmd/... ./internal/...`, `go vet`, `go test ./cmd/... ./internal/...` (0
failures), `gofmt -l` (clean), and `validate` over all 60 templates — 59 pass, the one failure being
the pre-existing `ubuntu24-x86_64-fde-raw.yml`, whose `fde.passphraseFile` points at a nonexistent
`/home/user/test-fde.txt`.

> Note for reviewers: `build-ubuntu24-immutable` currently fails on `main` for exactly this reason
> (`ubuntu24-x86_64-edge-raw.yml` → `default-raw-x86_64.yml`). It should go green on this branch,
> which is useful independent confirmation.
