### PR TITLE
test(api): de-flake TestHandleStartBuildAccepted status assertion

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -271,9 +271,12 @@ func TestHandleStartBuildErrors(t *testing.T) {
 
 // TestHandleStartBuildAccepted starts a real build against the fake ICT binary,
 // which exits 0 immediately, so the handler returns 202 with the accepted
-// envelope. The status is the build's real state at that instant — not-started
-// until the child's process group is recorded, then running — so accept either
-// rather than pinning a hardcoded "running" the server no longer reports.
+// envelope. The status is the build's real state at the instant the response is
+// snapshotted: StartBuild launches the build goroutine and then reads the
+// status, so under load (few CPUs, e.g. GOMAXPROCS=1) the fast-exiting fake can
+// race all the way to success before that read. Accept any of the states this
+// happy path can legitimately be in — not-started, running, or success — rather
+// than pinning an early one and flaking when the goroutine wins the race.
 func TestHandleStartBuildAccepted(t *testing.T) {
 	s, _ := newTestServer(t)
 	body := `{"compose":{"vertical":"robotics","sku":"amr","platform":"wcl","os":"ubuntu24","imageType":"iso"}}`
@@ -289,9 +292,13 @@ func TestHandleStartBuildAccepted(t *testing.T) {
 		!strings.HasSuffix(acc.LogsUrl, "/logs") {
 		t.Errorf("unexpected accepted envelope: %+v", acc)
 	}
-	if acc.Status != httpapi.BuildStatus(service.StatusNotStarted) &&
-		acc.Status != httpapi.BuildStatus(service.StatusRunning) {
-		t.Errorf("status = %q, want not-started or running", acc.Status)
+	switch acc.Status {
+	case httpapi.BuildStatus(service.StatusNotStarted),
+		httpapi.BuildStatus(service.StatusRunning),
+		httpapi.BuildStatus(service.StatusSuccess):
+		// expected for a fast, successful build
+	default:
+		t.Errorf("status = %q, want not-started, running, or success", acc.Status)
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestHandleStartBuildAccepted` is flaky and intermittently fails CI's "Unit Tests & Coverage Gate" across unrelated PRs with:

```
api_test.go: status = "success", want not-started or running
```

## Root cause

`Service.StartBuild` launches the build goroutine and *then* snapshots the build status for the 202 response body. The test's fake ICT binary exits 0 immediately, so under CPU pressure (reproducible locally with `GOMAXPROCS=1`, and hit on loaded CI runners) the goroutine can drive the build all the way to `success` before the response snapshot is read. The HTTP status is still a correct **202** — only the embedded `status` field is further along than the assertion allowed.

## Fix

Accept `success` in addition to `not-started`/`running` — every state this happy path can legitimately report at that instant. Test-only change; no production code touched.

## Verification

- `GOMAXPROCS=1 go test ./internal/api/ -run TestHandleStartBuildAccepted -count=600` — passes (previously failed within a few hundred iterations).
- `go build ./internal/... ./cmd/...`, `go vet`, `gofmt -l` — clean.