### PR TITLE
fix(config): drop stale kernel.version pin from the ubuntu24 OS defaults

### DIFF
--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-unattended-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-unattended-x86_64.yml
@@ -67,7 +67,6 @@ systemConfig:
 
   kernel:
     name: kernel
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 systemd.log_level=debug rd.debug"
     packages:
       - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -64,7 +64,6 @@ systemConfig:
 
   kernel:
     name: kernel
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 systemd.log_level=debug rd.debug"
     packages:
       - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-aarch64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-aarch64.yml
@@ -68,7 +68,6 @@ systemConfig:
       final: /etc/apt/sources.list.d/ubuntu-noble.list
 
   kernel:
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-raw-x86_64.yml
@@ -78,7 +78,6 @@ systemConfig:
       final: /etc/apt/sources.list.d/ubuntu-noble.list
 
   kernel:
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic-hwe-24.04

--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -96,6 +96,8 @@
 
 **Fixed**
 
+- `fix(config)`: drop stale `kernel.version` pin from the ubuntu24 OS defaults: ubuntu24 builds failed in pre-processing with `kernel version mismatch: requires kernel version "6.17", but available versions are: [6.8.0-31.31 7.0.0-28.28~24.04.1]`. Four default configs under `config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/` pinned `kernel.version: "6.17"` alongside the rolling metapackage `linux-image-generic-hwe-24.04`, and Ubuntu noble no longer ships 6.17. Any template without its own `kernel.version` inherited the stale pin, so `ubuntu24-x86_64-minimal-initrd.yml` and `ubuntu24-x86_64-dkms-demo.yml` failed even though the templates themselves were already clean. #765 removed this antipattern from the 12 affected user templates but did not cover the OS defaults, which is why the failure recurred; `image-templates/robotics-demo-ubuntu24-x86_64.yml` was also missed there and is fixed here. Dropping the pin lets `apt` resolve whatever the metapackage currently points to — no pin, nothing to go stale. Templates that pin a concrete kernel package (for example `linux-image-6.11.0-17-generic`, `linux-image-6.12-intel`) are unaffected.
+
 - `fix(ubuntu)`: `AllowPackages` not propagated to debutils.Repository (#480): The `allowPackages` list in user-provided package repository configuration was silently dropped instead of being passed through to the DEB package resolver.
 
 - `fix(inspect)`: ext4 filesystem misdetection in image inspect (#484): The image inspect command was incorrectly classifying some ext4 partitions as a different filesystem type.

--- a/image-templates/robotics-demo-ubuntu24-x86_64.yml
+++ b/image-templates/robotics-demo-ubuntu24-x86_64.yml
@@ -151,7 +151,6 @@ systemConfig:
     - ros-jazzy-demo-nodes-py
 
   kernel:
-    version: "6.17"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic-hwe-24.04


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

ubuntu24 builds fail in pre-processing, while downloading image packages:

```
ERROR debutils/download.go:988  kernel version mismatch: requires kernel version "6.17",
                                but available versions are: [6.8.0-31.31 7.0.0-28.28~24.04.1]
```

Four default configs under `config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/`
pin `kernel.version: "6.17"` alongside the **rolling** metapackage
`linux-image-generic-hwe-24.04`, and Ubuntu noble no longer ships 6.17 — the HWE
series has rolled past it. `archive.ubuntu.com` currently offers, for that
metapackage:

| Pocket | Version |
|---|---|
| `noble` (GA) | `6.8.0-31.31` |
| `noble-updates` | `7.0.0-28.28~24.04.1` |

which is the error message verbatim.

##### Templates that look clean still fail

A template inherits the default's `kernel` block whenever it does not set
`kernel.version` itself, so the stale pin reaches templates that were already fixed:

| Reproducer | Where the 6.17 comes from |
|---|---|
| `ubuntu24-x86_64-minimal-initrd.yml` | declares **no** `kernel` block → `default-initrd-x86_64.yml` |
| `ubuntu24-x86_64-dkms-demo.yml` | declares a `kernel` block with **no** `version` → `default-raw-x86_64.yml` |
| `default-initrd-x86_64.yml` | built directly |

##### Which CI workflows this repairs

Resolving every ubuntu24 template that a build workflow exercises shows **five**
inheriting the stale pin — so the blast radius is wider than the reported
reproducers:

| Workflow | Template | `kernel.version` before | after |
|---|---|---|---|
| `build-ubuntu24-immutable` | `ubuntu24-x86_64-edge-raw.yml` | `6.17` | `''` |
| `build-ubuntu24-raw` | `ubuntu24-x86_64-minimal-raw.yml` | `6.17` | `''` |
| `build-ubuntu24-arm-raw` | `ubuntu24-aarch64-minimal-raw.yml` | `6.17` | `''` |
| *(not CI-built)* | `ubuntu24-x86_64-minimal-initrd.yml` | `6.17` | `''` |
| *(not CI-built)* | `ubuntu24-x86_64-dkms-demo.yml` | `6.17` | `''` |
| *(not CI-built)* | `robotics-demo-ubuntu24-x86_64.yml` | `6.17` | `''` |

**This means the long-standing `build-ubuntu24-immutable` failure on `main` is this
bug**, reached through `edge-raw` → `default-raw-x86_64.yml` — not an unrelated
breakage as it has been assumed to be. This PR should turn that job green, which is
useful independent confirmation of the fix.

Not affected: `build-ubuntu24-iso` and `build-ubuntu24-unattended-iso` already
resolve to no pin, and `build-ubuntu24-dlstreamer` pins a *concrete* kernel package
(`linux-image-6.12-intel`), which is legitimate and untouched.

##### Relation to #765

**#765 removed exactly this antipattern from the 12 affected user templates but never
touched the OS defaults.** That is the whole of this bug, and the reason the failure
returned for a fourth time after #494 (6.14→6.17), #669 (6.17→7.0) and #761
(6.17→6.8). #765's own description lists `ubuntu24-x86_64-dkms-demo.yml` as fixed —
it was, at the template layer only.

`image-templates/robotics-demo-ubuntu24-x86_64.yml` was also missed by #765 and
carries the same `6.17` + rolling-metapackage pairing, so it is fixed here too.

#### The fix

Drop the `version:` line; keep the metapackage. `KernelVersion == ""` makes
`matchesKernelVersion` short-circuit (`internal/ospackage/debutils/resolver.go:1392-1395`)
and skips the mismatch guard (`internal/ospackage/debutils/download.go:1019`), so
`apt` resolves whatever the metapackage currently points to. No pin, nothing to go
stale.

**Deliberately no replacement version.** Substituting a new number is what produced
the previous three iterations of this fix. Templates that pin a *concrete* kernel
package (`linux-image-6.11.0-17-generic`, `linux-image-6.12-intel`,
`linux-image-6.18-intel`) genuinely mean it and are unaffected.

5 files, 5 deleted lines, plus one release note.

#### Still carrying the same pattern, left out of scope

Both resolve against today's archive, so neither is failing — but both are one roll
from the identical break, and are worth a follow-up:

- The three ubuntu26 defaults (`default-raw-x86_64.yml`, `default-raw-aarch64.yml`,
  `default-initrd-x86_64.yml`) pin `7.0` with rolling `linux-image-generic`.
- `image-templates/ubuntu24-x86_64-fde-raw.yml` pins `6.8.0-31.31` with the rolling
  HWE metapackage.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

Built, not just resolved:

```
sudo -E ./image-composer-tool build image-templates/ubuntu24-x86_64-minimal-initrd.yml
  -> minimal-os-image-ubuntu-24.04.img, 1m58s
  -> grep -c "kernel version mismatch" == 0
```

All six affected templates now resolve with an empty `kernel.version` and their
metapackage lists unchanged.

`go build ./cmd/... ./internal/...` clean, and `validate` over every template passes
except the pre-existing `ubuntu24-x86_64-fde-raw.yml`, whose `fde.passphraseFile`
points at a nonexistent `/home/user/test-fde.txt` (unrelated to this change).

> This fix was previously folded into the template-reorg PR #796 (and before that
> stood alone as #802). It is re-isolated here because it is an urgent
> build-blocking fix that should not wait on a larger refactor. The duplicate commit
> has been removed from #796.
