### PR TITLE
fix(pkgfetcher): abort stalled package downloads instead of hanging

### DIFF
--- a/internal/ospackage/pkgfetcher/pkgfetcher.go
+++ b/internal/ospackage/pkgfetcher/pkgfetcher.go
@@ -21,7 +21,61 @@ import (
 const (
 	maxDownloadAttempts = 3
 	initialRetryBackoff = 500 * time.Millisecond
+	// bodyIdleTimeout bounds the gap between successful reads of a response
+	// body. The shared client's ResponseHeaderTimeout only covers the wait for
+	// headers; once the body starts streaming, http has no read deadline, so a
+	// proxy that goes silent mid-transfer (headers received, then nothing) would
+	// otherwise block io.Copy forever. This does not cap total transfer time —
+	// the timer resets on every read that returns bytes — so a slow but
+	// progressing large package download is never killed.
+	bodyIdleTimeout = 60 * time.Second
 )
+
+// idleTimeoutReader wraps an io.ReadCloser and, if no bytes arrive within idle,
+// cancels the request context so an in-flight Read is unblocked and a stalled
+// mid-body transfer fails (and retries) instead of hanging. The timer resets on
+// every read that returns data, so only a true stall — not slow progress —
+// trips it.
+//
+// Cancelling the context (rather than calling rc.Close) is deliberate: a real
+// net/http HTTP/1.x response body serializes Close behind the in-flight Read,
+// so a Close-based watchdog would itself block on the stalled read and leave
+// the build hung. Cancelling the request makes http.Transport tear down the
+// underlying connection, which is the mechanism that reliably unblocks the read.
+type idleTimeoutReader struct {
+	rc      io.ReadCloser
+	idle    time.Duration
+	cancel  context.CancelFunc
+	timer   *time.Timer
+	tripped atomic.Bool
+}
+
+func newIdleTimeoutReader(rc io.ReadCloser, idle time.Duration, cancel context.CancelFunc) *idleTimeoutReader {
+	r := &idleTimeoutReader{rc: rc, idle: idle, cancel: cancel}
+	r.timer = time.AfterFunc(idle, func() {
+		r.tripped.Store(true)
+		r.cancel()
+	})
+	return r
+}
+
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	n, err := r.rc.Read(p)
+	if n > 0 {
+		r.timer.Reset(r.idle)
+	}
+	if err != nil && r.tripped.Load() {
+		return n, fmt.Errorf("stalled: no data received for %s: %w", r.idle, err)
+	}
+	return n, err
+}
+
+// stop halts the watchdog. Call it once the body has been fully read so the
+// timer does not linger; it does not close the underlying reader, which the
+// caller's deferred resp.Body.Close handles.
+func (r *idleTimeoutReader) stop() {
+	r.timer.Stop()
+}
 
 func shouldRetryHTTPStatus(statusCode int) bool {
 	switch statusCode {
@@ -48,15 +102,21 @@ func downloadWithRetry(ctx context.Context, client *http.Client, url, destPath s
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("download cancelled before attempt %d: %w", attempt, err)
 		}
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		// Per-attempt cancellable context so the idle watchdog can tear down a
+		// stalled exchange without affecting the caller's ctx or later attempts.
+		reqCtx, cancel := context.WithCancel(ctx)
+		req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
 		if reqErr != nil {
+			cancel()
 			return fmt.Errorf("build request: %w", reqErr)
 		}
 		resp, err := client.Do(req)
 		if err != nil {
+			cancel()
 			lastErr = err
 		} else {
 			func() {
+				defer cancel()
 				defer resp.Body.Close()
 
 				if resp.StatusCode != http.StatusOK {
@@ -75,7 +135,9 @@ func downloadWithRetry(ctx context.Context, client *http.Client, url, destPath s
 				}
 				defer out.Close()
 
-				writtenBytes, copyErr := io.Copy(out, resp.Body)
+				body := newIdleTimeoutReader(resp.Body, bodyIdleTimeout, cancel)
+				defer body.stop()
+				writtenBytes, copyErr := io.Copy(out, body)
 				if copyErr != nil {
 					lastErr = copyErr
 					if removeErr := os.Remove(destPath); removeErr != nil && !os.IsNotExist(removeErr) {

--- a/internal/ospackage/pkgfetcher/pkgfetcher_test.go
+++ b/internal/ospackage/pkgfetcher/pkgfetcher_test.go
@@ -822,3 +822,100 @@ func TestSummarizeFailuresEmpty(t *testing.T) {
 		t.Errorf("summarizeFailures(nil) = %q, want empty", got)
 	}
 }
+
+// TestIdleTimeoutReader_TripsOnStall verifies that a body which delivers some
+// bytes and then goes silent is aborted once no data arrives for the idle
+// window, surfacing a "stalled" error rather than blocking forever. This is the
+// direct regression guard for the hung-build bug (headers received, ~11MB
+// streamed, then the connection sat ESTAB with no further data): bodyIdleTimeout
+// is 60s in production, so the mechanism is exercised here with a short window.
+//
+// It runs against a real httptest.Server that flushes a partial body and then
+// blocks, rather than a fake reader, so the test exercises the actual net/http
+// transport path — the one where resp.Body.Close does NOT interrupt an in-flight
+// Read and only context cancellation reliably tears the exchange down.
+func TestIdleTimeoutReader_TripsOnStall(t *testing.T) {
+	release := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1048576") // promise more than we send
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("first chunk"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Go silent mid-body, mirroring a stalled proxy. Return once the test is
+		// done or the client's request context is cancelled (which is what the
+		// watchdog does), so the handler never outlives the request.
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	// Order matters: close(release) is registered last so it runs first (LIFO),
+	// unblocking the handler before ts.Close() waits for it to return.
+	defer ts.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET %s failed: %v", ts.URL, err)
+	}
+	defer resp.Body.Close()
+
+	r := newIdleTimeoutReader(resp.Body, 100*time.Millisecond, cancel)
+	defer r.stop()
+
+	start := time.Now()
+	_, err = io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected a stall error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("expected a stalled error, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("reader took too long to trip: %s", elapsed)
+	}
+}
+
+// TestIdleTimeoutReader_ProgressDoesNotTrip verifies that a body which keeps
+// delivering bytes — even slowly, in gaps shorter than the idle window — is
+// never aborted, so a slow-but-progressing large package download is not
+// killed. Each read resets the idle timer.
+func TestIdleTimeoutReader_ProgressDoesNotTrip(t *testing.T) {
+	// Feed 20 chunks with a 50ms gap against a 1s idle window; each gap sits
+	// well under the window (20x headroom, so CI scheduling jitter cannot
+	// falsely trip it) while the total time (~1s) still exceeds the window,
+	// proving the timer tracks idleness, not total duration.
+	const chunks = 20
+	pr, pw := io.Pipe()
+	go func() {
+		for i := 0; i < chunks; i++ {
+			time.Sleep(50 * time.Millisecond)
+			if _, err := pw.Write([]byte("chunk")); err != nil {
+				return
+			}
+		}
+		_ = pw.Close()
+	}()
+
+	// The cancel here closes the pipe reader; if the watchdog ever tripped, the
+	// read would fail — so a successful read proves it never did.
+	r := newIdleTimeoutReader(pr, 1*time.Second, func() { _ = pr.CloseWithError(errors.New("watchdog tripped")) })
+	defer r.stop()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("progressing reader should not trip the idle timeout: %v", err)
+	}
+	if got, want := len(data), len("chunk")*chunks; got != want {
+		t.Fatalf("read %d bytes, want %d", got, want)
+	}
+}

--- a/internal/utils/network/securehttp.go
+++ b/internal/utils/network/securehttp.go
@@ -4,12 +4,23 @@ import (
 	"crypto/tls"
 	"net/http"
 	"sync"
+	"time"
 )
 
 var (
 	secureClient *http.Client
 	once         sync.Once
 )
+
+// responseHeaderTimeout bounds the wait for a response's headers after the
+// request is written. It guards the "connection established but the server or
+// proxy never answers" stall: without it the request can block indefinitely,
+// because http.Client has no default read deadline once a connection is up.
+// It does NOT bound the response body transfer — a large package download can
+// legitimately take much longer than this — so mid-body stalls are handled
+// separately by the caller wrapping the body read with an idle timeout.
+// Both constructors apply it so every caller enforces the guard consistently.
+const responseHeaderTimeout = 30 * time.Second
 
 // GetSecureHTTPClient returns a singleton secure HTTP client
 func GetSecureHTTPClient() *http.Client {
@@ -23,6 +34,7 @@ func GetSecureHTTPClient() *http.Client {
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			},
 		}
+		base.ResponseHeaderTimeout = responseHeaderTimeout
 		secureClient = &http.Client{Transport: base}
 	})
 	return secureClient
@@ -44,6 +56,7 @@ func NewSecureHTTPClient() *http.Client {
 			// (intentionally omit non-allowed ciphers per Intel CT-35)
 		},
 	}
+	base.ResponseHeaderTimeout = responseHeaderTimeout
 
 	return &http.Client{Transport: base}
 }

--- a/internal/utils/network/securehttp_test.go
+++ b/internal/utils/network/securehttp_test.go
@@ -72,6 +72,31 @@ func TestNewSecureHTTPClient_TLSConfigBasics(t *testing.T) {
 	}
 }
 
+// TestResponseHeaderTimeoutSet guards that both constructors set
+// ResponseHeaderTimeout on their transport. Without these assertions a future
+// constructor refactor could silently drop the timeout and reintroduce the
+// indefinite header-phase hang this bounds.
+func TestResponseHeaderTimeoutSet(t *testing.T) {
+	once = sync.Once{}
+	secureClient = nil
+
+	for _, tc := range []struct {
+		name   string
+		client *http.Client
+	}{
+		{"NewSecureHTTPClient", NewSecureHTTPClient()},
+		{"GetSecureHTTPClient", GetSecureHTTPClient()},
+	} {
+		tr, ok := tc.client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("%s: expected *http.Transport, got %T", tc.name, tc.client.Transport)
+		}
+		if tr.ResponseHeaderTimeout != responseHeaderTimeout {
+			t.Errorf("%s: ResponseHeaderTimeout = %v, want %v", tc.name, tr.ResponseHeaderTimeout, responseHeaderTimeout)
+		}
+	}
+}
+
 func TestNewSecureHTTPClient_ConnectsToTLS13Server(t *testing.T) {
 	// TLS 1.3–only server
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

A silent proxy or mirror that accepted the connection and sent response headers but then went quiet mid-body could hang a build indefinitely: the shared secure HTTP client set no read deadline, so `io.Copy` on the response body blocked forever, the 3-attempt retry loop never advanced, and the whole build wedged with no error (observed as ~11MB received, then a dead-but-`ESTABLISHED` socket to the proxy).

This PR adds two independent guards to the package fetcher:

- **`ResponseHeaderTimeout` (30s)** on the secure HTTP transport — covers the "connection up but no response headers" stall. Applied in both `GetSecureHTTPClient` (singleton) and `NewSecureHTTPClient`, so every caller (pkgfetcher, rpmutils, debutils, overlay, apt_sources) enforces the guard consistently.
- **`idleTimeoutReader` (60s idle window)** wrapping the response body — covers the mid-body stall. The timer resets on every read that returns bytes, so a slow-but-progressing large package download is never killed; only a true stall trips it. A trip surfaces as a copy error (wrapping the underlying cause), which removes the partial file and feeds the existing retry loop.

A flat `http.Client.Timeout` was intentionally avoided: it would cap total transfer time and could kill a legitimately large package on a slow link.

**Files changed**
- `internal/utils/network/securehttp.go` — add `ResponseHeaderTimeout` to both client constructors.
- `internal/ospackage/pkgfetcher/pkgfetcher.go` — wrap the response body in `idleTimeoutReader`.
- `internal/ospackage/pkgfetcher/pkgfetcher_test.go` — coverage for the stall/idle-timeout behavior and the slow-progress path.

#### Any Newly Introduced Dependencies

None. Uses only the Go standard library (`net/http`, `time`, `io`).

#### How Has This Been Tested? <!-- REQUIRED -->

- `go test ./internal/ospackage/pkgfetcher/... ./internal/utils/network/...` — tests simulate a mid-body stall (body goes silent after some bytes) and assert the fetch aborts with a "stalled" error, and confirm a slow-but-progressing download (chunks paced well under the idle window) is never killed.
- `go build ./...` and `golangci-lint run` on the affected packages.
