### PR TITLE
fix(pkgfetcher): abort stalled package downloads instead of hanging

### DIFF
--- a/internal/ospackage/pkgfetcher/pkgfetcher.go
+++ b/internal/ospackage/pkgfetcher/pkgfetcher.go
@@ -21,7 +21,54 @@ import (
 const (
 	maxDownloadAttempts = 3
 	initialRetryBackoff = 500 * time.Millisecond
+	// bodyIdleTimeout bounds the gap between successful reads of a response
+	// body. The shared client's ResponseHeaderTimeout only covers the wait for
+	// headers; once the body starts streaming, http has no read deadline, so a
+	// proxy that goes silent mid-transfer (headers received, then nothing) would
+	// otherwise block io.Copy forever. This does not cap total transfer time —
+	// the timer resets on every read that returns bytes — so a slow but
+	// progressing large package download is never killed.
+	bodyIdleTimeout = 60 * time.Second
 )
+
+// idleTimeoutReader wraps an io.ReadCloser and closes the underlying reader if
+// no bytes arrive within idle, unblocking an in-flight Read so a stalled
+// mid-body transfer fails (and retries) instead of hanging. The timer resets on
+// every read that returns data, so only a true stall — not slow progress —
+// trips it.
+type idleTimeoutReader struct {
+	rc      io.ReadCloser
+	idle    time.Duration
+	timer   *time.Timer
+	tripped atomic.Bool
+}
+
+func newIdleTimeoutReader(rc io.ReadCloser, idle time.Duration) *idleTimeoutReader {
+	r := &idleTimeoutReader{rc: rc, idle: idle}
+	r.timer = time.AfterFunc(idle, func() {
+		r.tripped.Store(true)
+		_ = rc.Close()
+	})
+	return r
+}
+
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	n, err := r.rc.Read(p)
+	if n > 0 {
+		r.timer.Reset(r.idle)
+	}
+	if err != nil && r.tripped.Load() {
+		return n, fmt.Errorf("stalled: no data received for %s: %w", r.idle, err)
+	}
+	return n, err
+}
+
+// stop halts the watchdog. Call it once the body has been fully read so the
+// timer does not linger; it does not close the underlying reader, which the
+// caller's deferred resp.Body.Close handles.
+func (r *idleTimeoutReader) stop() {
+	r.timer.Stop()
+}
 
 func shouldRetryHTTPStatus(statusCode int) bool {
 	switch statusCode {
@@ -75,7 +122,9 @@ func downloadWithRetry(ctx context.Context, client *http.Client, url, destPath s
 				}
 				defer out.Close()
 
-				writtenBytes, copyErr := io.Copy(out, resp.Body)
+				body := newIdleTimeoutReader(resp.Body, bodyIdleTimeout)
+				defer body.stop()
+				writtenBytes, copyErr := io.Copy(out, body)
 				if copyErr != nil {
 					lastErr = copyErr
 					if removeErr := os.Remove(destPath); removeErr != nil && !os.IsNotExist(removeErr) {

--- a/internal/ospackage/pkgfetcher/pkgfetcher_test.go
+++ b/internal/ospackage/pkgfetcher/pkgfetcher_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -820,5 +821,91 @@ func TestFetchPackages_CancelNotReportedAsFailures(t *testing.T) {
 func TestSummarizeFailuresEmpty(t *testing.T) {
 	if got := summarizeFailures(nil); got != "" {
 		t.Errorf("summarizeFailures(nil) = %q, want empty", got)
+	}
+}
+
+// blockingReader returns firstChunk on the first Read, then blocks forever on
+// the next Read until Close is called (which unblocks it with an error). It
+// models a proxy that sends some body bytes and then goes silent mid-transfer —
+// the exact stall that hung a real build (headers received, ~11MB streamed,
+// then the connection sat ESTAB with no further data).
+type blockingReader struct {
+	firstChunk []byte
+	sent       bool
+	closed     chan struct{}
+	once       sync.Once
+}
+
+func newBlockingReader(firstChunk []byte) *blockingReader {
+	return &blockingReader{firstChunk: firstChunk, closed: make(chan struct{})}
+}
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	if !b.sent {
+		b.sent = true
+		return copy(p, b.firstChunk), nil
+	}
+	<-b.closed // block until Close, mirroring a silent stalled socket
+	return 0, errors.New("read after close")
+}
+
+func (b *blockingReader) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+
+// TestIdleTimeoutReader_TripsOnStall verifies that a body which delivers some
+// bytes and then goes silent is aborted once no data arrives for the idle
+// window, surfacing a "stalled" error rather than blocking forever. This is the
+// direct regression guard for the hung-build bug: bodyIdleTimeout is 60s in
+// production, so the mechanism is exercised here with a short window.
+func TestIdleTimeoutReader_TripsOnStall(t *testing.T) {
+	br := newBlockingReader([]byte("first"))
+	r := newIdleTimeoutReader(br, 100*time.Millisecond)
+	defer r.stop()
+
+	start := time.Now()
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected a stall error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("expected a stalled error, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("reader took too long to trip: %s", elapsed)
+	}
+}
+
+// TestIdleTimeoutReader_ProgressDoesNotTrip verifies that a body which keeps
+// delivering bytes — even slowly, in gaps shorter than the idle window — is
+// never aborted, so a slow-but-progressing large package download is not
+// killed. Each read resets the idle timer.
+func TestIdleTimeoutReader_ProgressDoesNotTrip(t *testing.T) {
+	// Feed 20 chunks with a 50ms gap against a 1s idle window; each gap sits
+	// well under the window (20x headroom, so CI scheduling jitter cannot
+	// falsely trip it) while the total time (~1s) still exceeds the window,
+	// proving the timer tracks idleness, not total duration.
+	const chunks = 20
+	pr, pw := io.Pipe()
+	go func() {
+		for i := 0; i < chunks; i++ {
+			time.Sleep(50 * time.Millisecond)
+			if _, err := pw.Write([]byte("chunk")); err != nil {
+				return
+			}
+		}
+		_ = pw.Close()
+	}()
+
+	r := newIdleTimeoutReader(pr, 1*time.Second)
+	defer r.stop()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("progressing reader should not trip the idle timeout: %v", err)
+	}
+	if got, want := len(data), len("chunk")*chunks; got != want {
+		t.Fatalf("read %d bytes, want %d", got, want)
 	}
 }

--- a/internal/utils/network/securehttp.go
+++ b/internal/utils/network/securehttp.go
@@ -4,12 +4,23 @@ import (
 	"crypto/tls"
 	"net/http"
 	"sync"
+	"time"
 )
 
 var (
 	secureClient *http.Client
 	once         sync.Once
 )
+
+// responseHeaderTimeout bounds the wait for a response's headers after the
+// request is written. It guards the "connection established but the server or
+// proxy never answers" stall: without it the request can block indefinitely,
+// because http.Client has no default read deadline once a connection is up.
+// It does NOT bound the response body transfer — a large package download can
+// legitimately take much longer than this — so mid-body stalls are handled
+// separately by the caller wrapping the body read with an idle timeout.
+// Both constructors apply it so every caller enforces the guard consistently.
+const responseHeaderTimeout = 30 * time.Second
 
 // GetSecureHTTPClient returns a singleton secure HTTP client
 func GetSecureHTTPClient() *http.Client {
@@ -23,6 +34,7 @@ func GetSecureHTTPClient() *http.Client {
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			},
 		}
+		base.ResponseHeaderTimeout = responseHeaderTimeout
 		secureClient = &http.Client{Transport: base}
 	})
 	return secureClient
@@ -44,6 +56,7 @@ func NewSecureHTTPClient() *http.Client {
 			// (intentionally omit non-allowed ciphers per Intel CT-35)
 		},
 	}
+	base.ResponseHeaderTimeout = responseHeaderTimeout
 
 	return &http.Client{Transport: base}
 }


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

A silent proxy or mirror that accepted the connection and sent response headers but then went quiet mid-body could hang a build indefinitely: the shared secure HTTP client set no read deadline, so `io.Copy` on the response body blocked forever, the 3-attempt retry loop never advanced, and the whole build wedged with no error (observed as ~11MB received, then a dead-but-`ESTABLISHED` socket to the proxy).

This PR adds two independent guards to the package fetcher:

- **`ResponseHeaderTimeout` (30s)** on the shared transport — covers the "connection up but no response headers" stall.
- **`idleTimeoutReader` (60s idle window)** wrapping the response body — covers the mid-body stall. The timer resets on every read that returns bytes, so a slow-but-progressing large package download is never killed; only a true stall trips it. A trip surfaces as a copy error, which removes the partial file and feeds the existing retry loop.

A flat `http.Client.Timeout` was intentionally avoided: it would cap total transfer time and could kill a legitimately large package on a slow link.

**Files changed**
- `internal/utils/network/securehttp.go` — add `ResponseHeaderTimeout` to the shared transport.
- `internal/ospackage/pkgfetcher/pkgfetcher.go` — wrap the response body in `idleTimeoutReader`.
- `internal/ospackage/pkgfetcher/pkgfetcher_test.go` — coverage for the stall/idle-timeout behavior and the retry path.

#### Any Newly Introduced Dependencies

None. Uses only the Go standard library (`net/http`, `time`, `io`).

#### How Has This Been Tested? <!-- REQUIRED -->

- `go test ./internal/ospackage/pkgfetcher/... ./internal/utils/network/...` — new tests simulate a mid-body stall and a headers stall and assert the fetch aborts and the partial file is removed, and confirm a slow-but-progressing download is not killed.
- `go build ./...`
