### PR TITLE
feat(templates): enable GDM graphical login for debian13 bb-graphics

### DIFF
--- a/image-templates/debian13-x86_64-bb-graphics-raw.yml
+++ b/image-templates/debian13-x86_64-bb-graphics-raw.yml
@@ -5,10 +5,11 @@
 #
 # This template demonstrates the EXTENDS feature: it inherits the Debian 13
 # Bayonne Bridge base (Debian 13 qcow2 input + custom initrd + qcow2 output) and
-# adds ONLY the graphics packages needed to run GUI desktop apps. It does NOT
-# declare a baseline or an overlay policy of its own — those come from the parent.
+# adds the graphics packages plus the display-manager configuration needed to
+# boot into a GUI desktop. It does NOT declare a baseline or an overlay policy
+# of its own — those come from the parent.
 #
-# HOW THE MERGE WORKS (why this file only lists packages):
+# HOW THE MERGE WORKS (why this file only adds `packages` + `configurations`):
 #   * `extends` pulls in the parent, resolved relative to this file's directory.
 #   * The parent declares the baseline + policy; this child inherits them and MUST
 #     NOT redeclare them. The tool restricts an additive package set to exactly
@@ -91,3 +92,29 @@ systemConfig:
     # GPU firmware the graphics stack / initrd may load at boot
     - firmware-linux
     - firmware-misc-nonfree
+    # Display manager + GNOME session — turns the backend X/Mesa stack into a
+    # graphical login. gdm3 is the GNOME Display Manager; gnome-session provides
+    # the session gdm launches; gnome-shell is that session's compositor and is
+    # also what GDM's own greeter renders with. Without these the image has the
+    # graphics backend but nothing to bring up a login, so it boots to a tty.
+    - gdm3
+    - gnome-session
+    - gnome-shell
+
+  # ---------------------------------------------------------------------------
+  # Enable the graphical login. These commands run in the baseline chroot after
+  # package install; they merge AFTER the parent's configurations (which enable
+  # the 91hello dracut module), so ordering is safe.
+  #
+  # Installing gdm3 is NOT sufficient on its own: the Debian cloud baseline's
+  # default systemd target is multi-user.target, and gdm3.service is
+  # WantedBy=graphical.target — so at boot the system stops at multi-user and
+  # gdm never starts (hence the tty console, XDG_SESSION_TYPE=tty). Switching
+  # the default target to graphical.target is what actually flips the image to a
+  # graphical login. `systemctl enable gdm3` makes gdm3 the display-manager
+  # service explicitly; both operations only create symlinks, so they work
+  # offline inside the build chroot.
+  # ---------------------------------------------------------------------------
+  configurations:
+    - cmd: 'systemctl set-default graphical.target'
+    - cmd: 'systemctl enable gdm3'


### PR DESCRIPTION
The debian13-x86_64-bb-graphics child shipped the X/Mesa backend but no display manager or session, and the Debian cloud baseline defaults to multi-user.target, so the composed image booted to a tty console.

Add gdm3 + gnome-session + gnome-shell (additively on the inherited base) and a configurations block that runs `systemctl set-default graphical.target` and `systemctl enable gdm3`. Switching the default target is required because gdm3.service is WantedBy=graphical.target; installing gdm3 alone would still stop at multi-user. Both systemctl commands only create symlinks, so they apply offline in the build chroot.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [ ] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

Enable a graphical (GDM) login for the Debian 13 Bayonne Bridge graphics child image, which previously booted to a tty despite carrying the X/Mesa backend.

#### Any Newly Introduced Dependencies

Debian packages only (main repo): `gdm3`, `gnome-session`, `gnome-shell` — GNOME Display Manager and session, GPLv2+/LGPL, used to bring up the graphical login. No third-party/out-of-distro dependencies.

#### How Has This Been Tested? <!-- REQUIRED -->

_Pending build + boot verification of the composed qcow2 (expect graphical.target with a GDM greeter instead of a tty)._