### PR TITLE
feat(templates): add Ubuntu 24.04 PTL PV desktop base and handheld extends child

### DIFF
--- a/image-templates/ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml
+++ b/image-templates/ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# =============================================================================
+# Ubuntu 24.04 generic handheld OS desktop image (raw) — extends child
+# =============================================================================
+# This is a THIN child of ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml.
+# It inherits the base's disk layout, package repositories, bootloader,
+# immutability, kernel, network-manager netplan file, base package set and base
+# configuration commands, and layers on ONLY the handheld additions:
+#
+#   * packages: Docker CE engine, Firefox (.deb), Intel RealSense SDK, oneVPL,
+#     power/thermal daemons, cloud-init/chrony, benchmarking & profiling tools,
+#     and the linux-tools runtime deps refresh,
+#   * a default `user`,
+#   * NoCloud datasource lockdown + systemd-boot purge, the kernel hotfix
+#     install, and K3s/Docker pre-install (disabled by default) commands.
+#
+# MERGE BEHAVIOUR (see internal/config/merge.go):
+#   - packages union+dedup with the base (base first, these appended);
+#   - configurations are APPENDED after the base's — the base's GPU/NPU/
+#     linux-tools steps run first, then the commands below;
+#   - users merge by name (this `user` is added);
+#   - disk / packageRepositories / kernel / bootloader / immutability are NOT
+#     redeclared here, so they are inherited from the base verbatim. In
+#     particular repositories MUST stay in the base: the merge keys repos by
+#     `codename` only, so a `noble` repo here would collapse the base's.
+# =============================================================================
+
+# AI-searchable metadata for template discovery
+metadata:
+  description: "Ubuntu 24.04 generic handheld OS desktop image (raw) — extends the PTL PV desktop base with Docker/K3s, Firefox, RealSense, oneVPL, power/thermal daemons and cloud-init"
+  use_cases:
+    - "generic handheld / edge device OS image"
+    - "container (Docker) or Kubernetes (K3s) edge host provisioned via cloud-init"
+    - "Intel RealSense + media/AI workloads"
+    - "raw image deployment"
+  keywords:
+    - handheld
+    - edge
+    - ptl
+    - ubuntu
+    - raw
+    - desktop
+    - docker
+    - k3s
+    - realsense
+    - cloud-init
+
+# Parent template — resolved relative to this file's directory.
+extends: "ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml"
+
+image:
+  name: generic-handheld-os-desktop
+  version: "24.04"
+
+# Must match the parent's target exactly (extends chain validation).
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+
+systemConfig:
+  name: generic-handheld-os
+  description: Generic handheld OS desktop image (extends the PTL PV desktop base)
+  hostname: minimal-desktop-ubuntu
+
+  # Default interactive user (groups for GPU/render/audio access).
+  users:
+    - name: user
+      password: ""               # Do not commit real credentials; set at deploy time (cloud-init/SSH keys) or a sha512 hash below
+      # password: "<HASHED_PASSWORD>"  # Uncomment and replace with a sha512 hash in real config
+      groups: ["sudo", "video", "render", "audio"]
+      hash_algo: sha512
+
+  # Handheld additions — unioned with the base's package set at merge time.
+  packages:
+    - curl
+    # libssl-dev hard-depends on "libssl3t64 (= <its own version>)". The resolver
+    # resolves the transitive libssl3t64 (pulled in by many base packages) to the
+    # -updates build 3.0.13-0ubuntu3.12, so libssl-dev must be pinned to the same
+    # -updates version or the exact "=" dep conflicts. Do NOT also list libssl3t64
+    # explicitly — that routes it through a path that stages the GA build instead.
+    - libssl-dev_3.0.13-0ubuntu3.12
+    # Docker CE engine (pre-installed, disabled by default; cloud-init enables on first boot)
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin
+    - firefox
+    - cloud-init
+    - chrony
+    - sg3-utils
+    - util-linux-extra
+    # -- Performance & Profiling Tools ------------------------------------------
+    # Intel Performance Counter Monitor - CPU/uncore/PCIe counters
+    - pcm
+    # Multi-purpose CPU / memory / I/O benchmark
+    - sysbench
+    # CPU, memory, I/O and device stress & benchmark suite
+    - stress-ng
+    # Flexible I/O tester for storage benchmarking
+    - fio
+    # -- Intel AI / Media Stack -------------------------------------------------
+    # oneVPL runtime - H.264 / HEVC / AV1 HW encode & decode via VA-API
+    - libvpl2
+    # Intel RealSense SDK
+    - librealsense2-dkms
+    - librealsense2
+    - librealsense2-utils
+    - librealsense2-dev
+    - librealsense2-gl
+    # Power and Thermal daemons for power and performance management
+    - intel-lpmd
+    - thermald
+
+  # Appended AFTER the base's configurations (GPU/NPU/linux-tools). All commands
+  # are idempotent / guarded, so running them after the base steps is safe.
+  configurations:
+    # ----------------------------------------------------------------------------------
+    # Cloud-init: restrict to NoCloud datasource only
+    # ----------------------------------------------------------------------------------
+    - cmd: "mkdir -p /etc/cloud/cloud.cfg.d"
+    - cmd: "printf 'datasource_list: [NoCloud, None]\\n' > /etc/cloud/cloud.cfg.d/99-datasource.cfg"
+    # Mask systemd-networkd-wait-online — NetworkManager-wait-online already provides network-online.target
+    - cmd: "systemctl mask systemd-networkd-wait-online.service"
+    # Purge systemd-boot — installed transitively. GRUB is the actual bootloader, so systemd-boot
+    # is unused — but its postinst (`bootctl install`) fails inside the chroot. Force-purge to recover, then pin to -1
+    # so later apt steps cannot re-pull it.
+    - cmd: "printf 'Package: systemd-boot systemd-boot-efi\\nPin: release *\\nPin-Priority: -1\\n' > /etc/apt/preferences.d/no-systemd-boot"
+    - cmd: "dpkg --purge --force-all systemd-boot systemd-boot-efi 2>/dev/null || true"
+    # Reconfigure linux-tools debs downloaded by the base stage after the additions above
+    - cmd: "find /tmp/linux-tools -maxdepth 1 -type f -name '*.deb' | xargs -r dpkg -i; apt-get install -y --fix-broken -o Dpkg::Options::=\"--force-overwrite\""
+    # Install hotfix kernel packages
+    - cmd: "mkdir -p /tmp/kernel-hotfix"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/hotfix/linux-intel-6.18/linux-image-6.18.23-lts-preprod-v6.18.23-linux-260708t100001z_6.18.23-260708t100001z-40_amd64.deb -O /tmp/kernel-hotfix/linux-image-6.18.23-lts-preprod-v6.18.23-linux-260708t100001z_6.18.23-260708t100001z-40_amd64.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/hotfix/linux-intel-6.18/linux-headers-6.18.23-lts-preprod-v6.18.23-linux-260708t100001z_6.18.23-260708t100001z-40_amd64.deb -O /tmp/kernel-hotfix/linux-headers-6.18.23-lts-preprod-v6.18.23-linux-260708t100001z_6.18.23-260708t100001z-40_amd64.deb"
+    # Verify SHA-256 against pinned hashes
+    - cmd: "cd /tmp/kernel-hotfix && printf '%s  %s\n' '998cb2daafee4d07616e561074830427950421955cabb876cecdfa8c2e738068' 'linux-image-6.18.23-lts-preprod-v6.18.23-linux-260708t100001z_6.18.23-260708t100001z-40_amd64.deb' '651afe5a312bc796564e62b50c83031b5bba493fd79827524226df5ce07ab1f9' 'linux-headers-6.18.23-lts-preprod-v6.18.23-linux-260708t100001z_6.18.23-260708t100001z-40_amd64.deb' | sha256sum -c -"
+    - cmd: "find /tmp/kernel-hotfix -maxdepth 1 -type f -name '*.deb' | xargs -r dpkg -i; apt-get install -y --fix-broken -o Dpkg::Options::=\"--force-overwrite\""
+    # ----------------------------------------------------------------------------------
+    # Pre-install K3s and Docker CE (both disabled by default)
+    # On first boot, cloud-init reads host_type from /etc/cloud/config-file and
+    # enables the correct service:
+    #   host_type=kubernetes  ? systemctl enable --now k3s + copies kubeconfig
+    #   host_type=container   ? systemctl disable k3s, enable --now docker
+    # See additionalfiles/ptl/edge-provisioning.cfg for the cloud-init runcmd.
+    # ----------------------------------------------------------------------------------
+    # Pre-install K3s binary and service (network available during build)
+    - cmd: "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_ENABLE=true INSTALL_K3S_SKIP_START=true INSTALL_K3S_EXEC='server --disable=traefik' sh - 2>&1 || echo Warning: K3s pre-install failed"
+    # Ensure both services are disabled by default; cloud-init activates the right one
+    - cmd: "systemctl disable k3s 2>/dev/null || true"
+    - cmd: "systemctl disable docker 2>/dev/null || true"
+    # Pre-create docker data-root and daemon config (avoids first-boot delay)
+    - cmd: "mkdir -p /opt/docker-data /etc/docker && echo '{\"data-root\": \"/opt/docker-data\"}' > /etc/docker/daemon.json"
+    # ----------------------------------------------------------------------------------
+    # Remove ICT-generated ubuntu-noble.list — duplicates the Ubuntu 24.04 native
+    # ubuntu.sources (DEB822 format)
+    # ----------------------------------------------------------------------------------
+    - cmd: "rm -f /etc/apt/sources.list.d/ubuntu-noble.list"

--- a/image-templates/ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml
@@ -1,0 +1,418 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# =============================================================================
+# Ubuntu 24.04 PTL PV desktop BASE template (raw)
+# =============================================================================
+# A trimmed desktop foundation derived from ubuntu24-x86_64-minimal-ptl-pv-raw.yml
+# with the heavyweight PTL/virtualisation content removed (qemu, libvirt, spice,
+# swtpm/tpm2, ibus/i18n input methods, and assorted dev/profiling extras).
+#
+# It is a standalone, buildable image AND the parent for downstream `extends:`
+# children (e.g. Ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml), which add
+# their own packages/users/configurations additively on top.
+#
+# NOTE ON REPOSITORIES: this base intentionally owns the COMPLETE
+# packageRepositories list — including repos only consumed by children
+# (Docker CE, RealSense, Mozilla, OpenVINO, oneAPI). The extends merge keys
+# package repositories by `codename` ALONE and keeps one repo per codename, so
+# base and child cannot each contribute a `noble` repo without collapsing them.
+# Keeping every repo here lets children declare none and inherit the full set
+# intact (the merge's zero-repos fast path skips the codename-collapse entirely).
+# =============================================================================
+
+# AI-searchable metadata for template discovery
+metadata:
+  description: "Ubuntu 24.04 PTL PV desktop base image (raw) — trimmed foundation for extends children; owns the full apt repository set"
+  use_cases:
+    - "PTL platform validation base"
+    - "Intel GPU and NPU enablement"
+    - "extends parent for downstream desktop/handheld images"
+    - "raw image deployment"
+  keywords:
+    - ptl
+    - pv
+    - ubuntu
+    - raw
+    - desktop
+    - base
+    - extends
+    - intel
+    - gpu
+    - npu
+
+image:
+  name: minimal-ptl-pv-desktop-base
+  version: "24.04"
+
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+
+# Disk layout and output artifact definition
+disk:
+  # Human friendly name logged by builders
+  name: minimal-ptl-pv-desktop-base
+  artifacts:
+    # Request conversion to raw
+    - type: raw
+      compression: gz
+  size: 32GiB
+  # GPT partition table per installer spec
+  partitionTableType: gpt
+  partitions:
+    # EFI system partition for bootloaders
+    - id: EFI
+      name: EFI
+      type: esp
+      # GPT type GUID for EFI system partition
+      typeUUID: c12a7328-f81f-11d2-ba4b-00a0c93ec93b
+      fsType: vfat
+      # Builder expects explicit MiB offsets
+      start: 1MiB
+      end: 1025MiB
+      mountPoint: /boot/efi
+      mountOptions: defaults
+      flags:
+        - boot
+        - esp
+    # Root filesystem
+    - id: SWAP
+      name: SWAP
+      type: linux-swap
+      typeUUID: 0657fd6d-a4ab-43c4-84e5-0933c84b4f4f
+      fsType: linux-swap
+      start: 1025MiB
+      end: 3073MiB
+      mountPoint: none
+      mountOptions: sw
+      flags: []
+
+    - id: ROOT
+      name: ROOT
+      type: linux-root-amd64
+      # Standard Linux root filesystem GUID for x86_64
+      typeUUID: 4f68bce3-e8cd-4db1-96e7-fbcaf984b709
+      fsType: ext4
+      start: 3073MiB
+      end: "0"
+      mountPoint: /
+      mountOptions: defaults
+      flags: []
+
+# Additional package repositories for this image.
+# Owns the COMPLETE set so extends children can inherit them all (see header).
+packageRepositories:
+  # Intel overlay repository (aligned with installer script)
+  - codename: "noble"
+    url: "https://download.01.org/intel-linux-overlay/ubuntu"
+    pkey: "https://download.01.org/intel-linux-overlay/ubuntu/E6FA98203588250569758E97D176E3162086EE4C.gpg"
+    component: "multimedia main non-free kernels"
+    priority: 2000
+    allowPackages:
+      - libigfxcmrt7
+      - curl
+      - gir1.2-gst-plugins-bad-1.0
+      - gir1.2-gstreamer-1.0
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-pulseaudio
+      # base gstreamer libs (pulled in as deps of the plugins above; the
+      # overlay ships 1.26.x while stock noble only has 1.24.x, so they must
+      # be allowed from the overlay to satisfy the >=1.26 version constraints)
+      - libgstreamer1.0-0
+      - libgstreamer-gl1.0-0
+      - libgstreamer-plugins-base1.0-0
+      - libgstreamer-plugins-bad1.0-0
+      - libigdgmm12
+      - libmfx-gen1.2
+      - libva-dev
+      - libva-drm2
+      - libva-glx2
+      - libva-wayland2
+      - libva-x11-2
+      - libva2
+      - libwayland-bin
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-dev
+      - libwayland-doc
+      - libwayland-egl-backend-dev
+      - libwayland-egl1
+      - libwayland-server0
+      - linux-firmware
+      - mesa-vulkan-drivers
+      - va-driver-all
+      - vainfo
+      - weston
+      - ffmpeg
+      - wayland-protocols
+      - linuxptp
+      - util-linux-extra
+      - dbus-x11
+      - sg3-utils
+      - linux-headers-6.18-intel
+      - linux-image-6.18-intel
+      # overlay dependencies
+      - libvpl2
+      - libavcodec62
+      - libavformat62
+      - libavutil60
+      - libavdevice62
+      - libavfilter11
+      - libswresample6
+      - libswscale9
+      - libweston-10-0
+      - dnsmasq-base
+      # additional PTL packages
+      - xdp-tools
+      - rpc-go
+      - lms
+      - metee
+      - libxdp-dev
+      - libxdp1
+      - intel-media-va-driver-non-free
+      # Power and Thermal daemons for power and performance management
+      - intel-lpmd
+      - thermald
+  # ----- OpenVINO -----
+  - codename: "ubuntu24"
+    url: "https://apt.repos.intel.com/openvino/2025"
+    pkey: "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
+  # ----- Intel oneAPI (oneDNN / Base Toolkit) -----
+  - codename: "all"
+    url: "https://apt.repos.intel.com/oneapi"
+    pkey: "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
+    component: "main"
+    priority: 500
+  # ----- Docker CE official -----
+  - codename: "noble"
+    url: "https://download.docker.com/linux/ubuntu"
+    pkey: "https://download.docker.com/linux/ubuntu/gpg"
+    component: "stable"
+    priority: 500
+  # ----- Intel RealSense SDK -----
+  # ref: https://docs.ros.org/en/iron/p/librealsense2/user_docs/distribution_linux.html
+  # TODO: the key ID below is hardcoded; need to find a better way to handle dynamic key discovery
+  #       in the packageRepositories section (ICT does not support shell substitution here).
+  # To get the current key ID if the build fails with NO_PUBKEY, run:
+  #   curl -sSf "https://librealsense.intel.com/Debian/apt-repo/dists/$(lsb_release -cs)/InRelease" \
+  #     | gpg --status-fd 1 --verify 2>/dev/null | grep "NO_PUBKEY" | awk '{print $3}'
+  # Then update the key ID in the pkey URL below.
+  - codename: "noble"
+    url: "https://librealsense.intel.com/Debian/apt-repo"
+    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xFB0B24895113F120"
+    component: "main"
+    priority: 500
+  # ----- Mozilla Team PPA (Firefox .deb, avoids Ubuntu's snap-transitional package) -----
+  - codename: "noble"
+    url: "https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu"
+    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0AB215679C571D1C8325275B9BDB3D89CE49EC21"
+    component: "main"
+    priority: 1001
+    allowPackages:
+      - firefox
+
+systemConfig:
+  name: minimal
+  description: Minimal desktop ubuntu base for PTL
+
+  bootloader:
+    bootType: efi
+    provider: grub
+
+  immutability:
+    enabled: false # default is true
+
+  # Base package set = the shared foundation. Downstream children add their own
+  # packages additively (the extends merge unions + dedups these with the child's).
+  packages:
+    - vim
+    - ocl-icd-libopencl1
+    - openssh-server
+    - net-tools
+    - libdrm-amdgpu1
+    - libdrm-common
+    - libdrm-dev
+    - libdrm-intel1
+    - libdrm-nouveau2
+    - libdrm-radeon1
+    - libdrm2
+    - bluez
+    - bsdutils
+    - debianutils
+    - diffutils
+    - findutils
+    - grep
+    - grub-efi-amd64-signed
+    - gzip
+    - language-pack-en
+    - language-pack-en-base
+    - language-pack-gnome-en
+    - language-pack-gnome-en-base
+    - libattr1
+    - va-driver-all
+    - linux-base
+    - mawk
+    - ncurses-base
+    - ncurses-bin
+    - python3-netifaces
+    - shim-signed
+    - ubuntu-desktop-minimal
+    - ubuntu-minimal
+    - ubuntu-standard
+    - gdm3
+    - systemd
+    - systemd-resolved
+    - util-linux
+    - udev
+    - initramfs-tools
+    - grub2-common
+    - grub-pc-bin
+    - grub-efi-amd64
+    - grub-efi-amd64-bin
+    - efibootmgr
+    # PTL network stack
+    - libbpf1
+    - wget
+    - cron
+    - ethtool
+    - iproute2
+    - network-manager
+    - libtbb12
+    # PTL packages
+    - libigfxcmrt7
+    - nano
+    - gir1.2-gst-plugins-bad-1.0
+    - gir1.2-gstreamer-1.0
+    - gstreamer1.0-plugins-bad
+    - gstreamer1.0-plugins-good
+    - gstreamer1.0-pulseaudio
+    - libigdgmm12
+    - libmfx-gen1.2
+    - libtpms-dev
+    - libtpms0
+    - libva-dev
+    - libva-drm2
+    - libva-glx2
+    - libva-wayland2
+    - libva-x11-2
+    - libva2
+    - libwayland-bin
+    - libwayland-client0
+    - libwayland-cursor0
+    - libwayland-dev
+    - libwayland-doc
+    - libwayland-egl-backend-dev
+    - libwayland-egl1
+    - libwayland-server0
+    - linux-firmware
+    - mesa-utils
+    - vainfo
+    - weston
+    - xserver-xorg-core
+    - cmake
+    - git
+    - intel-gpu-tools
+    - make
+    - mosquitto
+    - mosquitto-clients
+    - build-essential
+    - apt-transport-https
+    - ffmpeg
+    - git-lfs
+    - libglew-dev
+    - libglm-dev
+    - libsdl2-dev
+    - mc
+    - openssl
+    - pciutils
+    - python3-pip
+    - wayland-protocols
+    - msr-tools
+    - linuxptp
+    - lsscsi
+    - i2c-tools
+    - gnupg
+    - lsb-release
+    - socat
+    - rpm
+    # additional packages
+    - tcpdump
+    - mesa-vulkan-drivers
+    - xdp-tools
+    - rpc-go
+    - lms
+    - metee
+    - libxdp-dev
+    - libxdp1
+    - intel-media-va-driver-non-free
+    - firmware-sof-signed
+    # linux-tools runtime dependencies
+    - pahole
+    - libconfig9
+    - libbabeltrace1
+    - libdebuginfod1t64
+    - libopencsd1
+    - libtracefs1
+    - libtraceevent1
+    - libnuma1
+    - libslang2
+    - libpython3.12t64
+    - libdw1t64
+    - libnl-3-200
+    - libnl-genl-3-200
+    - libpci3
+
+  additionalFiles:
+    - local: ../additionalfiles/ptl/01-network-manager-all.yaml
+      final: /etc/netplan/01-network-manager-all.yaml
+
+  kernel:
+    cmdline: "xe.max_vfs=7 xe.force_probe=* modprobe.blacklist=i915 udmabuf.list_limit=8192 console=tty0 console=ttyS0,115200n8"
+    enableExtraModules: "intel_vpu uas"
+
+  configurations:
+    # Install Intel Graphics Compiler and compute runtime packages for PTL
+    - cmd: "mkdir -p /tmp/gpu-packages"
+    - cmd: "wget -q https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-core-2_2.28.4+20760_amd64.deb -O /tmp/gpu-packages/intel-igc-core-2_2.28.4+20760_amd64.deb"
+    - cmd: "wget -q https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-opencl-2_2.28.4+20760_amd64.deb -O /tmp/gpu-packages/intel-igc-opencl-2_2.28.4+20760_amd64.deb"
+    - cmd: "wget -q https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-ocloc_26.05.37020.3-0_amd64.deb -O /tmp/gpu-packages/intel-ocloc_26.05.37020.3-0_amd64.deb"
+    - cmd: "wget -q https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-opencl-icd_26.05.37020.3-0_amd64.deb -O /tmp/gpu-packages/intel-opencl-icd_26.05.37020.3-0_amd64.deb"
+    - cmd: "wget -q https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/libze-intel-gpu1_26.05.37020.3-0_amd64.deb -O /tmp/gpu-packages/libze-intel-gpu1_26.05.37020.3-0_amd64.deb"
+    - cmd: "wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.22.4/level-zero_1.22.4+u24.04_amd64.deb -O /tmp/gpu-packages/level-zero_1.22.4+u24.04_amd64.deb"
+    - cmd: "wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.22.4/level-zero-devel_1.22.4+u24.04_amd64.deb -O /tmp/gpu-packages/level-zero-devel_1.22.4+u24.04_amd64.deb"
+
+    - cmd: "find /tmp/gpu-packages -maxdepth 1 -type f -name '*.deb' | xargs -r dpkg -i; apt-get install -y --fix-broken -o Dpkg::Options::=\"--force-overwrite\" || true"
+    # Install NPU driver for PTL
+    - cmd: "dpkg --purge --force-remove-reinstreq intel-driver-compiler-npu intel-fw-npu intel-level-zero-npu intel-level-zero-npu-dbgsym 2>/dev/null "
+    - cmd: "mkdir -p /tmp/npu-driver"
+    - cmd: "cd /tmp/npu-driver && wget -q https://github.com/intel/linux-npu-driver/releases/download/v1.32.0/linux-npu-driver-v1.32.0.20260402-23905121947-ubuntu2404.tar.gz -O /tmp/npu-driver/linux-npu-driver-v1.32.0.20260402-23905121947-ubuntu2404.tar.gz"
+    - cmd: "cd /tmp/npu-driver && tar -xf linux-npu-driver-v1.32.0.20260402-23905121947-ubuntu2404.tar.gz"
+    - cmd: "find /tmp/npu-driver -name '*.deb' -print0 | xargs -0 dpkg -i"
+    # Install linux-tools packages from flat repo directory
+    - cmd: "dpkg --purge --force-depends linux-kbuild-6.18.23-intel+260427T075939Z linux-misc-tools linux-perf rtla libcpupower1 libcpupower-dev linux-cpupower bpftool hyperv-daemons intel-sdsi linux-bpf-dev linux-config-6.18 usbip 2>/dev/null "
+    - cmd: "mkdir -p /tmp/linux-tools"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/libcpupower1_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/libcpupower1.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/bpftool_7.7.0+6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/bpftool.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/hyperv-daemons_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/hyperv-daemons.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/intel-sdsi_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/intel-sdsi.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/libcpupower-dev_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/libcpupower-dev.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/linux-bpf-dev_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/linux-bpf-dev.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/linux-config-6.18_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/linux-config-6.18.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/linux-cpupower_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/linux-cpupower.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/linux-kbuild-6.18.23-intel+260427T075939Z_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/linux-kbuild.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/linux-misc-tools_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/linux-misc-tools.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/linux-perf_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/linux-perf.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/rtla_6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/rtla.deb"
+    - cmd: "wget -q https://download.01.org/intel-linux-overlay/ubuntu/linux-tools/usbip_2.0+6.18.23-intel+260427T075939Z_amd64.deb -O /tmp/linux-tools/usbip.deb"
+    - cmd: "dpkg -i /tmp/linux-tools/libcpupower1.deb"
+    - cmd: "find /tmp/linux-tools -maxdepth 1 -type f -name '*.deb' | xargs -r dpkg -i; apt-get install -y --fix-broken -o Dpkg::Options::=\"--force-overwrite\" || true"
+    # Pin linux-tools packages to prevent apt from downgrading or removing them
+    - cmd: "printf 'Package: bpftool hyperv-daemons intel-sdsi libcpupower1 libcpupower-dev linux-bpf-dev linux-config-6.18 linux-cpupower linux-kbuild-6.18.23-intel+260427T075939Z linux-misc-tools linux-perf rtla usbip\nPin: version *260427T075939Z*\nPin-Priority: 1001\n' > /etc/apt/preferences.d/linux-tools-pin"
+    # Fix broken deps but ignore systemd-boot EFI variable error (not accessible in chroot)
+    - cmd: "apt-get install -y --fix-broken -o Dpkg::Options::=\"--force-overwrite\" || true"
+    - cmd: "dpkg --configure -a --force-configure-any || true"


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

Adds two new Ubuntu 24.04 x86_64 image templates:

- **`ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml`** — a trimmed desktop
  base derived from the minimal PTL PV image, with heavyweight
  virtualisation/dev content (qemu, libvirt, spice, swtpm/tpm2, ibus/i18n input
  methods, and assorted dev/profiling extras) removed. It is standalone and
  buildable, and serves as the parent for downstream `extends:` children. The
  base intentionally owns the **complete** `packageRepositories` set so children
  can declare none and inherit it intact — the extends merge keys repositories
  by `codename` alone, so base and child cannot each contribute a `noble` repo
  without collapsing them.

- **`ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml`** — a thin `extends`
  child of the base that layers only the handheld additions: Docker CE engine,
  Firefox (.deb), Intel RealSense SDK, oneVPL, power/thermal daemons,
  cloud-init/chrony, benchmarking & profiling tools, and a linux-tools runtime
  deps refresh; a default `user`; and NoCloud datasource lockdown +
  systemd-boot purge, kernel hotfix install, and K3s/Docker pre-install
  (disabled by default) configuration steps.

#### Any Newly Introduced Dependencies

No new tool/code dependencies. The templates reference existing external apt
repositories and packages already used elsewhere in the project:

- Intel OpenVINO — `https://apt.repos.intel.com/openvino/2025`
- Intel oneAPI (oneDNN / Base Toolkit) — `https://apt.repos.intel.com/oneapi`
- Intel RealSense SDK — `https://librealsense.intel.com/Debian/apt-repo`
- Mozilla Team PPA (Firefox .deb) — `https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu`
- Docker CE — official Docker apt repository
- Intel level-zero `v1.22.4` GitHub release assets

#### How Has This Been Tested? <!-- REQUIRED -->

<!-- Please describe the tests that you ran to verify your changes. -->
