### PR TITLE
fix(config): key packageRepositories extends merge on (codename, url)

### DIFF
--- a/image-templates/ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml
+++ b/image-templates/ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml
@@ -5,10 +5,12 @@
 # Ubuntu 24.04 generic handheld OS desktop image (raw) — extends child
 # =============================================================================
 # This is a THIN child of ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml.
-# It inherits the base's disk layout, package repositories, bootloader,
+# It inherits the base's disk layout, the base overlay repository, bootloader,
 # immutability, kernel, network-manager netplan file, base package set and base
 # configuration commands, and layers on ONLY the handheld additions:
 #
+#   * packageRepositories: the child-only apt repos it alone consumes — Docker
+#     CE, RealSense, Mozilla (Firefox), OpenVINO and oneAPI,
 #   * packages: Docker CE engine, Firefox (.deb), Intel RealSense SDK, oneVPL,
 #     power/thermal daemons, cloud-init/chrony, benchmarking & profiling tools,
 #     and the linux-tools runtime deps refresh,
@@ -21,10 +23,11 @@
 #   - configurations are APPENDED after the base's — the base's GPU/NPU/
 #     linux-tools steps run first, then the commands below;
 #   - users merge by name (this `user` is added);
-#   - disk / packageRepositories / kernel / bootloader / immutability are NOT
-#     redeclared here, so they are inherited from the base verbatim. In
-#     particular repositories MUST stay in the base: the merge keys repos by
-#     `codename` only, so a `noble` repo here would collapse the base's.
+#   - packageRepositories merge by the (codename, url) PAIR, so the child-only
+#     repos below (Docker CE, RealSense, Mozilla, OpenVINO, oneAPI) are ADDED
+#     alongside the base's overlay `noble` repo instead of colliding with it;
+#   - disk / kernel / bootloader / immutability are NOT redeclared here, so they
+#     are inherited from the base verbatim.
 # =============================================================================
 
 # AI-searchable metadata for template discovery
@@ -60,6 +63,48 @@ target:
   dist: ubuntu24
   arch: x86_64
   imageType: raw
+
+# Child-only package repositories. Merged with the base by the (codename, url)
+# pair, so the `noble` repos here coexist with the base's overlay `noble` repo
+# rather than overriding it.
+packageRepositories:
+  # ----- OpenVINO -----
+  - codename: "ubuntu24"
+    url: "https://apt.repos.intel.com/openvino/2025"
+    pkey: "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
+  # ----- Intel oneAPI (oneDNN / Base Toolkit) -----
+  - codename: "all"
+    url: "https://apt.repos.intel.com/oneapi"
+    pkey: "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
+    component: "main"
+    priority: 500
+  # ----- Docker CE official -----
+  - codename: "noble"
+    url: "https://download.docker.com/linux/ubuntu"
+    pkey: "https://download.docker.com/linux/ubuntu/gpg"
+    component: "stable"
+    priority: 500
+  # ----- Intel RealSense SDK -----
+  # ref: https://docs.ros.org/en/iron/p/librealsense2/user_docs/distribution_linux.html
+  # TODO: the key ID below is hardcoded; need to find a better way to handle dynamic key discovery
+  #       in the packageRepositories section (ICT does not support shell substitution here).
+  # To get the current key ID if the build fails with NO_PUBKEY, run:
+  #   curl -sSf "https://librealsense.intel.com/Debian/apt-repo/dists/$(lsb_release -cs)/InRelease" \
+  #     | gpg --status-fd 1 --verify 2>/dev/null | grep "NO_PUBKEY" | awk '{print $3}'
+  # Then update the key ID in the pkey URL below.
+  - codename: "noble"
+    url: "https://librealsense.intel.com/Debian/apt-repo"
+    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xFB0B24895113F120"
+    component: "main"
+    priority: 500
+  # ----- Mozilla Team PPA (Firefox .deb, avoids Ubuntu's snap-transitional package) -----
+  - codename: "noble"
+    url: "https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu"
+    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0AB215679C571D1C8325275B9BDB3D89CE49EC21"
+    component: "main"
+    priority: 1001
+    allowPackages:
+      - firefox
 
 systemConfig:
   name: generic-handheld-os

--- a/image-templates/ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml
@@ -12,18 +12,17 @@
 # children (e.g. Ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml), which add
 # their own packages/users/configurations additively on top.
 #
-# NOTE ON REPOSITORIES: this base intentionally owns the COMPLETE
-# packageRepositories list — including repos only consumed by children
-# (Docker CE, RealSense, Mozilla, OpenVINO, oneAPI). The extends merge keys
-# package repositories by `codename` ALONE and keeps one repo per codename, so
-# base and child cannot each contribute a `noble` repo without collapsing them.
-# Keeping every repo here lets children declare none and inherit the full set
-# intact (the merge's zero-repos fast path skips the codename-collapse entirely).
+# NOTE ON REPOSITORIES: this base owns only the repositories its OWN package
+# set needs — the Intel linux-overlay `noble` repo. Repos consumed solely by
+# children (Docker CE, RealSense, Mozilla, OpenVINO, oneAPI) now live in those
+# children. The extends merge keys package repositories by the (codename, url)
+# PAIR, so a child may contribute its own `noble` repos (Docker/RealSense/
+# Mozilla) alongside this base's overlay `noble` repo without collapsing them.
 # =============================================================================
 
 # AI-searchable metadata for template discovery
 metadata:
-  description: "Ubuntu 24.04 PTL PV desktop base image (raw) — trimmed foundation for extends children; owns the full apt repository set"
+  description: "Ubuntu 24.04 PTL PV desktop base image (raw) — trimmed foundation for extends children; owns the Intel linux-overlay apt repository its base package set needs"
   use_cases:
     - "PTL platform validation base"
     - "Intel GPU and NPU enablement"
@@ -102,8 +101,9 @@ disk:
       mountOptions: defaults
       flags: []
 
-# Additional package repositories for this image.
-# Owns the COMPLETE set so extends children can inherit them all (see header).
+# Package repositories required by this base's own package set. Child templates
+# add their own repos additively; the merge keys on (codename, url) so children
+# may contribute further `noble` repos without overriding this one (see header).
 packageRepositories:
   # Intel overlay repository (aligned with installer script)
   - codename: "noble"
@@ -178,43 +178,6 @@ packageRepositories:
       # Power and Thermal daemons for power and performance management
       - intel-lpmd
       - thermald
-  # ----- OpenVINO -----
-  - codename: "ubuntu24"
-    url: "https://apt.repos.intel.com/openvino/2025"
-    pkey: "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
-  # ----- Intel oneAPI (oneDNN / Base Toolkit) -----
-  - codename: "all"
-    url: "https://apt.repos.intel.com/oneapi"
-    pkey: "https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB"
-    component: "main"
-    priority: 500
-  # ----- Docker CE official -----
-  - codename: "noble"
-    url: "https://download.docker.com/linux/ubuntu"
-    pkey: "https://download.docker.com/linux/ubuntu/gpg"
-    component: "stable"
-    priority: 500
-  # ----- Intel RealSense SDK -----
-  # ref: https://docs.ros.org/en/iron/p/librealsense2/user_docs/distribution_linux.html
-  # TODO: the key ID below is hardcoded; need to find a better way to handle dynamic key discovery
-  #       in the packageRepositories section (ICT does not support shell substitution here).
-  # To get the current key ID if the build fails with NO_PUBKEY, run:
-  #   curl -sSf "https://librealsense.intel.com/Debian/apt-repo/dists/$(lsb_release -cs)/InRelease" \
-  #     | gpg --status-fd 1 --verify 2>/dev/null | grep "NO_PUBKEY" | awk '{print $3}'
-  # Then update the key ID in the pkey URL below.
-  - codename: "noble"
-    url: "https://librealsense.intel.com/Debian/apt-repo"
-    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xFB0B24895113F120"
-    component: "main"
-    priority: 500
-  # ----- Mozilla Team PPA (Firefox .deb, avoids Ubuntu's snap-transitional package) -----
-  - codename: "noble"
-    url: "https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu"
-    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0AB215679C571D1C8325275B9BDB3D89CE49EC21"
-    component: "main"
-    priority: 1001
-    allowPackages:
-      - firefox
 
 systemConfig:
   name: minimal

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -574,11 +574,18 @@ func mergePackageRepositories(defaultRepos, userRepos []PackageRepository) []Pac
 	merged := make([]PackageRepository, len(defaultRepos))
 	copy(merged, defaultRepos)
 
-	// For each user repo, override if codename matches a default, otherwise append
+	// The merge key is the (codename, url, path) tuple, not codename alone. This
+	// lets an extend template add multiple repositories that share a codename but
+	// differ in location — remote repos with different URLs, or local/path-based
+	// repos (which leave url empty and set path) with different paths. A user repo
+	// overrides a default only when codename, url and path all match (updating the
+	// other fields); otherwise it is appended.
 	for _, userRepo := range userRepos {
 		found := false
 		for i, defRepo := range merged {
-			if defRepo.Codename == userRepo.Codename {
+			if defRepo.Codename == userRepo.Codename &&
+				defRepo.URL == userRepo.URL &&
+				defRepo.Path == userRepo.Path {
 				merged[i] = userRepo
 				found = true
 				break

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -589,30 +589,53 @@ func TestMergeKernelConfig(t *testing.T) {
 
 func TestMergePackageRepositoriesDetailed(t *testing.T) {
 	defaultRepos := []PackageRepository{
-		{Codename: "main", URL: "http://default.com/main"},
+		{Codename: "main", URL: "http://default.com/main", Component: "main"},
 		{Codename: "universe", URL: "http://default.com/universe"},
 	}
 
 	userRepos := []PackageRepository{
-		{Codename: "main", URL: "http://user.com/main"},     // Override by codename
-		{Codename: "extras", URL: "http://user.com/extras"}, // Add new
+		{Codename: "main", URL: "http://default.com/main", Component: "restricted"}, // Same codename+url: override in place
+		{Codename: "main", URL: "http://user.com/main"},                             // Same codename, different url: coexists
+		{Codename: "extras", URL: "http://user.com/extras"},                         // New codename: appended
 	}
 
 	merged := mergePackageRepositories(defaultRepos, userRepos)
 
-	// User repos are appended to defaults; matching codenames override defaults
-	if len(merged) != 3 {
-		t.Errorf("expected 3 repositories (default universe + user main override + user extras appended), got %d", len(merged))
+	// (codename, url) is the merge key: the same-url "main" overrides in place,
+	// the different-url "main" is added alongside it, and "extras" is appended.
+	if len(merged) != 4 {
+		t.Errorf("expected 4 repositories (universe + main override + second main + extras), got %d", len(merged))
+	}
+
+	// The default "main" (same codename+url) must be overridden, not duplicated.
+	var defaultMain *PackageRepository
+	mainURLs := make(map[string]bool)
+	for i := range merged {
+		if merged[i].Codename == "main" {
+			mainURLs[merged[i].URL] = true
+			if merged[i].URL == "http://default.com/main" {
+				defaultMain = &merged[i]
+			}
+		}
+	}
+
+	// Both "main" URLs should be present (same-codename repos coexist).
+	if !mainURLs["http://default.com/main"] || !mainURLs["http://user.com/main"] {
+		t.Errorf("expected both main URLs to be present, got %v", mainURLs)
+	}
+	if defaultMain == nil {
+		t.Fatalf("expected default-url main repo to be present")
+	}
+	// The matching (codename+url) user repo overrides other fields.
+	if defaultMain.Component != "restricted" {
+		t.Errorf("expected default main component overridden to 'restricted', got '%s'", defaultMain.Component)
 	}
 
 	repoMap := make(map[string]string)
 	for _, repo := range merged {
-		repoMap[repo.Codename] = repo.URL
-	}
-
-	// main should be overridden by user
-	if repoMap["main"] != "http://user.com/main" {
-		t.Errorf("expected main repo to be from user, got '%s'", repoMap["main"])
+		if repo.Codename != "main" {
+			repoMap[repo.Codename] = repo.URL
+		}
 	}
 
 	// extras should be appended from user
@@ -623,6 +646,49 @@ func TestMergePackageRepositoriesDetailed(t *testing.T) {
 	// universe should still be present from defaults
 	if repoMap["universe"] != "http://default.com/universe" {
 		t.Errorf("expected universe repo from defaults, got '%s'", repoMap["universe"])
+	}
+}
+
+// TestMergePackageRepositoriesPathBased verifies that local/path-based repos
+// (url empty, path set) merge on (codename, path) just as remote repos merge on
+// (codename, url): same path overrides in place, a different path coexists.
+func TestMergePackageRepositoriesPathBased(t *testing.T) {
+	defaultRepos := []PackageRepository{
+		{Codename: "local", Path: "/srv/repo-a", Component: "main"},
+		{Codename: "local", Path: "/srv/repo-b"},
+	}
+
+	userRepos := []PackageRepository{
+		{Codename: "local", Path: "/srv/repo-a", Component: "restricted"}, // Same codename+path: override in place
+		{Codename: "local", Path: "/srv/repo-c"},                          // Same codename, different path: coexists
+	}
+
+	merged := mergePackageRepositories(defaultRepos, userRepos)
+
+	// repo-a is overridden in place; repo-b is preserved; repo-c is appended.
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 repositories (repo-a override + repo-b + repo-c), got %d", len(merged))
+	}
+
+	paths := make(map[string]string) // path -> component
+	for _, repo := range merged {
+		if repo.Codename != "local" {
+			t.Errorf("unexpected codename %q", repo.Codename)
+		}
+		paths[repo.Path] = repo.Component
+	}
+
+	// Same (codename, path) must override, not duplicate.
+	if paths["/srv/repo-a"] != "restricted" {
+		t.Errorf("expected repo-a component overridden to 'restricted', got '%s'", paths["/srv/repo-a"])
+	}
+	// Untouched default path preserved.
+	if _, ok := paths["/srv/repo-b"]; !ok {
+		t.Errorf("expected repo-b to be preserved from defaults")
+	}
+	// Different path coexists rather than colliding on the empty URL.
+	if _, ok := paths["/srv/repo-c"]; !ok {
+		t.Errorf("expected repo-c to be appended from user")
 	}
 }
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

The `extends` merge for the `packageRepositories` section keyed each entry on
`codename` alone. A child (extend) template could therefore never add a second
repository that shares a parent's codename — the child entry silently
**replaced** the parent one. In practice several distinct Ubuntu repos all use
the `noble` codename (the Intel linux-overlay, Docker CE, RealSense, the Mozilla
PPA…), so a base and its child could not each contribute a `noble` repo.

This PR makes the merge key the **`(codename, url, path)` tuple**:

- `internal/config/merge.go` — `mergePackageRepositories` now matches on
  `codename`, `url` **and** `path`. A user repo overrides a default only when all
  three match (updating the remaining fields); otherwise it is appended, so
  repositories that share a codename but differ in location coexist. This covers
  both remote repos (different URLs) and local/path-based repos (empty `url`,
  distinct `path`). Downstream materialization already assumed this uniqueness
  (`generateAptSourcesContent` emits one `deb` line per repo;
  `generatePreferencesFilename` combines codename with a URL-derived part), so the
  merge function was the lone outlier.

- `image-templates/ubuntu24-x86_64-minimal-ptl-pv-desktop-base-raw.yml` /
  `ubuntu24-x86_64-generic-handheld-os-desktop-raw.yml` — leverages the new key:
  the PTL PV desktop **base** is trimmed to the single Intel linux-overlay
  `noble` repo its own package set needs, and the child-only repos (Docker CE,
  RealSense, Mozilla, OpenVINO, oneAPI) move into the **handheld child** that
  consumes them. The child's Docker/RealSense/Mozilla `noble` repos now merge
  **alongside** the base's overlay `noble` repo instead of colliding with it.
  Header/merge comments and the base's `metadata.description` are updated
  accordingly. The merged effective repository set is unchanged.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

- `go test ./internal/config/` — passes, including:
  - `TestMergePackageRepositoriesDetailed` — URL-based semantics (same codename +
    same url → override in place; same codename + different url → both retained;
    new codename → appended).
  - `TestMergePackageRepositoriesPathBased` — path-based semantics (same codename +
    same path → override; same codename + different path → coexist; untouched
    default path preserved).
- `image-composer-tool validate` passes for both templates, and the child resolves
  its `extends` chain.
- `image-composer-tool resolve` on the handheld child yields the same 6-repo
  effective set as before — now including four distinct `noble` repos (overlay +
  Docker + RealSense + Mozilla) coexisting, which the old codename-only key collapsed.
