### PR TITLE
fix(overlay): read partition starts with sfdisk when lsblk lacks START

### DIFF
--- a/internal/image/overlay/resize.go
+++ b/internal/image/overlay/resize.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -234,9 +235,12 @@ func resizeToolsForFS(fsType, table string) []string {
 // checkResizeToolsAvailable verifies every host tool the resize sequence needs is
 // present on the build host before any disk mutation, so a missing dependency
 // fails with a clear, actionable message up front rather than mid-sequence. The
-// partition-inspection guard also relies on lsblk, so it is included.
+// partition-inspection guard also relies on lsblk, and on sfdisk as its fallback
+// when lsblk predates the START column (util-linux < 2.38), so both are included:
+// a host missing sfdisk would otherwise only discover it after the guard had
+// already committed to the fallback path.
 func checkResizeToolsAvailable(layout *Layout) error {
-	tools := append([]string{"lsblk"}, resizeToolsForFS(layout.RootFSType, layout.PartitionTable)...)
+	tools := append([]string{"lsblk", "sfdisk"}, resizeToolsForFS(layout.RootFSType, layout.PartitionTable)...)
 	var missing []string
 	for _, t := range tools {
 		ok, err := resizeToolExists(t)
@@ -251,7 +255,7 @@ func checkResizeToolsAvailable(layout *Layout) error {
 		return fmt.Errorf(
 			"overlay resize: required tool(s) not found on the build host: %s; "+
 				"install them (growpart is in cloud-guest-utils, sgdisk in gdisk, "+
-				"resize2fs in e2fsprogs, xfs_growfs in xfsprogs, losetup/partx in util-linux) "+
+				"resize2fs in e2fsprogs, xfs_growfs in xfsprogs, losetup/partx/lsblk/sfdisk in util-linux) "+
 				"or remove/lower disk.size (optionally also set overlayPolicy.allowDiskResize: false) "+
 				"to keep the baseline layout and skip the resize",
 			strings.Join(missing, ", "))
@@ -263,18 +267,12 @@ func checkResizeToolsAvailable(layout *Layout) error {
 // last partition (by on-disk start offset) on the loop device. growpart extends
 // a partition only into the free space that immediately follows it, so growing a
 // non-last root would run into — and corrupt — a following partition. It reads
-// each partition's START sector via lsblk and confirms none starts after the
-// root partition. It performs only reads; it never mutates the disk.
+// each partition's START sector and confirms none starts after the root
+// partition. It performs only reads; it never mutates the disk.
 func assertRootIsLastPartition(loopDevPath, rootDevice string) error {
-	cmd := fmt.Sprintf("lsblk -b --json -o PATH,START,TYPE %s", shell.QuoteArg(loopDevPath))
-	out, err := resizeExec(cmd)
+	starts, err := partitionStarts(loopDevPath)
 	if err != nil {
-		return fmt.Errorf("overlay resize: failed to read partition layout of %s: %w", loopDevPath, err)
-	}
-
-	starts, err := parsePartitionStarts(out)
-	if err != nil {
-		return fmt.Errorf("overlay resize: %w", err)
+		return err
 	}
 
 	rootStart, ok := starts[rootDevice]
@@ -299,6 +297,118 @@ func assertRootIsLastPartition(loopDevPath, rootDevice string) error {
 		}
 	}
 	return nil
+}
+
+// partitionStarts returns each partition's start offset on loopDevPath, keyed by
+// device path.
+//
+// It prefers `lsblk --json -o PATH,START,TYPE`, but the START column only exists
+// from util-linux 2.38 onward. On an older host (Ubuntu 22.04 ships 2.37.2) lsblk
+// exits non-zero with "unknown column: START", which would otherwise fail the
+// resize with a message that says nothing about the real cause. Fall back to
+// `sfdisk -d`, which reports the same start offsets in sectors and has carried
+// that dump format for far longer.
+//
+// Mixing units between the two sources would be a correctness bug, so note that
+// both report SECTORS: lsblk's START is a sector offset even under -b (verified
+// against sfdisk on the same disk — both report 2099200 for a noble cloud image's
+// root). The guard only ever compares offsets against each other on one disk, so
+// a consistent unit is all it needs.
+func partitionStarts(loopDevPath string) (map[string]int64, error) {
+	lsblkCmd := fmt.Sprintf("lsblk -b --json -o PATH,START,TYPE %s", shell.QuoteArg(loopDevPath))
+	out, err := resizeExec(lsblkCmd)
+	if err == nil {
+		starts, perr := parsePartitionStarts(out)
+		if perr != nil {
+			return nil, fmt.Errorf("overlay resize: %w", perr)
+		}
+		return starts, nil
+	}
+
+	// Only an unsupported-column failure is retried through sfdisk. Any other
+	// lsblk error (missing device, permissions, …) is a genuine problem and must
+	// surface as-is rather than being masked by a second tool.
+	if !isUnknownColumnError(out, err) {
+		return nil, fmt.Errorf("overlay resize: failed to read partition layout of %s: %w", loopDevPath, err)
+	}
+	log.Infof("Overlay resize: lsblk on this host does not support the START column "+
+		"(util-linux < 2.38); reading the partition layout of %s with sfdisk instead", loopDevPath)
+
+	sfdiskCmd := fmt.Sprintf("sfdisk -d %s", shell.QuoteArg(loopDevPath))
+	sfOut, sfErr := resizeExec(sfdiskCmd)
+	if sfErr != nil {
+		return nil, fmt.Errorf(
+			"overlay resize: failed to read partition layout of %s (lsblk lacks the START column on this "+
+				"host and the sfdisk fallback also failed): %w", loopDevPath, sfErr)
+	}
+	starts, perr := parseSfdiskPartitionStarts(sfOut)
+	if perr != nil {
+		return nil, fmt.Errorf("overlay resize: %w", perr)
+	}
+	return starts, nil
+}
+
+// isUnknownColumnError reports whether an lsblk invocation failed specifically
+// because a requested output column is not known to this lsblk build. util-linux
+// prints "lsblk: unknown column: START,TYPE" on stderr and exits non-zero; the
+// exec wrapper folds that text into the captured output, so match on it there and
+// fall back only for this one recoverable cause.
+func isUnknownColumnError(out string, err error) bool {
+	if err == nil {
+		return false
+	}
+	haystack := strings.ToLower(out + " " + err.Error())
+	return strings.Contains(haystack, "unknown column")
+}
+
+// parseSfdiskPartitionStarts extracts each partition's start sector from
+// `sfdisk -d` output, keyed by device path. The dump lists one partition per line
+// after a header block:
+//
+//	label: gpt
+//	sector-size: 512
+//
+//	/dev/loop0p1 : start=     2099200, size=    48232415, type=0FC63DAF-…
+//	/dev/loop0p15 : start=       10240, size=      217088, type=C12A7328-…
+//
+// Header lines carry no "start=" field and are skipped. As with the lsblk parser
+// this fails closed: a partition line whose start is missing or unparseable
+// aborts the guard rather than defaulting to 0, since a silent 0 would make a
+// later partition look like it precedes root and could let growpart run into it.
+func parseSfdiskPartitionStarts(sfdiskDump string) (map[string]int64, error) {
+	starts := make(map[string]int64)
+	for _, line := range strings.Split(sfdiskDump, "\n") {
+		line = strings.TrimSpace(line)
+		// A partition entry is "<device> : start=<n>, size=<n>, …". Anything
+		// without both the " : " separator and a start= field is header noise.
+		devPart, fields, found := strings.Cut(line, ":")
+		if !found || !strings.Contains(fields, "start=") {
+			continue
+		}
+		device := strings.TrimSpace(devPart)
+		if device == "" {
+			continue
+		}
+
+		var startText string
+		for _, field := range strings.Split(fields, ",") {
+			key, value, ok := strings.Cut(strings.TrimSpace(field), "=")
+			if ok && strings.EqualFold(strings.TrimSpace(key), "start") {
+				startText = strings.TrimSpace(value)
+				break
+			}
+		}
+		start, convErr := strconv.ParseInt(startText, 10, 64)
+		if convErr != nil {
+			return nil, fmt.Errorf(
+				"missing or unparseable start offset for partition %s in sfdisk output", device)
+		}
+		starts[device] = start
+	}
+	if len(starts) == 0 {
+		return nil, fmt.Errorf("no partitions found in sfdisk output")
+	}
+	return starts, nil
 }
 
 // parsePartitionStarts extracts the START sector offset of each partition node

--- a/internal/image/overlay/resize_test.go
+++ b/internal/image/overlay/resize_test.go
@@ -1,6 +1,7 @@
 package overlay
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -473,5 +474,193 @@ func TestResizeBaseline_NilGuards(t *testing.T) {
 	}
 	if err := ResizeBaseline(&config.ImageTemplate{}, &Context{}, nil); err == nil {
 		t.Error("expected error for nil layout")
+	}
+}
+
+// The START column that assertRootIsLastPartition relies on only exists from
+// util-linux 2.38. On an older host (Ubuntu 22.04 ships 2.37.2) lsblk fails with
+// "unknown column: START,TYPE"; the resize must then read the layout with sfdisk
+// rather than aborting the build.
+func TestPartitionStarts_FallsBackToSfdiskWhenStartColumnUnsupported(t *testing.T) {
+	origExec := resizeExec
+	defer func() { resizeExec = origExec }()
+
+	var sawSfdisk bool
+	resizeExec = func(cmd string) (string, error) {
+		if strings.Contains(cmd, "lsblk") {
+			return "lsblk: unknown column: START,TYPE", errors.New("exit status 1")
+		}
+		if strings.Contains(cmd, "sfdisk") {
+			sawSfdisk = true
+			return `label: gpt
+sector-size: 512
+
+/dev/loop0p1 : start=     2099200, size=    48232415, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+/dev/loop0p14 : start=        2048, size=        8192, type=21686148-6449-6E6F-744E-656564454649
+/dev/loop0p15 : start=       10240, size=      217088, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+`, nil
+		}
+		return "", nil
+	}
+
+	starts, err := partitionStarts("/dev/loop0")
+	if err != nil {
+		t.Fatalf("partitionStarts: %v", err)
+	}
+	if !sawSfdisk {
+		t.Fatal("expected the sfdisk fallback to run when lsblk rejects the START column")
+	}
+	// Same offsets lsblk would have reported, so the caller's comparison is unchanged.
+	for dev, want := range map[string]int64{
+		"/dev/loop0p1":  2099200,
+		"/dev/loop0p14": 2048,
+		"/dev/loop0p15": 10240,
+	} {
+		if got := starts[dev]; got != want {
+			t.Errorf("start[%s] = %d, want %d", dev, got, want)
+		}
+	}
+}
+
+// Only an unknown-column failure is recoverable. Any other lsblk error is a real
+// problem (missing device, permissions) and must surface instead of being masked
+// by a second tool.
+func TestPartitionStarts_OtherLsblkErrorDoesNotFallBack(t *testing.T) {
+	origExec := resizeExec
+	defer func() { resizeExec = origExec }()
+
+	var sawSfdisk bool
+	resizeExec = func(cmd string) (string, error) {
+		if strings.Contains(cmd, "sfdisk") {
+			sawSfdisk = true
+			return "", nil
+		}
+		return "lsblk: /dev/loop9: not a block device", errors.New("exit status 32")
+	}
+
+	if _, err := partitionStarts("/dev/loop9"); err == nil {
+		t.Fatal("expected an error when lsblk fails for a non-column reason")
+	}
+	if sawSfdisk {
+		t.Error("sfdisk must not run for an lsblk failure unrelated to column support")
+	}
+}
+
+// A root partition that is genuinely last must still pass the guard when the
+// offsets came from sfdisk, so the fallback does not change the verdict.
+func TestAssertRootIsLastPartition_AcceptsViaSfdiskFallback(t *testing.T) {
+	origExec := resizeExec
+	defer func() { resizeExec = origExec }()
+
+	resizeExec = func(cmd string) (string, error) {
+		if strings.Contains(cmd, "lsblk") {
+			return "lsblk: unknown column: START,TYPE", errors.New("exit status 1")
+		}
+		// Canonical noble cloud layout: root (p1) starts last despite its low
+		// partition number.
+		return `label: gpt
+
+/dev/loop0p1 : start=2099200, size=48232415
+/dev/loop0p15 : start=10240, size=217088
+`, nil
+	}
+
+	if err := assertRootIsLastPartition("/dev/loop0", "/dev/loop0p1"); err != nil {
+		t.Fatalf("expected the guard to accept a last-positioned root: %v", err)
+	}
+}
+
+// ...and a non-last root must still be rejected through the fallback: the
+// fallback is a different data source, not a relaxation of the safety rule.
+func TestAssertRootIsLastPartition_RejectsNonLastRootViaSfdiskFallback(t *testing.T) {
+	origExec := resizeExec
+	defer func() { resizeExec = origExec }()
+
+	resizeExec = func(cmd string) (string, error) {
+		if strings.Contains(cmd, "lsblk") {
+			return "lsblk: unknown column: START,TYPE", errors.New("exit status 1")
+		}
+		return `/dev/loop0p1 : start=2048, size=1000
+/dev/loop0p2 : start=999999, size=1000
+`, nil
+	}
+
+	err := assertRootIsLastPartition("/dev/loop0", "/dev/loop0p1")
+	if err == nil {
+		t.Fatal("expected rejection: p2 starts after the root partition")
+	}
+	var unsupported *unsupportedLayoutError
+	if !errors.As(err, &unsupported) {
+		t.Errorf("expected unsupportedLayoutError, got %T: %v", err, err)
+	}
+}
+
+func TestParseSfdiskPartitionStarts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dump    string
+		want    map[string]int64
+		wantErr bool
+	}{
+		{
+			name: "header lines are skipped",
+			dump: `label: gpt
+label-id: 71A3CDBA-34C4-4018-AC81-DB7EF3A22198
+device: /dev/loop0
+unit: sectors
+first-lba: 34
+last-lba: 50331614
+sector-size: 512
+
+/dev/loop0p1 : start=2099200, size=48232415, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+`,
+			want: map[string]int64{"/dev/loop0p1": 2099200},
+		},
+		{
+			// "device: /dev/loop0" in the header also contains a colon but carries
+			// no start= field, so it must not be mistaken for a partition.
+			name: "device header is not treated as a partition",
+			dump: `device: /dev/loop0
+/dev/loop0p1 : start=2048, size=100
+`,
+			want: map[string]int64{"/dev/loop0p1": 2048},
+		},
+		{
+			name:    "a partition line with an unparseable start fails closed",
+			dump:    `/dev/loop0p1 : start=notanumber, size=100`,
+			wantErr: true,
+		},
+		{
+			name:    "no partition lines at all is an error, never an empty map",
+			dump:    "label: gpt\nsector-size: 512\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseSfdiskPartitionStarts(tt.dump)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got starts=%v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSfdiskPartitionStarts: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d partition(s) %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for dev, want := range tt.want {
+				if got[dev] != want {
+					t.Errorf("start[%s] = %d, want %d", dev, got[dev], want)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Overlay resize fails outright on Ubuntu 22.04:

```
overlay resize: failed to read partition layout of /dev/loop25:
failed to execute command with output "lsblk: unknown column: START,TYPE"
```

`assertRootIsLastPartition` reads each partition's start offset with
`lsblk -o PATH,START,TYPE` to confirm the root partition is last before letting
`growpart` extend it. **The `START` column only exists from util-linux 2.38 onward**;
Ubuntu 22.04 ships 2.37.2, so the command fails and takes the whole build with it —
*after* the baseline has already been downloaded, resolved and preflighted.

Compounding it, `checkResizeToolsAvailable` probes that `lsblk` **exists** but not
that it supports the column the guard needs, so the failure surfaces late and its
message points at the loop device rather than at the host's util-linux version.

Hit while building an overlay template on a 22.04 host; the repo's README
recommends Ubuntu 24.04, but the failure mode gives no hint that the host version
is the problem.

#### The fix

Fall back to `sfdisk -d`, which reports the same offsets and has carried its dump
format far longer. `sfdisk` is already on the shell allowlist.

- **Only** an unknown-column failure is retried this way. Any other `lsblk` error
  (missing device, permissions) still surfaces as-is rather than being masked by a
  second tool.
- `sfdisk` joins the up-front required-tools probe, so a host missing it fails early
  with the existing actionable message instead of part-way through the guard.

**Units matter here**, since mixing them would be a correctness bug: both sources
report **sectors**. `lsblk`'s `START` is a sector offset even under `-b` — verified
against one disk, where `lsblk` and `sfdisk` both report `2099200` for a noble cloud
image's root. The guard only compares offsets against each other, so a consistent
unit suffices.

#### The safety property is unchanged

`parseSfdiskPartitionStarts` fails closed exactly as the lsblk parser does: a
partition line with a missing or unparseable start **aborts** the guard rather than
defaulting to `0`. A silent `0` would make a later partition look like it precedes
root and could let `growpart` run into it. A dump with no partition lines is an
error, never an empty map.

#### Any Newly Introduced Dependencies

None. `sfdisk` was already allowlisted in `internal/utils/shell/shell.go`.

#### How Has This Been Tested? <!-- REQUIRED -->

`go build ./cmd/... ./internal/...`, `go vet`, `go test ./cmd/... ./internal/...`
(0 failures) and `gofmt -l` all clean.

New unit tests, using the existing `resizeExec` seam so no loop device or root is
needed:

| Test | Asserts |
|---|---|
| `TestPartitionStarts_FallsBackToSfdiskWhenStartColumnUnsupported` | the fallback fires on an unknown-column error and yields the same offsets |
| `TestPartitionStarts_OtherLsblkErrorDoesNotFallBack` | an unrelated lsblk failure surfaces; sfdisk must **not** run |
| `TestAssertRootIsLastPartition_AcceptsViaSfdiskFallback` | a genuinely-last root still passes through the fallback |
| `TestAssertRootIsLastPartition_RejectsNonLastRootViaSfdiskFallback` | a non-last root is still **rejected** — the fallback is a different data source, not a relaxed rule |
| `TestParseSfdiskPartitionStarts` | header skipping (incl. the `device:` line, which has a colon but no `start=`), and fail-closed on unparseable/absent starts |

The real-world sfdisk output the parser was written against was captured from an
actual overlay artifact rather than invented:

```
label: gpt
sector-size: 512

/dev/nbd0p1 : start=     2099200, size=    48232415, type=0FC63DAF-…
/dev/nbd0p15 : start=       10240, size=      217088, type=C12A7328-…
```
