### PR TITLE
docs: document Ubuntu 22.04 lsblk/resize2fs workaround for overlay resize

### DIFF
--- a/docs/user-guide/architecture/image-composer-tool-templates.md
+++ b/docs/user-guide/architecture/image-composer-tool-templates.md
@@ -370,7 +370,11 @@ RAW, or the complete SBOM vs the baseline SBOM — see
 > end-to-end. The resize shells out to `growpart` (cloud-guest-utils), `sgdisk`
 > (gdisk, GPT only), `resize2fs` (e2fsprogs) or `xfs_growfs` (xfsprogs), and
 > `losetup`/`partx` (util-linux); these must be present on the build host, and
-> the build fails early with a clear message if any is missing.
+> the build fails early with a clear message if any is missing. Resize also
+> reads partition start sectors via `lsblk -o PATH,START,TYPE`, which requires
+> **util-linux >= 2.38**; Ubuntu 22.04's stock `lsblk`/`resize2fs` are too old
+> and not upgradable via `apt` — see the
+> [util-linux/e2fsprogs build-from-source instructions](../get-started/prerequisites.md#util-linux-lsblk-and-e2fsprogs-resize2fs).
 
 ---
 

--- a/docs/user-guide/get-started/installation.md
+++ b/docs/user-guide/get-started/installation.md
@@ -20,6 +20,7 @@ prerequisites.
   - [Image Composition Prerequisites](#image-composition-prerequisites)
     - [ukify](#ukify)
     - [mmdebstrap](#mmdebstrap)
+    - [util-linux (lsblk) and e2fsprogs (resize2fs)](#util-linux-lsblk-and-e2fsprogs-resize2fs)
   - [Next Steps](#next-steps)
 
 ---
@@ -212,6 +213,18 @@ Downloads and installs Debian packages to initialize a chroot.
   1.4.3+ manually per the
   [mmdebstrap instructions](./prerequisites.md#mmdebstrap)
 - **Alternative**: `debootstrap` can be used for Debian-based images
+
+### util-linux (lsblk) and e2fsprogs (resize2fs)
+
+Required for overlay-mode disk resize (`overlayPolicy.allowDiskResize`);
+not needed for `create`-mode builds.
+
+- **Ubuntu 24.04+**: Already ships util-linux >= 2.38 and a compatible
+  `resize2fs`
+- **Ubuntu 22.04**: The repository versions (util-linux 2.37, e2fsprogs
+  1.46.5) are too old and cannot be upgraded via `apt` — build both from
+  source per the
+  [util-linux/e2fsprogs instructions](./prerequisites.md#util-linux-lsblk-and-e2fsprogs-resize2fs)
 
 ---
 

--- a/docs/user-guide/get-started/prerequisites.md
+++ b/docs/user-guide/get-started/prerequisites.md
@@ -68,3 +68,74 @@ sudo dpkg -i mmdebstrap_1.4.3-6_all.deb
 ```bash
 sudo apt --fix-broken install
 ```
+
+---
+
+## util-linux (lsblk) and e2fsprogs (resize2fs)
+
+Overlay-mode disk resize (`overlayPolicy.allowDiskResize`) requires `lsblk`
+from **util-linux >= 2.38** (it reads partition start sectors via
+`lsblk -o PATH,START,TYPE`) and a `resize2fs` build new enough to grow the
+baseline's filesystem. Ubuntu 22.04 ships util-linux 2.37 and e2fsprogs
+1.46.5, and neither is available as a newer version via `apt`. Build both
+from source instead.
+
+### Upgrade util-linux (lsblk)
+
+1. Download and build util-linux v2.38:
+
+```bash
+wget https://www.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.tar.xz
+tar -xf util-linux-2.38.tar.xz
+cd util-linux-2.38
+./configure --prefix=/usr/local
+make -j$(nproc)
+sudo make install
+```
+
+2. Divert the distro `lsblk` and point `/usr/bin/lsblk` at the new build.
+   `dpkg-divert` keeps the diversion registered so a later `apt upgrade` of
+   util-linux writes to the diverted path instead of clobbering your symlink:
+
+```bash
+sudo dpkg-divert --divert /usr/bin/lsblk.distrib --rename /usr/bin/lsblk
+sudo ln -s /usr/local/bin/lsblk /usr/bin/lsblk
+```
+
+3. Verify the installation:
+
+```bash
+lsblk --version
+```
+
+### Upgrade e2fsprogs (resize2fs)
+
+1. Install the build dependencies:
+
+```bash
+sudo apt-get install -y build-essential pkg-config git
+```
+
+2. Clone and build e2fsprogs v1.47.0:
+
+```bash
+git clone --depth 1 --branch v1.47.0 https://github.com/tytso/e2fsprogs.git
+cd e2fsprogs && mkdir build && cd build
+../configure
+make
+```
+
+3. Install `resize2fs` over the distro version in `/usr/sbin` (the overlay
+   resize path shells out only to `resize2fs`):
+
+```bash
+sudo make install-libs
+sudo install -m0755 resize/resize2fs /usr/sbin/resize2fs
+```
+
+4. Verify the installation:
+
+```bash
+/usr/sbin/resize2fs 2>&1 | head -1
+# expect: resize2fs 1.47.0 (...)
+```


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Overlay-mode disk resize (`overlayPolicy.allowDiskResize`) requires `lsblk`
from util-linux >= 2.38 (partition start-sector inspection) and a `resize2fs`
new enough to grow the baseline's filesystem. Ubuntu 22.04 ships util-linux
2.37 and e2fsprogs 1.46.5, and neither can be upgraded via `apt`, so the
overlay resize path is currently unusable on Ubuntu 22.04 hosts without a
manual tool upgrade.

This PR documents the build-from-source workaround:

- Adds a new **util-linux (lsblk) and e2fsprogs (resize2fs)** section to
  `docs/user-guide/get-started/prerequisites.md` with step-by-step build and
  install instructions for both tools.
- Cross-links that section from `docs/user-guide/get-started/installation.md`'s
  *Image Composition Prerequisites*, matching the existing `ukify`/`mmdebstrap`
  Ubuntu 22.04 callout pattern.
- Notes the `util-linux >= 2.38` / `lsblk -o PATH,START,TYPE` requirement in
  the overlay resize build-host notes in
  `docs/user-guide/architecture/image-composer-tool-templates.md`, linking
  back to the new instructions.

No code changes; documentation only.

#### Any Newly Introduced Dependencies

None. This documents building existing upstream tools (`util-linux`,
`e2fsprogs`) from source on hosts that need them; no dependency is added to
the project itself.

#### How Has This Been Tested? <!-- REQUIRED -->

Documentation-only change. Verified the added Markdown renders correctly and
that all internal cross-reference links (installation.md ↔ prerequisites.md
↔ image-composer-tool-templates.md) resolve to the correct anchors.