### PR TITLE
fix(build): return artifact ownership to the sudo invoker and drop redundant inner sudo

### DIFF
--- a/.github/workflows/gitleak-scan.yml
+++ b/.github/workflows/gitleak-scan.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           scan-scope: "all"
           source: "./"
+          version: "8.28.0"
           config_path: "./ci/gitleaks_baselines/image-composer-tool-gitleaks.sarif"
           report_format: "sarif"
           redact: "true"

--- a/cmd/image-composer-tool/build.go
+++ b/cmd/image-composer-tool/build.go
@@ -379,6 +379,52 @@ post:
 			}
 		}
 
+		// The build ran as root, so the output directory and image/SBOM inside it are
+		// owned by root:root and unreadable to the user who invoked `sudo`. Hand ownership
+		// of the artifact directory (and the path leading to it) back to that user so they
+		// can read/remove their own build output without root. This targets only the final
+		// artifact tree — the sibling chroot trees stay root-owned. Best-effort: a chown
+		// failure is logged but does not fail an otherwise successful build.
+		//
+		// In --no-cache mode the artifacts were just copied into the configured workspace
+		// (originalWorkDir); chown that copy, not the temporary workspace that cleanup removes.
+		chownWorkDir, workDirErr := config.WorkDir()
+		if isolated != nil {
+			chownWorkDir, workDirErr = isolated.OutputWorkDir(), nil
+		}
+		if workDirErr != nil {
+			log.Warnf("skipping artifact ownership restore: resolving work directory: %v", workDirErr)
+		} else {
+			providerId := system.GetProviderId(template.Target.OS, template.Target.Dist, template.Target.Arch)
+			imageBuildDir := filepath.Join(chownWorkDir, providerId, "imagebuild", template.GetSystemConfigName())
+			if err := system.ChownArtifactsToSudoUser(chownWorkDir, imageBuildDir); err != nil {
+				log.Warnf("could not fully restore build artifact ownership to invoking user: %v", err)
+			}
+		}
+
+		// Also hand back the temp directory, which the root build populated with GPG
+		// keys and decompressed metadata — inert scratch the user should be able to
+		// delete without root. Unlike the workspace it holds no extracted rootfs, so a
+		// full recursive chown is safe. The cache directory is intentionally LEFT
+		// root-owned: it persists across builds for reuse, and later root builds would
+		// recreate root-owned files inside it anyway.
+		//
+		// This runs in --no-cache mode too: SetupIsolated only makes the cache and
+		// workspace unique, not config.TempDir(), so a root --no-cache build still
+		// populates the shared temp dir and its cleanup does not remove it. Skipping the
+		// chown there would strand root-owned temp content the user cannot delete.
+		//
+		// config.TempDir() returns the configured temp dir (default ./tmp) as-is, or the
+		// system temp dir when temp_dir is left empty; ChownDirTreeToSudoUser refuses the
+		// latter, so an empty temp_dir safely no-ops rather than chowning /tmp. Resolve to
+		// an absolute path for that guard to apply.
+		tempDirPath, err := filepath.Abs(config.TempDir())
+		if err != nil {
+			log.Warnf("skipping temp ownership restore: resolving temp directory: %v", err)
+		} else if err := system.ChownDirTreeToSudoUser(tempDirPath); err != nil {
+			log.Warnf("could not fully restore temp directory ownership to invoking user: %v", err)
+		}
+
 		log.Info("image build completed successfully")
 		template.MarkBuildFinished()
 		// Overlay builds do not run through the create-mode stages that populate the

--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -68,7 +68,7 @@
 
 - `apt-get` install with `--no-install-recommends`: DEB package installation in the chroot environment now passes `--no-install-recommends`, reducing unnecessary package pulls.
 
-- sudo suppressed when already root: `GetFullCmdStr` detects when the process is already running as root (`euid == 0`) and omits the sudo prefix in chroot commands, avoiding permission escalation errors in CI environments that run as root.
+- sudo suppressed when already root: `GetFullCmdStr` detects when the process is already running as root (`euid == 0`) and omits the redundant inner `sudo` prefix from both chroot and host commands. ICT is launched as root (`sudo -E image-composer-tool build ...`, or the server's `sudo -n ...`), so an inner `sudo` is a root-to-root no-op that only forks an extra process per command; dropping it also avoids permission-escalation errors in CI environments that run as root. When the process is not root the prefix is kept so the per-command sudo model still elevates.
 
 - Partition mount-point path resolution: `resolveInstallRootMountPoint` is now the single canonical function for joining the install root and partition mount points. It handles empty, /-absolute, and relative mount-point strings uniformly.
 

--- a/internal/cache/isolated.go
+++ b/internal/cache/isolated.go
@@ -82,6 +82,14 @@ func SetupIsolated(originalCacheDir, originalWorkDir string) (*Isolated, func(),
 	return isolated, cleanup, nil
 }
 
+// OutputWorkDir returns the workspace that holds the build's final output after
+// cleanup. For --no-cache builds the artifacts are copied by PreserveOutput from
+// the temporary workspace back to the originally configured one, so that is where
+// the user-facing image ends up — not the isolated WorkDir, which cleanup removes.
+func (isolated *Isolated) OutputWorkDir() string {
+	return isolated.originalWorkDir
+}
+
 // KeepWorkspace marks the isolated workspace to be preserved by cleanup — e.g. when a
 // PostProcess step or the output copy-out fails and the partial build is needed for
 // recovery.

--- a/internal/utils/shell/shell.go
+++ b/internal/utils/shell/shell.go
@@ -570,6 +570,33 @@ func verifyCmdWithFullPath(cmd, chrootPath string) (string, error) {
 	return updatedCmdStr, nil
 }
 
+// geteuid is indirected through a package variable so tests can exercise the
+// root and non-root branches of sudoPrefix without actually running as root.
+// Production always uses os.Geteuid.
+var geteuid = os.Geteuid
+
+// sudoPrefix returns the "sudo " command prefix only when elevation is actually
+// needed — i.e. when the process is not already root.
+//
+// ICT is documented to run as root: the CLI via `sudo -E image-composer-tool
+// build …`, and the web server (serve --sudo) via `sudo -n image-composer-tool
+// build …`. In both cases the ICT process itself is already euid 0, so an inner
+// `sudo` prepended to each spawned command is a redundant root→root elevation
+// that only forks an extra sudo process per command (and, on the serve path,
+// would otherwise need its own sudoers entry). When euid == 0 we omit it and the
+// command runs directly as the already-root process.
+//
+// When euid != 0 the prefix is kept so a non-root invocation still elevates each
+// command through sudo (the per-command sudo model). Note kill/kill semantics
+// for signal delivery still assume the documented already-root model — see the
+// privilege note on applyExecAttrs.
+func sudoPrefix() string {
+	if geteuid() == 0 {
+		return ""
+	}
+	return "sudo "
+}
+
 // GetFullCmdStr prepares a command string with necessary prefixes
 func GetFullCmdStr(cmdStr string, sudo bool, chrootPath string, envVal []string) (string, error) {
 	var fullCmdStr string
@@ -594,7 +621,9 @@ func GetFullCmdStr(cmdStr string, sudo bool, chrootPath string, envVal []string)
 			envValStr += key + "=" + value + " "
 		}
 
-		fullCmdStr = "sudo " + envValStr + "chroot " + chrootPath + " " + fullPathCmdStr
+		// chroot always requires elevation; sudoPrefix drops the redundant inner
+		// sudo when the process is already root (see sudoPrefix docstring).
+		fullCmdStr = sudoPrefix() + envValStr + "chroot " + chrootPath + " " + fullPathCmdStr
 		chrootDir := filepath.Base(chrootPath)
 		// log.Debugf("Chroot " + chrootDir + " Exec: [" + fullPathCmdStr + "]")
 		// Avoid logging full command string to prevent leaking sensitive data.
@@ -608,7 +637,9 @@ func GetFullCmdStr(cmdStr string, sudo bool, chrootPath string, envVal []string)
 				envValStr += key + "=" + value + " "
 			}
 
-			fullCmdStr = "sudo " + envValStr + fullPathCmdStr
+			// sudoPrefix drops the redundant inner sudo when already root
+			// (see sudoPrefix docstring); otherwise elevates per command.
+			fullCmdStr = sudoPrefix() + envValStr + fullPathCmdStr
 			// log.Debugf("Exec: [sudo " + fullPathCmdStr + "]")
 			// Avoid logging full command string to prevent leaking sensitive data.
 			log.Debugf("Exec with sudo: [command executed]")

--- a/internal/utils/shell/shell_sudoprefix_internal_test.go
+++ b/internal/utils/shell/shell_sudoprefix_internal_test.go
@@ -1,0 +1,111 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withEuid swaps the package-level geteuid seam for the duration of a test so
+// the root / non-root branches of sudoPrefix can be exercised without actually
+// changing the process's privileges.
+func withEuid(t *testing.T, uid int) {
+	t.Helper()
+	orig := geteuid
+	geteuid = func() int { return uid }
+	t.Cleanup(func() { geteuid = orig })
+}
+
+func TestSudoPrefix_SuppressedWhenRoot(t *testing.T) {
+	withEuid(t, 0)
+	if got := sudoPrefix(); got != "" {
+		t.Errorf("sudoPrefix() as root = %q, want empty (inner sudo is redundant)", got)
+	}
+}
+
+func TestSudoPrefix_KeptWhenNonRoot(t *testing.T) {
+	withEuid(t, 1000)
+	if got := sudoPrefix(); got != "sudo " {
+		t.Errorf("sudoPrefix() as non-root = %q, want %q", got, "sudo ")
+	}
+}
+
+// TestGetFullCmdStr_HostSudoSuppressedWhenRoot verifies the host (non-chroot)
+// branch drops the inner sudo when already root but still emits the full binary
+// path and env vars.
+func TestGetFullCmdStr_HostSudoSuppressedWhenRoot(t *testing.T) {
+	withEuid(t, 0)
+	got, err := GetFullCmdStr("ls", true, HostPath, []string{"VAR=VALUE"})
+	if err != nil {
+		t.Fatalf("GetFullCmdStr: %v", err)
+	}
+	if strings.HasPrefix(got, "sudo ") {
+		t.Errorf("expected no leading sudo when root, got: %s", got)
+	}
+	if !strings.Contains(got, "VAR=VALUE") {
+		t.Errorf("expected env var preserved, got: %s", got)
+	}
+}
+
+func TestGetFullCmdStr_HostSudoKeptWhenNonRoot(t *testing.T) {
+	withEuid(t, 1000)
+	got, err := GetFullCmdStr("ls", true, HostPath, nil)
+	if err != nil {
+		t.Fatalf("GetFullCmdStr: %v", err)
+	}
+	if !strings.HasPrefix(got, "sudo ") {
+		t.Errorf("expected leading sudo when non-root, got: %s", got)
+	}
+}
+
+// TestGetFullCmdStr_ChrootSudoSuppressedWhenRoot verifies the chroot branch
+// drops the inner sudo when root while still emitting `chroot <path> <cmd>`.
+func TestGetFullCmdStr_ChrootSudoSuppressedWhenRoot(t *testing.T) {
+	withEuid(t, 0)
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "ls"), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetFullCmdStr("ls", false, tempDir, nil)
+	if err != nil {
+		t.Fatalf("GetFullCmdStr: %v", err)
+	}
+	if strings.HasPrefix(got, "sudo ") {
+		t.Errorf("expected no leading sudo in chroot cmd when root, got: %s", got)
+	}
+	if !strings.Contains(got, "chroot "+tempDir+" /bin/ls") {
+		t.Errorf("expected chroot invocation preserved, got: %s", got)
+	}
+}
+
+func TestGetFullCmdStr_ChrootSudoKeptWhenNonRoot(t *testing.T) {
+	withEuid(t, 1000)
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "ls"), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetFullCmdStr("ls", false, tempDir, nil)
+	if err != nil {
+		t.Fatalf("GetFullCmdStr: %v", err)
+	}
+	// Proxy env vars may be interpolated between `sudo ` and `chroot ` (see
+	// GetOSProxyEnvirons), so assert the leading sudo and the chroot invocation
+	// separately rather than requiring them to be adjacent.
+	if !strings.HasPrefix(got, "sudo ") {
+		t.Errorf("expected leading sudo when non-root, got: %s", got)
+	}
+	if !strings.Contains(got, "chroot "+tempDir+" /bin/ls") {
+		t.Errorf("expected chroot invocation preserved, got: %s", got)
+	}
+}

--- a/internal/utils/system/ownership.go
+++ b/internal/utils/system/ownership.go
@@ -201,9 +201,20 @@ func refuseDangerousChownRoot(dir string) error {
 	if dir == string(os.PathSeparator) {
 		return fmt.Errorf("refusing to recursively chown filesystem root %q", dir)
 	}
-	if sys := filepath.Clean(os.TempDir()); dir == sys {
+	sys := filepath.Clean(os.TempDir())
+	if resolved, err := filepath.EvalSymlinks(sys); err == nil {
+		sys = resolved
+	}
+	if dir == sys {
 		return fmt.Errorf("refusing to recursively chown the system temp directory %q "+
 			"(set a dedicated temp_dir to enable ownership restore)", dir)
+	}
+	// Refuse common shared system trees (or their descendants) that are not
+	// ICT-managed private workspaces and are likely to be used by other services.
+	for _, root := range []string{"/var/tmp", "/var/cache", "/var/lib"} {
+		if dir == root || strings.HasPrefix(dir, root+string(os.PathSeparator)) {
+			return fmt.Errorf("refusing to recursively chown shared system directory %q", dir)
+		}
 	}
 	// A top-level directory like "/tmp" or "/var" has a parent of "/". ICT's own
 	// cache/temp dirs are always nested at least one level below a top-level dir

--- a/internal/utils/system/ownership.go
+++ b/internal/utils/system/ownership.go
@@ -1,0 +1,258 @@
+package system
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// sudoUserIDs returns the uid/gid of the user who invoked the tool via sudo.
+//
+// sudo exports SUDO_UID/SUDO_GID for the original (unprivileged) invoker. When
+// they are absent the tool was not started through sudo — it is running as a
+// genuine root login or inside a container where there is no unprivileged owner
+// to hand artifacts back to — so ownership must be left as-is. A SUDO_UID of 0
+// (root escalating to root) is treated the same: there is nothing to drop to.
+// ok is false in every one of those cases so callers no-op rather than chowning
+// files to uid 0 (a no-op that would still walk the tree pointlessly).
+func sudoUserIDs() (uid, gid int, ok bool) {
+	uidStr := strings.TrimSpace(os.Getenv("SUDO_UID"))
+	gidStr := strings.TrimSpace(os.Getenv("SUDO_GID"))
+	if uidStr == "" || gidStr == "" {
+		return 0, 0, false
+	}
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil || uid <= 0 {
+		return 0, 0, false
+	}
+	gid, err = strconv.Atoi(gidStr)
+	if err != nil || gid < 0 {
+		return 0, 0, false
+	}
+	return uid, gid, true
+}
+
+// ChownArtifactsToSudoUser returns ownership of the build's output to the user
+// who invoked the tool via `sudo`, so the resulting image/SBOM are readable and
+// removable without root.
+//
+// The tool runs as root (for loop devices, mount, chroot), which leaves every
+// directory and file it creates owned by root:root — including the final image
+// directory — so the invoking user cannot read or delete their own build output.
+// This restores access with the minimum ownership change:
+//
+//   - The path nodes from workDir down to imageBuildDir's parent are chowned
+//     non-recursively (one inode each). That transfers ownership of the directory
+//     nodes themselves — enough for the user to traverse (cd) and list them —
+//     WITHOUT touching their other children. In particular the sibling chroot
+//     trees (chrootenv/, chrootbuild/) keep their root:root ownership, which they
+//     must: they are real root filesystems whose file ownership is load-bearing.
+//   - imageBuildDir itself is chowned recursively, so every artifact inside it
+//     (the .raw/.iso, SBOM, checksums, converted images) becomes user-owned.
+//
+// imageBuildDir must be equal to or nested under workDir; both must be absolute.
+// The walk uses Lchown and does not follow symlinks, so a symlink planted in the
+// artifact directory cannot redirect the chown outside the tree.
+//
+// It is best-effort: individual chown failures are collected and returned as a
+// single joined error for the caller to log, but they never abort the build —
+// a successfully built image the user cannot chmod is still a successfully built
+// image. When the tool was not invoked via sudo it is a no-op returning nil.
+func ChownArtifactsToSudoUser(workDir, imageBuildDir string) error {
+	uid, gid, ok := sudoUserIDs()
+	if !ok {
+		log.Debugf("SUDO_UID/SUDO_GID unset or root; leaving build artifact ownership unchanged")
+		return nil
+	}
+
+	workDir = filepath.Clean(workDir)
+	imageBuildDir = filepath.Clean(imageBuildDir)
+	if !filepath.IsAbs(workDir) || !filepath.IsAbs(imageBuildDir) {
+		return fmt.Errorf("chown artifacts: workDir %q and imageBuildDir %q must both be absolute", workDir, imageBuildDir)
+	}
+
+	// Reject an obvious escape on the lexical paths first, so a target that is
+	// plainly outside workDir is refused even when it does not exist yet.
+	if err := assertContained(workDir, imageBuildDir); err != nil {
+		return err
+	}
+
+	// Lchown does not follow a final symlink, but a symlinked *intermediate*
+	// component (e.g. workDir/<provider> pointing at /etc) is resolved by the
+	// kernel during path traversal, so the recursive walk below would descend the
+	// real target instead of the tree we validated. Resolve both paths to their
+	// real locations and re-check containment so the paths we walk are the ones we
+	// vetted. Resolution is best-effort: a not-yet-materialised path keeps its
+	// cleaned form (the lexical check above already ran).
+	if resolved, err := filepath.EvalSymlinks(workDir); err == nil {
+		workDir = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(imageBuildDir); err == nil {
+		imageBuildDir = resolved
+	}
+	// Never recursively chown a system root (e.g. a workDir misconfigured to "/"
+	// or a top-level directory), matching ChownDirTreeToSudoUser's guard.
+	if err := refuseDangerousChownRoot(workDir); err != nil {
+		return err
+	}
+	if err := assertContained(workDir, imageBuildDir); err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(workDir, imageBuildDir)
+	if err != nil {
+		return fmt.Errorf("chown artifacts: relating %q to %q: %w", imageBuildDir, workDir, err)
+	}
+
+	log.Infof("returning build artifact ownership to invoking user %d:%d under %s", uid, gid, workDir)
+
+	var errs []error
+	// Chown the path nodes non-recursively, from the workspace root down to (but
+	// not including) the artifact leaf. When rel == "." the leaf IS the workspace
+	// root and the loop body never runs — the recursive chown below covers it.
+	current := workDir
+	if err := chownNode(current, uid, gid); err != nil {
+		errs = append(errs, err)
+	}
+	if rel != "." {
+		for _, comp := range strings.Split(rel, string(os.PathSeparator)) {
+			current = filepath.Join(current, comp)
+			if current == imageBuildDir {
+				break // the leaf is handled by the recursive walk below
+			}
+			if err := chownNode(current, uid, gid); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// Chown the artifact directory and everything inside it recursively.
+	errs = append(errs, chownTree(imageBuildDir, uid, gid)...)
+
+	return errors.Join(errs...)
+}
+
+// ChownDirTreeToSudoUser recursively returns ownership of an entire directory
+// tree to the user who invoked the tool via sudo. It is the coarse companion to
+// ChownArtifactsToSudoUser, intended for the cache and temp directories: these
+// hold only inert build inputs (downloaded packages, GPG keys, decompressed
+// metadata) — NOT an extracted root filesystem whose file ownership is
+// load-bearing — so a blanket chown is safe and lets the user re-run or clean
+// up without root.
+//
+// It refuses to touch clearly-dangerous roots — "/", the system temp directory
+// (which ICT falls back to when temp_dir is left empty; see config.TempDir),
+// and any other path that is not a private, ICT-managed subdirectory — so a
+// misconfiguration can never turn this into a recursive chown of /tmp or the
+// whole filesystem. dir must be absolute.
+//
+// Like its sibling it is best-effort (per-file failures are joined and
+// returned, never fatal) and a no-op when the tool was not launched via sudo.
+func ChownDirTreeToSudoUser(dir string) error {
+	uid, gid, ok := sudoUserIDs()
+	if !ok {
+		log.Debugf("SUDO_UID/SUDO_GID unset or root; leaving %s ownership unchanged", dir)
+		return nil
+	}
+
+	dir = filepath.Clean(dir)
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("chown tree: %q must be absolute", dir)
+	}
+	// Resolve symlink components before validating and walking: refuseDangerousChownRoot
+	// and WalkDir must act on the same real directory. Otherwise a symlinked component
+	// (or dir itself being a symlink to, say, "/") could pass the string check yet make
+	// the walk chown a different tree than the one vetted. Best-effort: a path that does
+	// not exist yet keeps its cleaned form and is still checked lexically.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	if err := refuseDangerousChownRoot(dir); err != nil {
+		return err
+	}
+
+	log.Infof("returning ownership of %s to invoking user %d:%d", dir, uid, gid)
+	return errors.Join(chownTree(dir, uid, gid)...)
+}
+
+// assertContained returns an error unless child equals or is nested under parent.
+// Both must already be absolute and cleaned. It is the lexical containment check
+// shared by ChownArtifactsToSudoUser's pre- and post-symlink-resolution guards.
+func assertContained(parent, child string) error {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return fmt.Errorf("chown artifacts: relating %q to %q: %w", child, parent, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("chown artifacts: imageBuildDir %q escapes workDir %q", child, parent)
+	}
+	return nil
+}
+
+// refuseDangerousChownRoot rejects paths that must never be recursively chowned:
+// the filesystem root, the system temp directory (ICT's empty-temp_dir
+// fallback), and any top-level directory (a path with no parent segment, e.g.
+// "/tmp" or "/home"). A safe target is a nested, ICT-created directory such as
+// "<repo>/cache" or "<repo>/tmp".
+func refuseDangerousChownRoot(dir string) error {
+	if dir == string(os.PathSeparator) {
+		return fmt.Errorf("refusing to recursively chown filesystem root %q", dir)
+	}
+	if sys := filepath.Clean(os.TempDir()); dir == sys {
+		return fmt.Errorf("refusing to recursively chown the system temp directory %q "+
+			"(set a dedicated temp_dir to enable ownership restore)", dir)
+	}
+	// A top-level directory like "/tmp" or "/var" has a parent of "/". ICT's own
+	// cache/temp dirs are always nested at least one level below a top-level dir
+	// (e.g. "<workspaceroot>/cache"), so a parent of "/" signals a bare system
+	// directory we must not touch.
+	if filepath.Dir(dir) == string(os.PathSeparator) {
+		return fmt.Errorf("refusing to recursively chown top-level directory %q", dir)
+	}
+	return nil
+}
+
+// chownTree recursively lchowns dir and everything under it, returning the
+// collected per-entry errors (empty when fully successful). Walk errors and
+// individual chown failures are accumulated rather than aborting, so a single
+// unreadable entry does not prevent the rest of the tree from being fixed.
+func chownTree(dir string, uid, gid int) []error {
+	var errs []error
+	walkErr := filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			errs = append(errs, err)
+			return nil // keep walking; best-effort
+		}
+		if chErr := chownNode(path, uid, gid); chErr != nil {
+			errs = append(errs, chErr)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		errs = append(errs, fmt.Errorf("walking directory %q: %w", dir, walkErr))
+	}
+	return errs
+}
+
+// lchown is the ownership-changing primitive, indirected through a package
+// variable so tests can record calls without needing real root (os.Lchown of a
+// file to another uid requires CAP_CHOWN). Production always uses os.Lchown,
+// which does not follow a final symlink.
+var lchown = os.Lchown
+
+// chownNode changes ownership of a single path without following a final
+// symlink. A "no such file" is ignored: the path-node walk visits directories
+// that are always present, but the recursive walk can race a concurrent
+// remove, and a missing node needs no ownership fix.
+func chownNode(path string, uid, gid int) error {
+	if err := lchown(path, uid, gid); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("chown %q to %d:%d: %w", path, uid, gid, err)
+	}
+	return nil
+}

--- a/internal/utils/system/ownership_test.go
+++ b/internal/utils/system/ownership_test.go
@@ -354,6 +354,10 @@ func TestChownDirTree_RefusesDangerousRoots(t *testing.T) {
 		"filesystem root":     string(os.PathSeparator),
 		"system temp dir":     filepath.Clean(os.TempDir()),
 		"top-level directory": "/var",
+		"shared var tmp":      "/var/tmp",
+		"shared var tmp child": "/var/tmp/ict-temp",
+		"shared var cache":    "/var/cache",
+		"shared var lib":      "/var/lib",
 		"relative path":       "cache",
 	}
 	for name, dir := range cases {
@@ -366,6 +370,30 @@ func TestChownDirTree_RefusesDangerousRoots(t *testing.T) {
 				t.Errorf("expected no chown calls when refusing %q, got %v", dir, rec.calls)
 			}
 		})
+	}
+}
+
+func TestChownDirTree_RefusesResolvedSystemTempAlias(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	rec := installChownRecorder(t)
+
+	root := t.TempDir()
+	realTemp := filepath.Join(root, "real-tmp")
+	if err := os.MkdirAll(realTemp, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkTemp := filepath.Join(root, "link-tmp")
+	if err := os.Symlink(realTemp, linkTemp); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TMPDIR", linkTemp)
+
+	if err := ChownDirTreeToSudoUser(realTemp); err == nil {
+		t.Fatalf("expected resolved system temp alias %q to be refused, got nil error", realTemp)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no chown calls when refusing %q, got %v", realTemp, rec.calls)
 	}
 }
 

--- a/internal/utils/system/ownership_test.go
+++ b/internal/utils/system/ownership_test.go
@@ -351,14 +351,14 @@ func TestChownDirTree_RefusesDangerousRoots(t *testing.T) {
 	setSudoEnv(t, "1000", "1000")
 
 	cases := map[string]string{
-		"filesystem root":     string(os.PathSeparator),
-		"system temp dir":     filepath.Clean(os.TempDir()),
-		"top-level directory": "/var",
-		"shared var tmp":      "/var/tmp",
+		"filesystem root":      string(os.PathSeparator),
+		"system temp dir":      filepath.Clean(os.TempDir()),
+		"top-level directory":  "/var",
+		"shared var tmp":       "/var/tmp",
 		"shared var tmp child": "/var/tmp/ict-temp",
-		"shared var cache":    "/var/cache",
-		"shared var lib":      "/var/lib",
-		"relative path":       "cache",
+		"shared var cache":     "/var/cache",
+		"shared var lib":       "/var/lib",
+		"relative path":        "cache",
 	}
 	for name, dir := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/utils/system/ownership_test.go
+++ b/internal/utils/system/ownership_test.go
@@ -1,0 +1,379 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// chownRecorder captures (path, uid, gid) tuples in place of a real Lchown so
+// the traversal logic can be exercised without CAP_CHOWN. It installs itself as
+// the package-level lchown and restores the original on cleanup.
+type chownRecorder struct {
+	calls []string
+}
+
+func installChownRecorder(t *testing.T) *chownRecorder {
+	t.Helper()
+	rec := &chownRecorder{}
+	orig := lchown
+	lchown = func(path string, uid, gid int) error {
+		rec.calls = append(rec.calls, path)
+		return nil
+	}
+	t.Cleanup(func() { lchown = orig })
+	return rec
+}
+
+// setSudoEnv sets SUDO_UID/SUDO_GID for the duration of the test.
+func setSudoEnv(t *testing.T, uid, gid string) {
+	t.Helper()
+	t.Setenv("SUDO_UID", uid)
+	t.Setenv("SUDO_GID", gid)
+}
+
+func TestChownArtifacts_ChownsPathNodesAndArtifactTreeOnly(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	rec := installChownRecorder(t)
+
+	workDir := t.TempDir()
+	provider := "ubuntu-ubuntu24-x86_64"
+	imageBuildDir := filepath.Join(workDir, provider, "imagebuild", "cfg")
+
+	// Build a realistic layout: the artifact leaf with an image + SBOM, plus a
+	// sibling chroot tree that must NOT be chowned.
+	if err := os.MkdirAll(imageBuildDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	image := filepath.Join(imageBuildDir, "image.raw")
+	sbom := filepath.Join(imageBuildDir, "image.spdx.json")
+	for _, f := range []string{image, sbom} {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	chrootTree := filepath.Join(workDir, provider, "chrootenv", "etc")
+	if err := os.MkdirAll(chrootTree, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	chrootFile := filepath.Join(chrootTree, "shadow")
+	if err := os.WriteFile(chrootFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ChownArtifactsToSudoUser(workDir, imageBuildDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := make(map[string]bool)
+	for _, c := range rec.calls {
+		got[c] = true
+	}
+
+	// Path nodes chowned (non-recursively) + artifact tree chowned (recursively).
+	wantChowned := []string{
+		workDir,
+		filepath.Join(workDir, provider),
+		filepath.Join(workDir, provider, "imagebuild"),
+		imageBuildDir,
+		image,
+		sbom,
+	}
+	for _, w := range wantChowned {
+		if !got[w] {
+			t.Errorf("expected %q to be chowned, but it was not (calls: %v)", w, sortedKeys(got))
+		}
+	}
+
+	// The chroot tree and its files must be left untouched.
+	for _, forbidden := range []string{
+		filepath.Join(workDir, provider, "chrootenv"),
+		chrootTree,
+		chrootFile,
+	} {
+		if got[forbidden] {
+			t.Errorf("chroot path %q must not be chowned, but it was", forbidden)
+		}
+	}
+}
+
+func TestChownArtifacts_RefusesDangerousWorkDir(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+
+	for name, workDir := range map[string]string{
+		"filesystem root":     string(os.PathSeparator),
+		"top-level directory": "/var",
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := installChownRecorder(t)
+			imageBuildDir := filepath.Join(workDir, "p", "imagebuild", "cfg")
+			if err := ChownArtifactsToSudoUser(workDir, imageBuildDir); err == nil {
+				t.Errorf("expected workDir %q (%s) to be refused, got nil error", workDir, name)
+			}
+			if len(rec.calls) != 0 {
+				t.Errorf("expected no chown calls when refusing %q, got %v", workDir, rec.calls)
+			}
+		})
+	}
+}
+
+// TestChownArtifacts_SymlinkComponentCannotRedirect verifies that a symlinked
+// intermediate path component cannot make the recursive walk escape workDir: the
+// image build dir resolves through a symlink to a sibling outside the workspace,
+// which must be refused after symlink resolution rather than chowned.
+func TestChownArtifacts_SymlinkComponentCannotRedirect(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	rec := installChownRecorder(t)
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	if err := os.MkdirAll(workDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A real directory OUTSIDE workDir, holding a file that must never be chowned.
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Materialise the artifact path under the outside dir so EvalSymlinks resolves
+	// the redirected leaf to a real location outside workDir (an unresolvable path
+	// would keep its lexical form and pass containment for a different reason).
+	if err := os.MkdirAll(filepath.Join(outside, "imagebuild", "cfg"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(outside, "imagebuild", "cfg", "secret")
+	if err := os.WriteFile(secret, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A component under workDir that is actually a symlink to the outside dir.
+	link := filepath.Join(workDir, "provider")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	imageBuildDir := filepath.Join(link, "imagebuild", "cfg")
+	if err := ChownArtifactsToSudoUser(workDir, imageBuildDir); err == nil {
+		t.Fatal("expected symlink-redirected imageBuildDir to be refused, got nil")
+	}
+	for _, c := range rec.calls {
+		if strings.HasPrefix(c, outside) {
+			t.Errorf("symlink redirect chowned outside workDir: %q", c)
+		}
+	}
+}
+
+func TestChownArtifacts_NoopWithoutSudoEnv(t *testing.T) {
+	// Explicitly clear both vars so a sudo-launched test runner does not leak them.
+	t.Setenv("SUDO_UID", "")
+	t.Setenv("SUDO_GID", "")
+	rec := installChownRecorder(t)
+
+	workDir := t.TempDir()
+	imageBuildDir := filepath.Join(workDir, "p", "imagebuild", "cfg")
+	if err := os.MkdirAll(imageBuildDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ChownArtifactsToSudoUser(workDir, imageBuildDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no chown calls without SUDO_UID/SUDO_GID, got %v", rec.calls)
+	}
+}
+
+func TestChownArtifacts_NoopWhenSudoUserIsRoot(t *testing.T) {
+	setSudoEnv(t, "0", "0")
+	rec := installChownRecorder(t)
+
+	workDir := t.TempDir()
+	imageBuildDir := filepath.Join(workDir, "p", "imagebuild", "cfg")
+	if err := os.MkdirAll(imageBuildDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ChownArtifactsToSudoUser(workDir, imageBuildDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no chown calls when SUDO_UID is 0, got %v", rec.calls)
+	}
+}
+
+func TestChownArtifacts_RejectsImageDirEscapingWorkDir(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	rec := installChownRecorder(t)
+
+	workDir := t.TempDir()
+	// A sibling directory outside workDir.
+	outside := filepath.Join(filepath.Dir(workDir), "elsewhere", "imagebuild", "cfg")
+
+	err := ChownArtifactsToSudoUser(workDir, outside)
+	if err == nil {
+		t.Fatal("expected an error when imageBuildDir escapes workDir, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Errorf("expected an escape error, got: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no chown calls on escape rejection, got %v", rec.calls)
+	}
+}
+
+func TestChownArtifacts_RejectsRelativePaths(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	installChownRecorder(t)
+
+	if err := ChownArtifactsToSudoUser("relative/work", "relative/work/p/imagebuild/cfg"); err == nil {
+		t.Fatal("expected an error for relative paths, got nil")
+	}
+}
+
+func TestChownArtifacts_LeafEqualsWorkDir(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	rec := installChownRecorder(t)
+
+	workDir := t.TempDir()
+	f := filepath.Join(workDir, "image.raw")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Degenerate but valid: imageBuildDir == workDir. The recursive walk must
+	// still cover the directory and its contents, with no duplicate/erroneous
+	// node chown above it.
+	if err := ChownArtifactsToSudoUser(workDir, workDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, c := range rec.calls {
+		got[c] = true
+	}
+	if !got[workDir] || !got[f] {
+		t.Errorf("expected workDir and its file to be chowned, got %v", sortedKeys(got))
+	}
+}
+
+// TestChownArtifacts_RealChownAsRoot exercises the genuine os.Lchown path (no
+// recorder) and asserts ownership actually lands on the invoking user. It needs
+// real root to chown to another uid, so it is skipped otherwise — mirroring the
+// other Geteuid()==0-gated integration tests in this repo.
+func TestChownArtifacts_RealChownAsRoot(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to chown files to another uid")
+	}
+	// Chown back to whoever launched sudo; fall back to a common unprivileged uid.
+	uid, gid := 1000, 1000
+	setSudoEnv(t, "1000", "1000")
+
+	workDir := t.TempDir()
+	imageBuildDir := filepath.Join(workDir, "p", "imagebuild", "cfg")
+	if err := os.MkdirAll(imageBuildDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	image := filepath.Join(imageBuildDir, "image.raw")
+	if err := os.WriteFile(image, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ChownArtifactsToSudoUser(workDir, imageBuildDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, p := range []string{workDir, filepath.Join(workDir, "p"), imageBuildDir, image} {
+		fi, err := os.Lstat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		st, ok := fi.Sys().(*syscall.Stat_t)
+		if !ok {
+			t.Fatalf("unexpected stat type for %s", p)
+		}
+		if int(st.Uid) != uid || int(st.Gid) != gid {
+			t.Errorf("%s owned by %d:%d, want %d:%d", p, st.Uid, st.Gid, uid, gid)
+		}
+	}
+}
+
+func TestChownDirTree_ChownsEverythingRecursively(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+	rec := installChownRecorder(t)
+
+	// Nest the cache under a parent so it is not itself a top-level directory
+	// (which the safety guard would reject).
+	root := t.TempDir()
+	cache := filepath.Join(root, "cache")
+	pkgs := filepath.Join(cache, "pkgCache", "ubuntu-ubuntu24-x86_64")
+	if err := os.MkdirAll(pkgs, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pkg := filepath.Join(pkgs, "foo.deb")
+	if err := os.WriteFile(pkg, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ChownDirTreeToSudoUser(cache); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, c := range rec.calls {
+		got[c] = true
+	}
+	for _, want := range []string{cache, filepath.Join(cache, "pkgCache"), pkgs, pkg} {
+		if !got[want] {
+			t.Errorf("expected %q to be chowned, got %v", want, sortedKeys(got))
+		}
+	}
+}
+
+func TestChownDirTree_NoopWithoutSudoEnv(t *testing.T) {
+	t.Setenv("SUDO_UID", "")
+	t.Setenv("SUDO_GID", "")
+	rec := installChownRecorder(t)
+
+	root := t.TempDir()
+	cache := filepath.Join(root, "cache")
+	if err := os.MkdirAll(cache, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ChownDirTreeToSudoUser(cache); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no chown calls without sudo env, got %v", rec.calls)
+	}
+}
+
+func TestChownDirTree_RefusesDangerousRoots(t *testing.T) {
+	setSudoEnv(t, "1000", "1000")
+
+	cases := map[string]string{
+		"filesystem root":     string(os.PathSeparator),
+		"system temp dir":     filepath.Clean(os.TempDir()),
+		"top-level directory": "/var",
+		"relative path":       "cache",
+	}
+	for name, dir := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := installChownRecorder(t)
+			if err := ChownDirTreeToSudoUser(dir); err == nil {
+				t.Errorf("expected %q (%s) to be refused, got nil error", dir, name)
+			}
+			if len(rec.calls) != 0 {
+				t.Errorf("expected no chown calls when refusing %q, got %v", dir, rec.calls)
+			}
+		})
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

ICT runs as root so it can create loop devices, mount, and chroot. Two consequences of that are addressed here.

**1. Return build artifact ownership to the sudo invoker** (`feat(build)`)

Because the tool runs as root, every directory and file it creates is `root:root` — including the final image, SBOM, and checksums, plus the temp scratch dir. After a successful `sudo -E ict build` the invoking user could not read or delete their own output without root.

- Adds `system.ChownArtifactsToSudoUser` and `system.ChownDirTreeToSudoUser`, keyed off `SUDO_UID`/`SUDO_GID`, called on the build **success** path.
- Artifacts: the path nodes from the workspace down to `imagebuild/<name>` are chowned non-recursively (enough to traverse/list); the artifact leaf is chowned recursively so the image/SBOM/checksums become user-owned. Sibling chroot trees (`chrootenv/`, `chrootbuild/`) are deliberately left root-owned — they are real root filesystems whose ownership is load-bearing.
- Temp dir is chowned recursively (inert scratch). The cache dir is intentionally left root-owned: it persists across builds and later root builds repopulate it anyway.
- Both helpers no-op when not launched via sudo (`SUDO_UID` unset, or root→root), use `os.Lchown` so a planted symlink cannot redirect the chown out of the tree, and are best-effort — a chown failure is logged but never fails an otherwise successful build. Both resolve symlink components (`filepath.EvalSymlinks`) and re-validate before walking, so a symlinked intermediate path component cannot redirect the recursive chown outside the tree that was vetted, and both refuse dangerous roots (`/`, the system temp dir an empty `temp_dir` falls back to, and any top-level directory).
- For `--no-cache` the artifact chown targets the workspace the output was copied back to. The temp chown also runs in `--no-cache` mode: isolation only makes the cache and workspace unique, not `config.TempDir()`, so a root build still populates the shared temp dir and its cleanup does not remove it.

**2. Drop the redundant inner sudo when already root** (`refactor(shell)`)

`GetFullCmdStr` unconditionally prepended `sudo ` to every privileged host and chroot command. ICT is already launched as root (CLI via `sudo -E ict build …`, server via `sudo -n ict build …`), so that inner sudo is a root→root no-op that only forks an extra sudo process per command (and would otherwise need its own sudoers entry on the serve path).

- Adds a `sudoPrefix()` helper that omits the prefix when `os.Geteuid() == 0` and keeps it otherwise, applied to both the chroot and host branches. `geteuid` is indirected through a package variable so both branches are unit-testable without changing process privileges.
- When the process is not root, the per-command sudo model is unchanged. The mock executor is intentionally left always-sudo so existing `sudo chroot .*` test patterns keep matching; only the real path is euid-aware.
- Makes the behavior the release notes already described actually true, and extends it from chroot-only to host commands too; the note is updated to match.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

- `go test ./internal/utils/system/...` — covers `ChownArtifactsToSudoUser`/`ChownDirTreeToSudoUser`, including the no-op-when-not-sudo, symlink-safety, and dangerous-root-refusal paths (`internal/utils/system/ownership_test.go`).
- `go test ./internal/utils/shell/...` — covers `sudoPrefix()` in both the root and non-root branches via the indirected `geteuid` (`internal/utils/shell/shell_sudoprefix_internal_test.go`).
- Manual: `sudo -E ict build` of an Ubuntu 24.04 overlay image; verified the resulting image/SBOM/checksums and `./tmp` are owned by the invoking user on success, while `chrootenv/`/`chrootbuild/` and `./cache` remain root-owned.
