### PR TITLE
feat(security): capability-confined build mode to reduce the root privilege surface

### DIFF
--- a/deploy/systemd/image-composer-tool.service
+++ b/deploy/systemd/image-composer-tool.service
@@ -1,0 +1,55 @@
+# image-composer-tool build server, confined to the minimal capability set.
+# See docs/architecture-decision-record/adr-reduce-root-privilege.md (Phase 1)
+# and docs/user-guide/get-started/run-confined.md.
+#
+# Install:
+#   sudo install -m0644 deploy/systemd/image-composer-tool.service \
+#       /etc/systemd/system/image-composer-tool.service
+#   # edit ExecStart / User below for your deployment, then:
+#   sudo systemctl daemon-reload && sudo systemctl enable --now image-composer-tool
+#
+# IMPORTANT — read before relying on this for the WEB SERVER (`serve`):
+# The server's --sudo mode runs each privileged build step via `sudo -n <cmd>`.
+# A `sudo` child starts a NEW process whose capabilities are derived from the
+# bounding set at exec time, so CapabilityBoundingSet= here confines the server
+# process itself but NOT a `sudo -n`-spawned build child. To actually confine
+# builds, run the server WITHOUT --sudo as a root service (so build steps are
+# direct children bounded by this unit) — the configuration below does that:
+# User=root with the bounding set reduced, and no per-command sudo.
+#
+# CapabilityBoundingSet lists ONLY the capabilities a build needs (kept in sync
+# with scripts/ict-capabilities.env). systemd drops everything else; the empty
+# AmbientCapabilities means children still derive permitted caps from the
+# bounding set as uid-0 processes, matching the audited `capsh --drop` model.
+
+[Unit]
+Description=Image Composer Tool build server (capability-confined)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+
+# Adjust to your install path and desired listen address/flags.
+# Note: no --sudo — builds run as direct root children so this unit's bounding
+# set confines them.
+ExecStart=/usr/bin/image-composer-tool serve
+
+# Minimal capability set (mirror of scripts/ict-capabilities.env).
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_SYS_CHROOT CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FSETID CAP_MKNOD CAP_SETUID CAP_SETGID CAP_SETFCAP
+# No ambient caps: uid-0 children inherit permitted caps from the bounding set.
+AmbientCapabilities=
+
+# Defence in depth (safe with the bounding set above; loosen only if a build step needs it).
+NoNewPrivileges=no
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=no
+
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/architecture-decision-record/adr-reduce-root-privilege.md
+++ b/docs/architecture-decision-record/adr-reduce-root-privilege.md
@@ -104,10 +104,22 @@ ICT under a dropped capability set (via `capsh`) and run one real Ubuntu 24.04
 build. Whatever fails identifies the true minimal set. This is the go/no-go gate
 before any code rework. Deliverable: `scripts/cap-audit.sh` + this ADR.
 
-**Phase 1 — ship the minimal-capability invocation as the portable default.**
-Document and provide a `setcap` wrapper / systemd unit granting only the
-confirmed set. No change to the build mechanism. Verify across the build matrix
-(Ubuntu / ELXR / EMT / azl, x86 + ARM).
+**Phase 1 (DELIVERED, 2026-08-07) — minimal-capability invocation as the
+portable default.** No change to the build mechanism. Deliverables:
+- `scripts/ict-capabilities.env` — the minimal set, single-sourced.
+- `scripts/ict-confined.sh` — CLI wrapper that reduces the bounding set to the
+  minimal set (the audited `capsh --drop` mechanism) and runs ICT, so every
+  build child is bounded too.
+- `deploy/systemd/image-composer-tool.service` — server unit with
+  `CapabilityBoundingSet` reduced to the same set. Documents that the server's
+  `--sudo` per-command model would escape a process-level bounding set, so the
+  unit runs the server as root without `--sudo` (build steps are direct
+  children the unit bounds).
+- `docs/user-guide/get-started/run-confined.md` — how-to.
+
+The audit harness (`scripts/cap-audit.sh`) now also sources the shared env, so
+the audited set and the shipped set cannot drift. Remaining verification: the
+full build matrix (Ubuntu / ELXR / EMT / azl, x86 + ARM) under the wrapper.
 
 **Phase 2 (optional) — privileged-helper split.** Route the
 `CAP_SYS_ADMIN` / `CAP_SYS_CHROOT` core (loopdev + mount + chroot-enter) through

--- a/docs/architecture-decision-record/adr-reduce-root-privilege.md
+++ b/docs/architecture-decision-record/adr-reduce-root-privilege.md
@@ -1,0 +1,197 @@
+# ADR: Reduce the Root Privilege Surface of Image Builds
+
+**Status**: Proposed
+**Date**: 2026-08-07
+**Updated**: N/A
+**Authors**: OS Image Composer Team
+**Technical Area**: Build Runtime / Security / Portability
+
+---
+
+## Summary
+
+ICT builds run as full root because they perform loop-device attach, host
+mounts, and `chroot`. This ADR proposes shrinking that privilege surface in
+portable, incremental steps rather than a single rewrite:
+
+1. **Tier 1 (shipped)** — return build-artifact ownership to the invoking
+   `sudo` user after a successful build, so root is required only *during* the
+   build, not to read or delete its output afterward.
+2. **Tier 2 — capability confinement (this ADR's focus).** Run the build with a
+   *minimal, explicit set of Linux capabilities* instead of unrestricted root.
+   The build mechanism (loop + mount + chroot) is unchanged, so this stays
+   portable across every target kernel/distro/arch; only the granted privilege
+   shrinks.
+3. **Tier 3 — optional backends and further isolation.** A libguestfs/guestfish
+   image backend for environments that specifically want *zero host mounts* (and
+   have KVM), offered opt-in; and, if desired later, a privileged-helper split
+   that confines the dangerous capabilities to a small audited binary.
+
+Genuinely-rootless-everywhere via unprivileged user namespaces was considered
+and **rejected as the default** on portability grounds (see Alternatives): the
+hardened distros ICT targets (e.g. Ubuntu 24.04) restrict unprivileged user
+namespaces by default, so a userns build would fail on exactly the hosts we care
+about.
+
+---
+
+## Context
+
+### Problem Statement
+
+ICT is launched as root — the CLI via `sudo -E ict build …`, the server via
+`sudo -n ict build …`. It needs privilege for four classes of operation:
+
+| Operation | Capability it classically needs | Where |
+| --- | --- | --- |
+| `losetup` attach/detach (raw image → loop device) | `CAP_SYS_ADMIN` | `internal/image/imagedisc/loopdev.go` |
+| `mount` / bind / sysfs into the chroot | `CAP_SYS_ADMIN` | `internal/utils/mount/mount.go` |
+| `chroot` into the rootfs | `CAP_SYS_CHROOT` | `internal/chroot/chrootenv.go`, installers |
+| device nodes, ownership of root-owned rootfs files | `CAP_MKNOD`, `CAP_CHOWN`, `CAP_FOWNER`, `CAP_DAC_OVERRIDE` | scattered |
+
+Running as unrestricted root means a bug, a malicious package post-install
+script, or a path-traversal in the build can affect the entire host, not just
+the build tree. Reducing the granted privilege bounds that blast radius.
+
+### Key architectural facts (verified in the code)
+
+- **Single exec funnel.** Every privileged operation runs as a shell string
+  through `shell.ExecCmd*` (`internal/utils/shell/shell.go`). There are ~176
+  call sites with `sudo=true`. Nothing uses Go's `syscall.Mount` /
+  `syscall.Chroot` directly — it is all `losetup` / `mount` / `chroot` command
+  strings. This funnel is the key asset: it is the single place to intercept,
+  audit, or redirect privileged work.
+- **The dangerous capabilities are concentrated.** Only loop attach
+  (`loopdev.go`), mount (`mount.go`), and chroot-enter (the `ExecCmd` calls with
+  a non-`HostPath` chrootPath) genuinely need `CAP_SYS_ADMIN` / `CAP_SYS_CHROOT`.
+- **The majority of `sudo=true` sites are ordinary file operations** (`rm`,
+  `chmod`, `touch`, `mkfs` on an already-attached device, writing into the
+  rootfs) that require root only because the *files/devices are root-owned* —
+  i.e. they need `CAP_CHOWN` / `CAP_FOWNER` / `CAP_DAC_OVERRIDE`, not
+  `CAP_SYS_ADMIN`.
+
+This concentration is what makes capability confinement tractable and portable
+rather than a rewrite.
+
+---
+
+## Decision
+
+Adopt the tiered plan above, with **Tier 2 (capability confinement) as the
+portable default direction** and Tier 3 backends as opt-in.
+
+### Candidate minimal capability set
+
+To be confirmed empirically by Phase 0:
+
+```
+CAP_SYS_ADMIN      # losetup, mount, bind, sysfs, mkswap
+CAP_SYS_CHROOT     # entering the chroot
+CAP_CHOWN          # own root-owned rootfs files
+CAP_FOWNER         # operate on files not owned by the euid
+CAP_DAC_OVERRIDE   # read/traverse root-owned trees regardless of perms
+CAP_MKNOD          # device nodes in the rootfs (mmdebstrap/rpm may need this)
+```
+
+Possible additions the audit may surface: `CAP_SETFCAP` (file capabilities set
+inside the rootfs, e.g. on `ping`), `CAP_SETUID`/`CAP_SETGID` (accounts created
+in the rootfs), `CAP_MAC_ADMIN`/`CAP_MAC_OVERRIDE` (SELinux/AppArmor labelling).
+
+### Implementation phases
+
+**Phase 0 — capability audit harness (this deliverable).** Provide a way to run
+ICT under a dropped capability set (via `capsh`) and run one real Ubuntu 24.04
+build. Whatever fails identifies the true minimal set. This is the go/no-go gate
+before any code rework. Deliverable: `scripts/cap-audit.sh` + this ADR.
+
+**Phase 1 — ship the minimal-capability invocation as the portable default.**
+Document and provide a `setcap` wrapper / systemd unit granting only the
+confirmed set. No change to the build mechanism. Verify across the build matrix
+(Ubuntu / ELXR / EMT / azl, x86 + ARM).
+
+**Phase 2 (optional) — privileged-helper split.** Route the
+`CAP_SYS_ADMIN` / `CAP_SYS_CHROOT` core (loopdev + mount + chroot-enter) through
+a small audited helper holding only those caps, while the main process runs with
+none. The `shell.ExecCmd` funnel is the interception seam. Security review is the
+long pole.
+
+**Tier 3 — libguestfs backend (opt-in, parallel track).** Introduce a backend
+interface behind `loopdev.go` + the mount-based assembly path:
+`HostLoopBackend` (default, today's code) vs `GuestfishBackend`. Select via
+`--image-backend=guestfish` or auto-detect `/dev/kvm`. The guestfish path does
+partition / mkfs / populate *inside a VM*, needing zero host loop devices and
+zero host mounts — dropping `CAP_SYS_ADMIN` entirely for image assembly. Offered
+opt-in only: it needs `/dev/kvm` for acceptable speed and pulls a heavy appliance
+dependency, so the capability-confined host path remains the portable default.
+
+---
+
+## Alternatives Considered
+
+### Unprivileged user namespaces (`unshare -r`, `mmdebstrap --mode=unshare`)
+
+The cleanest *rootless* mechanism, but the **least portable**. Ubuntu 24.04 ships
+an AppArmor profile restricting unprivileged user namespaces by default; many CI
+runners are themselves containers where nested userns is blocked; behaviour
+depends on `kernel.unprivileged_userns_clone` and kernel version. A userns build
+would work on some hosts and silently fail on others, and would need per-host
+privileged configuration to enable — defeating the goal. **Rejected as the
+default;** may be offered as a third opt-in backend later for hosts that allow
+it.
+
+### Keep unrestricted root (status quo)
+
+Maximally portable and simplest, but leaves the full-host blast radius. Tier 1
+already removed the *user-facing* pain (unreadable artifacts); capability
+confinement addresses the *security* dimension the status quo ignores.
+
+### Full libguestfs-only (no host-mount path at all)
+
+Uniform behaviour, but the `/dev/kvm` speed cliff and heavy dependency make it a
+poor *default* for the portability requirement. Hence backend, not replacement.
+
+---
+
+## Consequences
+
+**Positive**
+- Bounded blast radius: a compromised build cannot trivially affect the whole
+  host.
+- Portable: capabilities exist on every target kernel; no dependency on userns
+  being enabled.
+- Incremental and low-risk: Phase 1 changes granted privilege, not the build
+  mechanism, so the matrix-verified behaviour is unchanged.
+- The `shell.ExecCmd` funnel means later isolation (Phase 2) has a clean seam.
+
+**Negative / risks**
+- The true minimal capability set is not fully known until Phase 0 runs; some
+  operations may pull in more caps than the candidate set.
+- `CAP_SYS_ADMIN` is broad — confining to it is a real but partial win; the
+  privileged-helper split (Phase 2) or guestfish backend (Tier 3) is needed to
+  drop it entirely.
+- The libguestfs backend adds a heavy optional dependency and a KVM requirement
+  for its fast path.
+
+---
+
+## Verification
+
+- **Phase 0 (DONE, 2026-08-07):** two Ubuntu 24.04 x86 builds ran to
+  `image build completed successfully` (exit 0) under the candidate capability
+  set — all 30 other capabilities dropped from the bounding set via
+  `scripts/cap-audit.sh` — with no `EPERM` / "operation not permitted" failures:
+    - **Overlay** build (10m27s): losetup attach/detach, root + ESP mounts, the
+      chroot configuration steps, and the Tier-1 ownership restore.
+    - **Full-bootstrap raw** build (`image-templates/ubuntu24-x86_64-minimal-raw.yml`,
+      11m28s): the from-scratch path — `mmdebstrap` bootstrap into `chrootenv/`
+      (Chroot Env Initialization 18s), Image Build 7m53s, mkfs, loop
+      attach/detach, image conversion — exercising `CAP_MKNOD` / `CAP_SETUID` /
+      `CAP_SETGID` / `CAP_SETFCAP` that the overlay path does not.
+
+  **The 11-cap candidate set is confirmed sufficient on Ubuntu 24.04 x86 for
+  both the overlay and full-bootstrap paths.** Still to confirm before Phase 1:
+  an ARM target, and the other providers (ELXR/EMT/azl) in the build matrix.
+- **Phase 1:** full build matrix (Ubuntu / ELXR / EMT / azl, x86 + ARM) green
+  under the minimal-capability invocation.
+- **Tier 3:** a guestfish-backed build producing a bootable image with no host
+  loop device or host mount held during assembly.

--- a/docs/user-guide/get-started/run-confined.md
+++ b/docs/user-guide/get-started/run-confined.md
@@ -1,0 +1,110 @@
+# Running with reduced privilege (capability confinement)
+
+Image Composer Tool (ICT) builds run as root because they attach loop devices,
+mount filesystems, and enter a `chroot`. Running as *unrestricted* root means a
+bug or a malicious package post-install script during a build could affect the
+whole host. This page shows how to run ICT with only the **minimal set of Linux
+capabilities** a build actually needs, so the rest of root's power is dropped.
+
+This does not change how ICT works or what it can build — the loop/mount/chroot
+mechanism is unchanged. It only lowers the privilege the process is granted, and
+it is portable: capabilities exist on every kernel ICT targets, with no
+dependency on unprivileged user namespaces (which some hardened distributions,
+including Ubuntu 24.04, restrict by default).
+
+## The minimal capability set
+
+A build needs exactly these capabilities (defined once in
+`scripts/ict-capabilities.env`):
+
+| Capability | Why |
+| --- | --- |
+| `CAP_SYS_ADMIN` | `losetup`, `mount`, bind mounts, sysfs, `mkswap` |
+| `CAP_SYS_CHROOT` | entering the chroot |
+| `CAP_CHOWN` | own root-owned rootfs files |
+| `CAP_FOWNER` | operate on files not owned by the effective uid |
+| `CAP_DAC_OVERRIDE` | read/traverse root-owned trees regardless of permissions |
+| `CAP_DAC_READ_SEARCH` | read-bypass distinct from `DAC_OVERRIDE` (metadata/loop reads) |
+| `CAP_FSETID` | preserve setuid/setgid bits when writing rootfs files |
+| `CAP_MKNOD` | device nodes in the rootfs (`mmdebstrap`/`dpkg`) |
+| `CAP_SETUID` / `CAP_SETGID` | accounts and groups created inside the rootfs |
+| `CAP_SETFCAP` | file capabilities on binaries inside the rootfs (e.g. `ping`) |
+
+Every other capability (for example `CAP_SYS_MODULE`, `CAP_SYS_RAWIO`,
+`CAP_SYS_PTRACE`, `CAP_NET_ADMIN`, `CAP_BPF`) is dropped. This set was validated
+by building both an overlay image and a from-scratch (`mmdebstrap`) raw image on
+Ubuntu 24.04 with the other capabilities removed.
+
+`CAP_SYS_ADMIN` is still broad. Confining to this set is a meaningful reduction,
+not full isolation; dropping `CAP_SYS_ADMIN` entirely requires the optional
+libguestfs backend described in the architecture decision record.
+
+## CLI: run a build confined
+
+Use the wrapper, which reduces the capability bounding set to the minimal set
+and then runs ICT — every build child (`mmdebstrap`, `mount`, `losetup`,
+`chroot`, `apt`, …) is bounded to the same set:
+
+```bash
+sudo -E ./scripts/ict-confined.sh build image-templates/ubuntu24-x86_64-minimal-raw.yml
+```
+
+It takes the same arguments as `image-composer-tool` and forwards them
+unchanged. Point it at an installed binary with `ICT_BIN`:
+
+```bash
+ICT_BIN=/usr/bin/image-composer-tool \
+  sudo -E ./scripts/ict-confined.sh build my-template.yml --workers 16
+```
+
+`sudo -E` is required: shrinking the bounding set itself needs `CAP_SETPCAP`
+(i.e. entering as root), exactly as ICT is launched today. `SUDO_UID`/`SUDO_GID`
+are preserved, so the post-build ownership restore still hands the image back to
+your user.
+
+### Verify the confinement
+
+To see which capabilities were dropped for a given template — or to re-validate
+the set after a toolchain change — use the audit harness, which builds under the
+reduced set and reports whether any operation needed a capability that was
+dropped:
+
+```bash
+sudo -E ./scripts/cap-audit.sh image-templates/ubuntu24-x86_64-minimal-raw.yml
+```
+
+## Server: run the build server confined (systemd)
+
+`deploy/systemd/image-composer-tool.service` runs the build server with
+`CapabilityBoundingSet` reduced to the minimal set.
+
+> **Important.** The web server's `--sudo` mode runs each privileged step via
+> `sudo -n <cmd>`. A `sudo` child is a new process whose capabilities come from
+> the bounding set at exec time, so a unit that bounds only the server process
+> does **not** confine a `sudo -n`-spawned build child. The shipped unit
+> therefore runs the server **as root without `--sudo`**, so build steps are
+> direct children bounded by the unit. Do not add `--sudo` to `ExecStart` unless
+> you have arranged confinement for the sudo children separately.
+
+```bash
+sudo install -m0644 deploy/systemd/image-composer-tool.service \
+    /etc/systemd/system/image-composer-tool.service
+# edit ExecStart (binary path, listen flags) to match your deployment
+sudo systemctl daemon-reload
+sudo systemctl enable --now image-composer-tool
+```
+
+Confirm the running service holds only the expected set:
+
+```bash
+systemctl show image-composer-tool -p CapabilityBoundingSet
+```
+
+## Troubleshooting
+
+If a build fails with `Operation not permitted` / `EPERM` after confinement, an
+operation needs a capability not in the set. Identify it with the audit harness
+(it prints the offending lines), then add the capability to **both**
+`scripts/ict-capabilities.env` and the `CapabilityBoundingSet` line in the
+systemd unit. Please also open an issue so the documented set can be updated —
+the audited set above is expected to be sufficient for the supported templates.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -46,6 +46,7 @@ See the [Quick Start guide](./get-started/quick-start.md) to build your first im
 | [Custom Build Actions](./configuration/configure-additional-actions-for-build.md) | Commands during image compose (chroot)   |
 | [Custom Initrd Script](./configuration/configure-custom-initrd-script.md)       | Debian 13 GRUB initramfs-tools initrd hook |
 | [Multiple Repos](./configuration/configure-multiple-package-repositories.md)      | Using multiple package repositories      |
+| [Run with Reduced Privilege](./get-started/run-confined.md)                       | Confine builds to a minimal capability set |
 
 ## Get Help
 
@@ -72,6 +73,7 @@ Quick Start <./get-started/quick-start.md>
 Prerequisites <./get-started/prerequisites.md>
 Installation <./get-started/installation.md>
 Usage Guide <./get-started/usage-guide.md>
+Run with Reduced Privilege <./get-started/run-confined.md>
 AI Template Generation (RAG) <./get-started/ai-template-generation.md>
 
 :::

--- a/scripts/cap-audit.sh
+++ b/scripts/cap-audit.sh
@@ -28,23 +28,21 @@
 
 set -uo pipefail
 
-# --- Candidate minimal capability set (keep list). Kept in sync with the ADR. ---
-# CAP_SYS_ADMIN    losetup, mount, bind, sysfs, mkswap
-# CAP_SYS_CHROOT   entering the chroot
-# CAP_CHOWN        own root-owned rootfs files
-# CAP_FOWNER       operate on files not owned by the euid
-# CAP_DAC_OVERRIDE read/traverse root-owned trees regardless of perms
-# CAP_MKNOD        device nodes in the rootfs
-# CAP_SETUID/SETGID accounts created inside the rootfs (useradd/passwd)
-# CAP_SETFCAP      file capabilities set on binaries inside the rootfs (e.g. ping)
-# CAP_DAC_READ_SEARCH read-bypass distinct from DAC_OVERRIDE (metadata/loop reads)
-# CAP_FSETID       preserve setuid/setgid bits when writing rootfs files
-DEFAULT_KEEP_CAPS="cap_sys_admin,cap_sys_chroot,cap_chown,cap_fowner,cap_dac_override,cap_mknod,cap_setuid,cap_setgid,cap_setfcap,cap_dac_read_search,cap_fsetid"
+err() { printf 'cap-audit: %s\n' "$*" >&2; }
+
+# --- Candidate minimal capability set (keep list). ---
+# Single-sourced from ict-capabilities.env so the audit and the production
+# wrapper (ict-confined.sh) / systemd unit never diverge. Override for an
+# experiment with KEEP_CAPS=... in the environment.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+if ! source "$_SCRIPT_DIR/ict-capabilities.env"; then
+    err "cannot source $_SCRIPT_DIR/ict-capabilities.env"
+    exit 2
+fi
 
 ICT_BIN="${ICT_BIN:-./image-composer-tool}"
-KEEP_CAPS="${KEEP_CAPS:-$DEFAULT_KEEP_CAPS}"
-
-err() { printf 'cap-audit: %s\n' "$*" >&2; }
+KEEP_CAPS="${KEEP_CAPS:-$ICT_MIN_CAPS}"
 
 if [[ $# -lt 1 ]]; then
     err "usage: sudo $0 <template.yml> [extra ict build args...]"

--- a/scripts/cap-audit.sh
+++ b/scripts/cap-audit.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# cap-audit.sh — Phase 0 of the "reduce root privilege surface" plan
+# (see docs/architecture-decision-record/adr-reduce-root-privilege.md).
+#
+# Runs an ICT build under a MINIMAL Linux capability set instead of unrestricted
+# root, so we can discover empirically which capabilities the build actually
+# needs. Any operation that fails names a capability missing from the candidate
+# set; a clean build confirms the set is sufficient.
+#
+# Mechanism: ICT runs as root (uid 0), and a uid-0 process derives each child's
+# permitted capabilities from the BOUNDING SET. So the only reliable way to
+# constrain what the build (and every losetup/mount/chroot child it spawns) can
+# do is to drop the complement of our keep-set from the bounding set. capsh does
+# exactly that; dropping from the bounding set needs CAP_SETPCAP, which we have
+# because we are launched via sudo (real root), matching how ICT already runs.
+#
+# Usage:
+#   sudo ./scripts/cap-audit.sh <template.yml> [extra ict build args...]
+#
+# Environment:
+#   ICT_BIN        path to the image-composer-tool binary (default: ./image-composer-tool)
+#   KEEP_CAPS      comma-separated caps to KEEP (default: the candidate set below)
+#   AUDIT_LOG      where to tee the build log (default: ./cap-audit-<ts>.log)
+#
+# This script changes NO ICT code. It only launches the existing binary under a
+# reduced bounding set and captures the result for analysis.
+
+set -uo pipefail
+
+# --- Candidate minimal capability set (keep list). Kept in sync with the ADR. ---
+# CAP_SYS_ADMIN    losetup, mount, bind, sysfs, mkswap
+# CAP_SYS_CHROOT   entering the chroot
+# CAP_CHOWN        own root-owned rootfs files
+# CAP_FOWNER       operate on files not owned by the euid
+# CAP_DAC_OVERRIDE read/traverse root-owned trees regardless of perms
+# CAP_MKNOD        device nodes in the rootfs
+# CAP_SETUID/SETGID accounts created inside the rootfs (useradd/passwd)
+# CAP_SETFCAP      file capabilities set on binaries inside the rootfs (e.g. ping)
+# CAP_DAC_READ_SEARCH read-bypass distinct from DAC_OVERRIDE (metadata/loop reads)
+# CAP_FSETID       preserve setuid/setgid bits when writing rootfs files
+DEFAULT_KEEP_CAPS="cap_sys_admin,cap_sys_chroot,cap_chown,cap_fowner,cap_dac_override,cap_mknod,cap_setuid,cap_setgid,cap_setfcap,cap_dac_read_search,cap_fsetid"
+
+ICT_BIN="${ICT_BIN:-./image-composer-tool}"
+KEEP_CAPS="${KEEP_CAPS:-$DEFAULT_KEEP_CAPS}"
+
+err() { printf 'cap-audit: %s\n' "$*" >&2; }
+
+if [[ $# -lt 1 ]]; then
+    err "usage: sudo $0 <template.yml> [extra ict build args...]"
+    exit 2
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    err "must run as root (via sudo) so CAP_SETPCAP is available to shrink the bounding set"
+    exit 2
+fi
+
+for tool in capsh getcap; do
+    command -v "$tool" >/dev/null 2>&1 || { err "required tool '$tool' not found (install libcap2-bin)"; exit 2; }
+done
+
+if [[ ! -x "$ICT_BIN" ]]; then
+    err "ICT binary not found or not executable: $ICT_BIN (build it, or set ICT_BIN=)"
+    exit 2
+fi
+ICT_BIN="$(readlink -f "$ICT_BIN")"
+
+TEMPLATE="$1"
+shift
+EXTRA_ARGS=("$@")
+
+# --- Compute the complement to drop: every host capability NOT in the keep set. ---
+# We read the live bounding set so this stays correct across kernels that add or
+# omit capabilities (the keep set may name a cap absent here; that is harmless).
+mapfile -t ALL_CAPS < <(capsh --print | sed -n 's/^Bounding set =//p' | tr ',' '\n' | sed '/^$/d')
+if [[ ${#ALL_CAPS[@]} -eq 0 ]]; then
+    err "could not read the bounding set from capsh --print"
+    exit 2
+fi
+
+declare -A KEEP_SET=()
+IFS=',' read -ra _keep <<< "$KEEP_CAPS"
+for c in "${_keep[@]}"; do
+    c="$(echo "$c" | tr '[:upper:]' '[:lower:]' | xargs)"   # normalize
+    [[ -n "$c" ]] && KEEP_SET["$c"]=1
+done
+
+DROP_LIST=()
+for c in "${ALL_CAPS[@]}"; do
+    if [[ -z "${KEEP_SET[$c]:-}" ]]; then
+        DROP_LIST+=("$c")
+    fi
+done
+DROP_CSV="$(IFS=,; echo "${DROP_LIST[*]}")"
+
+# Warn about keep-set entries not present on this host (typo or newer cap name).
+for c in "${!KEEP_SET[@]}"; do
+    present=0
+    for h in "${ALL_CAPS[@]}"; do [[ "$h" == "$c" ]] && { present=1; break; }; done
+    [[ $present -eq 0 ]] && err "note: kept cap '$c' is not in this host's bounding set (ignored)"
+done
+
+ts="$(date +%Y%m%d-%H%M%S 2>/dev/null || echo run)"
+AUDIT_LOG="${AUDIT_LOG:-./cap-audit-${ts}.log}"
+
+{
+    echo "=========================================================="
+    echo "ICT capability-confinement audit (Phase 0)"
+    echo "=========================================================="
+    echo "binary   : $ICT_BIN"
+    echo "template : $TEMPLATE"
+    echo "extra    : ${EXTRA_ARGS[*]:-(none)}"
+    echo "keep caps: $KEEP_CAPS"
+    echo "drop caps: $DROP_CSV"
+    echo "----------------------------------------------------------"
+    echo "Reading a failure: a build step that dies with EPERM / 'Operation not"
+    echo "permitted' / 'must be run as root' names a capability we dropped and"
+    echo "must add to the keep set. A clean build confirms the set is sufficient."
+    echo "=========================================================="
+} | tee "$AUDIT_LOG"
+
+# --- Launch the build under the reduced bounding set. ---
+# --drop shrinks the bounding set (bounds every uid-0 child too).
+# SUDO_UID/SUDO_GID are preserved so ICT's Tier-1 ownership restore still runs.
+# We pass through the current environment (matching `sudo -E`) via `env`.
+# Capture the build's own output separately (BUILD_LOG) so classification below
+# scans only what the build emitted — never this script's instructional header,
+# which mentions "EPERM"/"Operation not permitted" as guidance and would
+# otherwise false-positive as a capability failure.
+BUILD_LOG="$(mktemp)"
+trap 'rm -f "$BUILD_LOG"' EXIT
+set -x
+capsh --drop="$DROP_CSV" -- -c \
+    "exec env SUDO_UID='${SUDO_UID:-}' SUDO_GID='${SUDO_GID:-}' '$ICT_BIN' build '$TEMPLATE' ${EXTRA_ARGS[*]}" \
+    2>&1 | tee -a "$AUDIT_LOG" "$BUILD_LOG"
+rc="${PIPESTATUS[0]}"
+set +x
+
+# Classify a non-zero exit: only blame capabilities when the log actually shows
+# a permission signal AND a privileged op was reached. A build that dies during
+# package resolution (before any losetup/mount/chroot/bootstrap) has nothing to
+# do with the dropped capabilities, and saying otherwise sends the reader
+# chasing a non-existent cap.
+CAP_SIGNAL_RE='Operation not permitted|operation not permitted|EPERM|[Pp]ermission denied|must be run as root'
+PRIV_OP_RE='Losetup .* created|Mounted |chroot|mmdebstrap|bootstrap'
+
+{
+    echo "----------------------------------------------------------"
+    if [[ "$rc" -eq 0 ]]; then
+        echo "RESULT: build exited 0 under the minimal capability set."
+        echo "        The candidate keep set appears SUFFICIENT for this template."
+    elif grep -qEi "$CAP_SIGNAL_RE" "$BUILD_LOG"; then
+        echo "RESULT: build exited $rc AND the log shows a permission signal."
+        echo "        LIKELY a capability failure. The matching lines:"
+        grep -nEi "$CAP_SIGNAL_RE" "$BUILD_LOG" | grep -viE 'INFO' | head -10 | sed 's/^/          /'
+        echo "        Map the failing op to its capability and add it to KEEP_CAPS."
+    elif ! grep -qEi "$PRIV_OP_RE" "$BUILD_LOG"; then
+        echo "RESULT: build exited $rc, but FAILED BEFORE ANY PRIVILEGED OPERATION"
+        echo "        (no losetup/mount/chroot/bootstrap ran). This is UNRELATED to"
+        echo "        capability confinement — e.g. package resolution, config, or"
+        echo "        network. Re-run with a template that resolves to test the caps."
+    else
+        echo "RESULT: build exited $rc with no permission signal in the log."
+        echo "        A privileged op ran, so this is probably NOT a capability gap"
+        echo "        (a dropped cap normally surfaces as EPERM). Inspect the error"
+        echo "        above; re-run as full root to confirm it is not cap-related."
+    fi
+    echo "log: $AUDIT_LOG"
+} | tee -a "$AUDIT_LOG"
+
+exit "$rc"

--- a/scripts/ict-capabilities.env
+++ b/scripts/ict-capabilities.env
@@ -1,0 +1,21 @@
+# Minimal Linux capability set an ICT build requires, confirmed by the Phase 0
+# audit (see docs/architecture-decision-record/adr-reduce-root-privilege.md).
+# Sourced by scripts/cap-audit.sh (the audit harness) and scripts/ict-confined.sh
+# (the production wrapper), and mirrored in deploy/systemd/image-composer-tool.service,
+# so the set is defined in ONE place and cannot drift between them.
+#
+# Why each is needed:
+#   cap_sys_admin       losetup, mount, bind, sysfs, mkswap
+#   cap_sys_chroot      entering the chroot
+#   cap_chown           own root-owned rootfs files
+#   cap_fowner          operate on files not owned by the euid
+#   cap_dac_override    read/traverse root-owned trees regardless of perms
+#   cap_dac_read_search read-bypass distinct from DAC_OVERRIDE (metadata/loop reads)
+#   cap_fsetid          preserve setuid/setgid bits when writing rootfs files
+#   cap_mknod           device nodes in the rootfs (mmdebstrap/dpkg)
+#   cap_setuid          accounts created inside the rootfs
+#   cap_setgid          groups created inside the rootfs
+#   cap_setfcap         file capabilities on binaries inside the rootfs (e.g. ping)
+#
+# Lower-case, comma-separated (cap_from_text / capsh --caps format).
+ICT_MIN_CAPS="cap_sys_admin,cap_sys_chroot,cap_chown,cap_fowner,cap_dac_override,cap_dac_read_search,cap_fsetid,cap_mknod,cap_setuid,cap_setgid,cap_setfcap"

--- a/scripts/ict-confined.sh
+++ b/scripts/ict-confined.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# ict-confined.sh — run image-composer-tool with only the minimal Linux
+# capabilities a build needs, instead of unrestricted root.
+# See docs/architecture-decision-record/adr-reduce-root-privilege.md (Phase 1).
+#
+# ICT must run as root (uid 0) for loop-device attach, host mounts, and chroot.
+# This wrapper keeps uid 0 but shrinks the CAPABILITY BOUNDING SET to the
+# minimal, audited set (ICT_MIN_CAPS in scripts/ict-capabilities.env), dropping
+# every other capability. Because a uid-0 process — and every child it spawns
+# (mmdebstrap, mount, losetup, chroot, apt, …) — derives its capabilities from
+# the bounding set, this bounds the whole build to the minimal set and makes the
+# dropped capabilities unrecoverable. This is the exact mechanism validated by
+# the Phase 0 audit, so production behaviour matches what was tested.
+#
+# It changes NO ICT behaviour or command construction; it only lowers the
+# privilege the process is granted. Dropping from the bounding set needs
+# CAP_SETPCAP, so this wrapper itself must be entered as root (via sudo -E),
+# exactly as ICT is invoked today.
+#
+# Usage:
+#   sudo -E ./scripts/ict-confined.sh build <template.yml> [args...]
+#   sudo -E ./scripts/ict-confined.sh serve  [args...]
+#   ICT_BIN=/usr/bin/image-composer-tool sudo -E ./scripts/ict-confined.sh build t.yml
+#
+# Environment:
+#   ICT_BIN   path to the binary (default: ./image-composer-tool, else the first
+#             image-composer-tool found on PATH)
+
+set -uo pipefail
+
+err() { printf 'ict-confined: %s\n' "$*" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+if ! source "$SCRIPT_DIR/ict-capabilities.env"; then
+    err "cannot source $SCRIPT_DIR/ict-capabilities.env"
+    exit 2
+fi
+if [[ -z "${ICT_MIN_CAPS:-}" ]]; then
+    err "ICT_MIN_CAPS is empty; check ict-capabilities.env"
+    exit 2
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    err "must be entered as root (e.g. 'sudo -E $0 ...') so the bounding set can be shrunk"
+    exit 2
+fi
+
+command -v capsh >/dev/null 2>&1 || { err "'capsh' not found (install libcap2-bin)"; exit 2; }
+
+# Resolve the binary: explicit ICT_BIN, else ./image-composer-tool, else PATH.
+if [[ -n "${ICT_BIN:-}" ]]; then
+    :
+elif [[ -x "./image-composer-tool" ]]; then
+    ICT_BIN="./image-composer-tool"
+else
+    ICT_BIN="$(command -v image-composer-tool 2>/dev/null || true)"
+fi
+if [[ -z "${ICT_BIN:-}" || ! -x "$ICT_BIN" ]]; then
+    err "image-composer-tool binary not found (set ICT_BIN=/path/to/image-composer-tool)"
+    exit 2
+fi
+ICT_BIN="$(readlink -f "$ICT_BIN")"
+
+if [[ $# -eq 0 ]]; then
+    err "usage: sudo -E $0 <build|serve|...> [args...]"
+    exit 2
+fi
+
+# Compute the complement to drop: every host capability NOT in the keep set.
+# Reading the live bounding set keeps this correct across kernels that add or
+# omit capabilities.
+mapfile -t ALL_CAPS < <(capsh --print | sed -n 's/^Bounding set =//p' | tr ',' '\n' | sed '/^$/d')
+if [[ ${#ALL_CAPS[@]} -eq 0 ]]; then
+    err "could not read the bounding set from capsh --print"
+    exit 2
+fi
+
+declare -A KEEP_SET=()
+IFS=',' read -ra _keep <<< "$ICT_MIN_CAPS"
+for c in "${_keep[@]}"; do
+    c="$(echo "$c" | tr '[:upper:]' '[:lower:]' | xargs)"
+    [[ -n "$c" ]] && KEEP_SET["$c"]=1
+done
+
+DROP_LIST=()
+for c in "${ALL_CAPS[@]}"; do
+    [[ -z "${KEEP_SET[$c]:-}" ]] && DROP_LIST+=("$c")
+done
+
+if [[ ${#DROP_LIST[@]} -eq 0 ]]; then
+    err "nothing to drop — refusing to run without confinement (check ICT_MIN_CAPS)"
+    exit 2
+fi
+DROP_CSV="$(IFS=,; echo "${DROP_LIST[*]}")"
+
+# Preserve SUDO_UID/SUDO_GID so ICT's post-build ownership restore still targets
+# the invoking user, and pass through the environment (matching `sudo -E`).
+# Each incoming argument is single-quoted so paths with spaces survive the
+# `capsh -- -c` string.
+quoted=""
+for a in "$@"; do
+    quoted+=" '${a//\'/\'\\\'\'}'"
+done
+
+exec capsh --drop="$DROP_CSV" -- -c \
+    "exec env SUDO_UID='${SUDO_UID:-}' SUDO_GID='${SUDO_GID:-}' '$ICT_BIN'$quoted"


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [ ] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

ICT builds run as root for loop-device attach, host mounts, and `chroot`. Running as *unrestricted* root means a bug or a malicious package post-install script during a build could affect the whole host. This change lets ICT run with only the **minimal set of Linux capabilities** a build actually needs, dropping the rest.

The build mechanism (loop + mount + chroot) is unchanged, so this stays portable across every target kernel — no dependency on unprivileged user namespaces, which some hardened distributions (including Ubuntu 24.04) restrict by default.

This is the first two phases of a tiered plan captured in a new ADR (`docs/architecture-decision-record/adr-reduce-root-privilege.md`):

- **ADR + audit harness** — documents the plan and adds `scripts/cap-audit.sh`, which builds under a reduced capability bounding set to discover empirically which capabilities a build needs. It classifies a non-zero exit as a genuine capability failure, a failure *before* any privileged operation (unrelated to capabilities), or a non-permission error, so results are not misread.
- **Capability-confined run mode** — the portable default:
  - `scripts/ict-capabilities.env` single-sources the minimal set: `sys_admin`, `sys_chroot`, `chown`, `fowner`, `dac_override`, `dac_read_search`, `fsetid`, `mknod`, `setuid`, `setgid`, `setfcap`. The audit harness sources the same file, so the tested and shipped sets cannot diverge.
  - `scripts/ict-confined.sh` runs a build with the bounding set reduced to that set, so every build child (`mmdebstrap`, `mount`, `losetup`, `chroot`, `apt`, …) is bounded too.
  - `deploy/systemd/image-composer-tool.service` confines the build server via `CapabilityBoundingSet`. Because the server's `--sudo` per-command model would escape a process-level bounding set, the unit runs the server as root **without** `--sudo` so build steps are direct, bounded children — this is documented rather than shipped as silent false confinement.
  - `docs/user-guide/get-started/run-confined.md` documents the CLI and server paths and the sudo caveat.

`CAP_SYS_ADMIN` remains broad; confining to this set is a meaningful reduction, not full isolation. Dropping it entirely is future work (an optional libguestfs backend), noted in the ADR.

This is documentation + tooling only — **no change to ICT production Go code or command construction.**

#### Any Newly Introduced Dependencies

None. The tooling uses `capsh` from `libcap2-bin`, which is already required for the build environment.

#### How Has This Been Tested? <!-- REQUIRED -->

On Ubuntu 24.04 x86_64, with all capabilities except the minimal set dropped from the bounding set:

- **Overlay build** (`ubuntu24-x86_64-overlay-ubuntu-raw`) — completed successfully (exit 0): losetup attach/detach, root + ESP mounts, chroot configuration, and post-build ownership restore, with no `EPERM` failures.
- **From-scratch raw build** (`image-templates/ubuntu24-x86_64-minimal-raw.yml`) — completed successfully (exit 0): full `mmdebstrap` bootstrap, chroot env init, mkfs, loop attach/detach, and image conversion — exercising `CAP_MKNOD` / `CAP_SETUID` / `CAP_SETGID` / `CAP_SETFCAP` that the overlay path does not.
- Both were run through the audit harness *and* re-confirmed through the production `scripts/ict-confined.sh` wrapper.

Reproduce:
```
sudo -E ./scripts/ict-confined.sh build image-templates/ubuntu24-x86_64-minimal-raw.yml
```

Not yet run across the full matrix (ARM, and the ELXR/EMT/azl providers); tracked as remaining verification in the ADR.
