### PR TITLE
chore(docs): add blank line before Supported Distributions heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A command-line tool for building custom Linux images from pre-built packages. De
 
 The diagram above illustrates the overall build flow and may show representative or planned provider/architecture
 combinations. The table below lists the OS and architecture combinations that are currently supported.
+
 ## Supported Distributions
 
 | OS | Distribution | Architecture |


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

Adds a single blank line before the `## Supported Distributions` heading in `README.md`.
The heading was directly adjacent to the preceding paragraph, which is the standard
markdownlint MD022 case (headings should be surrounded by blank lines). This is the only
occurrence in the file.

Whitespace only — no content, wording, or table changes.

To be fully transparent about intent: this PR was opened primarily to verify my
push/PR access to this repository end to end. The change itself is real and correct,
but it is not urgent — feel free to close it rather than merge if you'd prefer not to
carry a trivial commit.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

No build or test run is applicable — the change is a single blank line in a markdown file.
Verified with `git diff`, which reports exactly `README.md | 1 +` (1 insertion, 0 deletions),
and by confirming the README renders unchanged apart from the corrected heading spacing.
