### PR TITLE
feat(templates): bare-metal bring-up (DHCP + SSH) for the Debian 13 BB overlay, cloud-init optional

### DIFF
--- a/docs/user-guide/configuration/configure-baremetal-network-ssh.md
+++ b/docs/user-guide/configuration/configure-baremetal-network-ssh.md
@@ -1,0 +1,207 @@
+# Enable Networking and SSH on Bare Metal (Debian 13 overlay)
+
+## Overview
+
+**Goal:** get a Debian 13 **overlay** image that boots on **bare metal** to acquire a
+DHCP address and start `sshd`, when the image is a cloud image with **no cloud-init
+datasource**.
+
+**Why this is needed:** the Debian 13 generic cloud image relies on cloud-init to
+configure networking and SSH from a datasource at first boot. Flashed to real
+hardware there is usually no datasource, so cloud-init stalls boot probing the
+network and never brings up DHCP or `sshd` — the device gets **no IP** and **SSH
+never starts**. (QEMU hides this: its instant built-in DHCP lets cloud-init
+succeed, so the failure only shows on hardware.)
+
+**Approach:** deliver a small, idempotent, mode-agnostic bring-up script plus a
+systemd unit through `systemConfig.additionalFiles`, and pick *who runs it* with a
+single-line MODE toggle in `systemConfig.configurations`.
+
+**Full working example:**
+[image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml](https://github.com/open-edge-platform/image-composer-tool/blob/main/image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml)
+with `image-templates/additionalfiles/debian13-bb-baremetal/`.
+
+## What the bring-up script does
+
+`bare-metal-bringup.sh` runs on the device at boot and performs the two steps the
+flashed cloud image is missing:
+
+1. **Networking** — write a `systemd-networkd` `.network` drop-in that requests DHCP
+   on every wired NIC (matched by device type, `Type=ether`, not by name prefix),
+   then enable and (re)start `systemd-networkd`. Matching by type covers NICs whose
+   predictable names do not start with `en` (e.g. `eth0` under `net.ifnames=0`) while
+   still excluding loopback and WiFi. `systemd-networkd` ships with systemd, so this
+   needs no `ifupdown` / `netplan` / `NetworkManager`.
+2. **SSH** — `ssh-keygen -A` generates any missing host keys, ensure `/run/sshd`,
+   enable password auth via a `00-` `sshd_config.d` drop-in, then enable and start
+   `ssh` (Debian's unit is `ssh`, not `sshd`). Keys are **per-device** only because
+   MODE A removes any host keys baked by the `openssh-server` install at build time,
+   so `ssh-keygen -A` fills them in freshly on first boot.
+
+The script never touches cloud-init — the cloud-init policy is the template's job
+(see the MODE toggle below), so the same script is correct under both invokers.
+
+## The DHCP client identifier matters on bare metal
+
+The single most common bare-metal failure is getting **no IPv4 lease** or an
+**unexpected address**, even though the link is up. The cause is the DHCP *client
+identifier*:
+
+- By default `systemd-networkd` sends an **RFC-4361 DUID** as the client id.
+- Many bare-metal DHCP servers lease by **MAC address** (reservations or per-MAC
+  pools) and ignore the DUID, so they hand out no address for that identity or a
+  different one than you expect.
+
+The drop-in therefore forces MAC-based identification and disables IPv6 RA so the
+NIC does not come "up" with only an RA-derived IPv6 address and no usable IPv4:
+
+```ini
+[Match]
+Type=ether
+
+[Network]
+DHCP=yes
+IPv6AcceptRA=no
+
+[DHCPv4]
+SendRelease=false
+ClientIdentifier=mac
+```
+
+> QEMU's slirp DHCP leases regardless of client id, so this only matters on
+> hardware. If networking works in QEMU but not on a device, check this first.
+
+## Template wiring
+
+Deliver the script and its systemd unit with `additionalFiles`. Default
+(end-of-build) stage is correct — neither belongs in the initramfs. The script is
+`0755` in the repo and `additionalFiles` preserves mode (`cp -p`), so it lands
+executable.
+
+```yaml
+  packages:
+    - openssh-server           # so sshd exists (only openssh-client ships by default)
+
+  additionalFiles:
+    - local: additionalfiles/debian13-bb-baremetal/usr/local/sbin/bare-metal-bringup.sh
+      final: /usr/local/sbin/bare-metal-bringup.sh
+    - local: additionalfiles/debian13-bb-baremetal/etc/systemd/system/bare-metal-bringup.service
+      final: /etc/systemd/system/bare-metal-bringup.service
+```
+
+## Run a script on first boot only
+
+`bare-metal-bringup.service` is an idempotent oneshot that runs on **every** boot
+(re-applying the same config is harmless and self-heals a wiped `/run`). If instead
+you want a unit to run its script only on the **first** boot, guard it with a
+sentinel file and have systemd create that file after a successful run:
+
+```ini
+[Unit]
+Description=First-boot only setup
+# Skip the unit once the sentinel exists, so the script runs exactly once.
+ConditionPathExists=!/var/lib/bare-metal-firstboot.done
+Wants=network.target
+Before=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/my-firstboot.sh
+# Only mark "done" if the script succeeded, so a failed first boot retries next boot.
+ExecStartPost=/usr/bin/touch /var/lib/bare-metal-firstboot.done
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ConditionPathExists=!<file>` makes systemd skip the unit once the sentinel exists,
+so the script runs once and is a no-op on later boots. (systemd also offers
+`ConditionFirstBoot=yes`, which fires only while `/etc/machine-id` is unpopulated —
+handy for images that ship without a committed machine-id.)
+
+## Choose a MODE (the switch)
+
+Exactly one of the two `configurations` lines below is active. Switch by moving the
+`#` — comment the active line and uncomment the other. Nothing else changes.
+
+| MODE | Use when | What it does |
+| ---- | -------- | ------------ |
+| **A** (bare metal, default) | The device has **no** datasource | Disable cloud-init at build so it cannot stall boot, and enable the systemd oneshot that runs the script. |
+| **B** (cloud) | The image also runs where a **real** datasource exists | Leave cloud-init **enabled** so it provisions networking/SSH from the cloud metadata. The bring-up script/unit are still shipped but stay unenabled. |
+
+```yaml
+  configurations:
+    # MODE A (default): disable cloud-init, drop baked SSH host keys, enable the oneshot.
+    - cmd: mkdir -p /etc/cloud && touch /etc/cloud/cloud-init.disabled && rm -f /etc/ssh/ssh_host_* && mkdir -p /etc/systemd/system/multi-user.target.wants && ln -sf /etc/systemd/system/bare-metal-bringup.service /etc/systemd/system/multi-user.target.wants/bare-metal-bringup.service
+    # MODE B: leave cloud-init enabled; it provisions from the cloud datasource.
+    # - cmd: rm -f /etc/cloud/cloud-init.disabled
+```
+
+Notes:
+
+- MODE A creates the `multi-user.target.wants` symlink **directly** because
+  `systemctl enable` cannot run in the `configurations` stage (it executes before
+  `additionalFiles` are copied in); the symlink resolves once the unit lands at
+  end-of-build.
+- MODE A chains its steps with `&&` (not `;`) so the build fails fast if disabling
+  cloud-init or enabling the oneshot did not actually happen — a `;` chain would
+  mask an early failure behind the final command's exit status.
+- MODE A removes host keys baked by the `openssh-server` install (`rm -f
+  /etc/ssh/ssh_host_*`) so first boot generates per-device keys; without this every
+  flashed unit would share the same build-time keys.
+- MODE A disables cloud-init, which forfeits its first-boot rootfs `growpart`.
+- Do **not** bake a local NoCloud seed for MODE B — a seed under
+  `/var/lib/cloud/seed/nocloud/` can outrank and shadow the real cloud datasource.
+
+## Provide a login user
+
+Overlay mode applies `systemConfig.users`, but this feature does not create an
+account itself. Password SSH is useless without one, so add a login user — see
+[Configure Users](configure-image-user.md). For example:
+
+```yaml
+  users:
+    - name: user
+      password: user1234
+      groups: ["sudo"]
+```
+
+> **Insecure bring-up.** This flow enables **password** SSH auth with a known
+> credential purely to get a first shell. For any real deployment switch to
+> key-based auth (drop an `authorized_keys` via `additionalFiles`) and remove
+> `/etc/ssh/sshd_config.d/00-baremetal.conf`.
+
+## Build and verify
+
+Build and compose the image per the
+[README](https://github.com/open-edge-platform/image-composer-tool/blob/main/README.md),
+then flash the **raw** artifact to the device.
+
+On the booted device:
+
+- `ip -4 a` — the wired NIC should show the expected DHCP address.
+- `networkctl status <iface>` — confirms the DHCP client id is the **link/MAC**.
+- `systemctl is-active ssh` and `ssh user@<ip>` — sshd is up with per-device keys.
+- `journalctl -u bare-metal-bringup.service` — the script's `bare-metal-bringup:`
+  log lines (MODE A only).
+
+## Troubleshooting
+
+| Problem | Check |
+| ------- | ----- |
+| Works in QEMU, no IPv4 on hardware | `ClientIdentifier=mac` in the `.network` drop-in — the DHCP server likely leases by MAC. |
+| Link up but only an IPv6/`fe80:` address | `IPv6AcceptRA=no`; confirm the DHCP server offers IPv4. |
+| No IP and no SSH at all (MODE A) | The oneshot did not run — verify the `multi-user.target.wants/bare-metal-bringup.service` symlink and `journalctl -u bare-metal-bringup.service`. |
+| Boot stalls / hangs probing network | cloud-init is still enabled — MODE A must `touch /etc/cloud/cloud-init.disabled`. |
+| `sshd` fails to start | Missing host keys (`ssh-keygen -A`) or `/run/sshd`; both are handled by the script. |
+| Can reach host but cannot log in | No login user — add one via `systemConfig.users`. |
+
+An offline diagnostic, `scripts/inspect-image-login.sh`, mounts a built image
+read-only via `qemu-nbd` and reports the account + sshd state without booting.
+
+## Related documentation
+
+- [Configure Users](configure-image-user.md) — add the login account this feature needs.
+- [Custom Build Actions](configure-additional-actions-for-build.md) — `configurations` commands run in the chroot.
+- [Image templates](../architecture/image-composer-tool-templates.md) — `additionalFiles` fields and merge behavior.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -45,6 +45,7 @@ See the [Quick Start guide](./get-started/quick-start.md) to build your first im
 | [Configure Users](./configuration/configure-image-user.md)                        | Adding users to images                   |
 | [Custom Build Actions](./configuration/configure-additional-actions-for-build.md) | Commands during image compose (chroot)   |
 | [Custom Initrd Script](./configuration/configure-custom-initrd-script.md)       | Debian 13 GRUB initramfs-tools initrd hook |
+| [Bare-Metal Networking + SSH](./configuration/configure-baremetal-network-ssh.md) | DHCP + SSH for a Debian 13 overlay on bare metal |
 | [Multiple Repos](./configuration/configure-multiple-package-repositories.md)      | Using multiple package repositories      |
 
 ## Get Help
@@ -85,6 +86,7 @@ Configure Full-Disk Encryption <./configuration/configure-fde.md>
 Configure Users <./configuration/configure-image-user.md>
 Customize Image Build <./configuration/configure-additional-actions-for-build.md>
 Configure Custom Initrd Script <./configuration/configure-custom-initrd-script.md>
+Enable Bare-Metal Networking and SSH <./configuration/configure-baremetal-network-ssh.md>
 Configure Multiple Package Repositories <./configuration/configure-multiple-package-repositories.md>
 
 :::

--- a/image-templates/additionalfiles/debian13-bb-baremetal/etc/systemd/system/bare-metal-bringup.service
+++ b/image-templates/additionalfiles/debian13-bb-baremetal/etc/systemd/system/bare-metal-bringup.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bare-metal bring-up: DHCP networking + SSH (no cloud-init datasource)
+Documentation=file:/usr/local/sbin/bare-metal-bringup.sh
+# Order our config work before networking comes up; we (re)start networkd and ssh
+# from inside the script. We deliberately do NOT order Before=ssh.service: the
+# script runs `systemctl restart ssh` synchronously, so ordering this oneshot
+# before ssh.service would form a cycle and stall until TimeoutStartSec.
+Wants=network.target
+Before=network.target
+ConditionPathExists=/usr/local/sbin/bare-metal-bringup.sh
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/bare-metal-bringup.sh
+StandardOutput=journal+console
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/image-templates/additionalfiles/debian13-bb-baremetal/usr/local/sbin/bare-metal-bringup.sh
+++ b/image-templates/additionalfiles/debian13-bb-baremetal/usr/local/sbin/bare-metal-bringup.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# bare-metal-bringup.sh — first-/every-boot bring-up for a Debian cloud image
+# flashed to bare metal, where there is NO cloud-init datasource.
+#
+# The Debian generic cloud image expects cloud-init to configure networking and
+# SSH from a metadata datasource at first boot. On bare metal there is no
+# datasource, so networking and sshd never come up — the device gets no IP and
+# SSH never starts. This script performs that bring-up directly:
+#
+#   1. DHCP every wired NIC via systemd-networkd (always present with systemd),
+#   2. generate PER-DEVICE SSH host keys, enable password auth, start sshd.
+#
+# It is idempotent — safe to run repeatedly (the MODE A oneshot runs it on every
+# boot, and it is safe to re-run by hand). Only MODE A actually runs it (see the
+# image template's MODE toggle):
+#   * MODE A (no cloud-init): run by the bare-metal-bringup.service systemd oneshot.
+#   * MODE B (cloud-init):    shipped but left inert; cloud-init provisions
+#                             networking/SSH from the datasource instead (no local
+#                             NoCloud seed is baked — it would shadow that datasource).
+#
+# This script is deliberately MODE-AGNOSTIC: it does NOT touch cloud-init. Whether
+# cloud-init is disabled is the template's decision (MODE A disables it at build;
+# MODE B keeps it enabled), so the same script is correct under both invokers.
+# Run it by hand for recovery:  sudo bare-metal-bringup.sh
+#
+# INSECURE BRING-UP: this enables PASSWORD SSH auth. Before any real deployment,
+# switch to key-based auth and remove /etc/ssh/sshd_config.d/00-baremetal.conf.
+#
+# It also does NOT create a login user — the login account is provisioned by the
+# image template (systemConfig.users). Without a user, password SSH has nothing
+# to log into.
+
+# Keep going if an individual step fails (no `set -e`), but REMEMBER failures of
+# required steps in `rc` so the oneshot still exits nonzero — otherwise a broken
+# bring-up (no IP / no SSH) would report success under RemainAfterExit=yes.
+# Optional steps (systemd-resolved, unit enablement) stay best-effort.
+set -uo pipefail
+
+rc=0
+log()  { echo "bare-metal-bringup: $*"; }
+fail() { log "ERROR: $*"; rc=1; }
+
+# --- 1. Networking: DHCP on every wired interface ----------------------------
+# systemd-networkd ships with systemd, so this works without ifupdown / netplan /
+# NetworkManager being installed. Match every wired NIC by DEVICE TYPE (Type=ether)
+# rather than by name prefix: predictable names are not guaranteed to start with
+# `en` (e.g. `eth0` under net.ifnames=0, or vendor/board names), and Type=ether
+# still excludes loopback and WiFi (Type=wlan).
+#
+# ClientIdentifier=mac is REQUIRED for bare metal: by default networkd sends an
+# RFC-4361 DUID as the DHCP client id, but many bare-metal DHCP servers lease by
+# MAC (reservations / per-MAC pools) and ignore the DUID — so you get no lease or
+# a different address than expected. Sending the raw MAC matches those servers.
+# IPv6AcceptRA=no stops the NIC coming "up" with only an RA-derived IPv6 address
+# and no usable IPv4. (QEMU's slirp DHCP leases regardless, which masked this.)
+#
+# Caveat (MODE B): if cloud-init is left enabled and also renders a network
+# config, both request DHCP on the same NIC — harmless (they converge on the same
+# lease), but for a real deployment pick ONE network manager.
+mkdir -p /etc/systemd/network || fail "could not create /etc/systemd/network"
+cat > /etc/systemd/network/20-baremetal-dhcp.network <<'EOF' || fail "could not write DHCP .network drop-in"
+# Bare-metal bring-up: DHCP every wired NIC. Replace with a static or otherwise
+# managed configuration for a real deployment.
+[Match]
+Type=ether
+
+[Network]
+DHCP=yes
+IPv6AcceptRA=no
+
+[DHCPv4]
+SendRelease=false
+ClientIdentifier=mac
+EOF
+
+systemctl enable systemd-networkd >/dev/null 2>&1 || true
+# Restart (not just start) so a config rewritten on a later boot is re-read.
+# REQUIRED: without networkd running there is no DHCP, so a failure fails the unit.
+systemctl restart systemd-networkd 2>/dev/null || systemctl start systemd-networkd 2>/dev/null || fail "systemd-networkd did not (re)start"
+# DNS resolution — OPTIONAL and harmless if the unit is absent (best-effort).
+systemctl enable systemd-resolved >/dev/null 2>&1 || true
+systemctl start systemd-resolved 2>/dev/null || true
+log "systemd-networkd configured for DHCP"
+
+# --- 2. SSH: per-device host keys + password auth + service ------------------
+# /run is a fresh tmpfs each boot; sshd's privilege-separation dir must exist.
+mkdir -p /run/sshd || fail "could not create /run/sshd"
+
+# ssh-keygen -A generates any MISSING host keys under /etc/ssh — it does NOT
+# overwrite existing ones. Keys are UNIQUE per unit only if the build shipped
+# none: the MODE A configurations step removes any host keys baked by the
+# openssh-server install (otherwise every flashed unit would share them — a
+# fleet-wide MITM risk). First boot regenerates them here; later boots find them
+# present and leave the device identity unchanged (idempotent).
+ssh-keygen -A || fail "ssh-keygen -A failed to generate host keys"
+log "host keys ensured"
+
+# Force password auth on for bring-up. A 00- drop-in wins over the baseline's
+# "PasswordAuthentication no" (the Include sits above that line and sshd takes
+# the first value it sees per option); we also rewrite the main line to remove
+# any ambiguity.
+mkdir -p /etc/ssh/sshd_config.d || fail "could not create /etc/ssh/sshd_config.d"
+cat > /etc/ssh/sshd_config.d/00-baremetal.conf <<'EOF' || fail "could not write sshd_config.d drop-in"
+PasswordAuthentication yes
+PermitRootLogin no
+EOF
+if [ -f /etc/ssh/sshd_config ]; then
+	sed -i 's/^[#[:space:]]*PasswordAuthentication[[:space:]].*/PasswordAuthentication yes/' /etc/ssh/sshd_config || true
+fi
+log "password SSH auth enabled"
+
+# Debian's unit is named "ssh" (not "sshd"). Enable for future boots (best-effort;
+# the oneshot restarts ssh every boot anyway), start now.
+systemctl enable ssh >/dev/null 2>&1 || true
+# REQUIRED: without sshd running there is no login, so a failure fails the unit.
+systemctl restart ssh 2>/dev/null || systemctl start ssh 2>/dev/null || fail "ssh did not (re)start"
+log "sshd enabled and started"
+
+if [ "$rc" -ne 0 ]; then
+	log "bring-up completed WITH ERRORS — see the ERROR lines above"
+else
+	log "bring-up complete"
+fi
+exit "$rc"

--- a/image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml
+++ b/image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml
@@ -152,7 +152,19 @@ overlayPolicy:
 systemConfig:
   name: overlay
   description: Debian 13 Bayonne Bridge base — overlaid base packages + custom dracut initrd
-
+  # ---------------------------------------------------------------------------
+  # Login account. This BASE bakes NO credential of its own. In MODE A the
+  # bring-up script turns ON password SSH, but sshd has nothing to log into until
+  # an account exists — and MODE A disables cloud-init, so cloud-init will not
+  # create one either. Provide a login here (or in a child/user template) so MODE
+  # A yields a usable shell; under MODE B, cloud-init provisions the user instead.
+  # Uncomment and set a password HASH, or leave the password unset and drop an
+  # authorized_keys via additionalFiles for key-only auth. Do NOT commit a real
+  # plaintext password.
+  # users:
+  #   - name: user
+  #     password: "<SHA512-CRYPT HASH>"   # e.g. `mkpasswd -m sha512crypt`; NOT plaintext
+  #     groups: ["sudo"]
   # ---------------------------------------------------------------------------
   # Base packages overlaid onto the Debian 13 cloud image. The overlay is
   # additive-and-upgrade (see overlayPolicy above): each package and its
@@ -200,10 +212,11 @@ systemConfig:
     - traceroute
     - tcpdump
     - openssh-client
-    - openssh-server
+    - openssh-server   # SSH login on bare metal (started by bare-metal-bringup.sh at boot)
     # Hardware / system introspection
     - pciutils
     - usbutils
+    - efibootmgr   # hardware cleanup: revert EFI boot order back to the host disk
     - lshw
     - lsof
     - strace
@@ -245,6 +258,30 @@ systemConfig:
       final: /usr/lib/dracut/modules.d/91hello/initqueue-sample.sh
       stage: pre-initramfs
 
+    # ---------------------------------------------------------------------------
+    # Bare-metal bring-up (DHCP networking + SSH) — runs at BOOT, not build.
+    #
+    # The Debian cloud baseline leans on cloud-init to configure networking and
+    # SSH from a datasource at first boot. On bare metal there is no datasource,
+    # so networking and sshd never come up. Rather than provisioning sshd at build
+    # time (which bakes shared host keys and does nothing for networking), the
+    # bring-up runs at BOOT via the shared script bare-metal-bringup.sh: DHCP every
+    # wired NIC via systemd-networkd, generate PER-DEVICE host keys, start sshd.
+    #
+    # The script and its systemd unit are delivered regardless of mode; the MODE
+    # toggle in configurations (below) decides whether they are activated. In
+    # MODE B (cloud) they are shipped but left inert, and cloud-init provisions
+    # networking/SSH from the cloud datasource instead. (No cloud-init seed is
+    # baked in: a local NoCloud seed would shadow the real cloud datasource.)
+    #
+    # Default (end-of-build) stage is correct — neither belongs in the initramfs.
+    # The script is 0755 in the repo and additionalFiles preserves mode (cp -p),
+    # so it lands executable.
+    - local: additionalfiles/debian13-bb-baremetal/usr/local/sbin/bare-metal-bringup.sh
+      final: /usr/local/sbin/bare-metal-bringup.sh
+    - local: additionalfiles/debian13-bb-baremetal/etc/systemd/system/bare-metal-bringup.service
+      final: /etc/systemd/system/bare-metal-bringup.service
+
   # ---------------------------------------------------------------------------
   # Configuration commands run inside the baseline chroot AFTER package install
   # and BEFORE boot regeneration. They enable the 91hello dracut module. The
@@ -263,5 +300,45 @@ systemConfig:
   configurations:
     # Enable the 91hello module in the composed initramfs.
     - cmd: 'mkdir -p /etc/dracut.conf.d && echo ''add_dracutmodules+=" hello "'' > /etc/dracut.conf.d/91hello.conf'
-    # Enable the ssh service (Debian's unit is named "ssh", not "sshd").
-    - cmd: "systemctl enable ssh"
+    # ==========================================================================
+    # BARE-METAL vs CLOUD MODE — THE SWITCH. Exactly ONE of the two `- cmd:` lines
+    # below is uncommented. To change mode, move the `#`: comment the active line
+    # and uncomment the other. Nothing else in this template changes.
+    #
+    #   MODE A (bare metal) : disable cloud-init, drop baked SSH host keys, enable
+    #                         our systemd bring-up.
+    #   MODE B (cloud)      : leave cloud-init enabled so it provisions from the
+    #                         cloud datasource; our script/unit stay shipped-inert.
+    #
+    - cmd: mkdir -p /etc/cloud && touch /etc/cloud/cloud-init.disabled && rm -f /etc/ssh/ssh_host_* && mkdir -p /etc/systemd/system/multi-user.target.wants && ln -sf /etc/systemd/system/bare-metal-bringup.service /etc/systemd/system/multi-user.target.wants/bare-metal-bringup.service   # MODE A (default)
+    # - cmd: rm -f /etc/cloud/cloud-init.disabled                                                                                                                                                                                            # MODE B
+    #
+    # WHY: the Debian cloud baseline relies on cloud-init to bring up networking and
+    # SSH from a datasource at first boot.
+    #
+    #   * MODE A (bare metal): there is NO datasource, so cloud-init stalls boot and
+    #     never brings up DHCP or sshd (QEMU masked this via instant DHCP). We
+    #     DISABLE cloud-init and run bare-metal-bringup.sh from a systemd oneshot
+    #     instead — DHCP every wired NIC via systemd-networkd, PER-DEVICE host keys,
+    #     start sshd. We also `rm -f /etc/ssh/ssh_host_*` at build so first boot
+    #     regenerates keys UNIQUE per unit: ssh-keygen -A only fills in MISSING keys,
+    #     so any keys baked by the openssh-server install would otherwise be shared
+    #     fleet-wide. The steps are chained with `&&` (not `;`) so the build fails
+    #     fast if any of them did not actually happen. We create the wants symlink
+    #     directly because `systemctl enable` cannot run in this stage (it executes
+    #     before additionalFiles are copied in). Trade-off: disabling cloud-init
+    #     forfeits its first-boot rootfs growpart. INSECURE bring-up: password SSH
+    #     auth is on.
+    #
+    #   * MODE B (cloud): there IS a datasource, so leave cloud-init ENABLED and let
+    #     it provision networking/SSH normally from the cloud metadata. The `rm -f`
+    #     just clears any inherited disable flag; our bring-up script/unit remain
+    #     shipped but unenabled, and NO local seed is baked (it would shadow the
+    #     cloud datasource).
+    #
+    # The login account is NOT provisioned by this BASE (see the commented
+    # systemConfig.users example near the top of systemConfig). MODE A turns on
+    # password SSH, but with cloud-init disabled nothing creates a user, so add
+    # one (a password hash or an authorized_keys file) or MODE A starts sshd with
+    # no way to log in.
+    # ==========================================================================

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -360,6 +360,13 @@ func TestHandleStartBuildAccepted(t *testing.T) {
 	default:
 		t.Errorf("status = %q, want not-started, running, or success", acc.Status)
 	}
+	// Wait for the async build goroutine to finish before returning, so its
+	// writes under WorkDir complete before t.TempDir()'s deferred RemoveAll
+	// runs. Otherwise cleanup races the still-running build and flakes with
+	// "directory not empty".
+	if h, ok := s.svc.Build(acc.BuildId); ok {
+		<-h.Done()
+	}
 }
 
 // --- artifacts / details handlers (through the mux, with path params) ---


### PR DESCRIPTION
The Debian 13 cloud baseline leans on cloud-init to configure networking and SSH from a datasource at first boot. Flashed to bare metal there is usually no datasource, so cloud-init stalls boot probing the network and never brings up DHCP or sshd — the device acquires no IP and SSH never starts. (QEMU masked this: its instant DHCP lets cloud-init succeed.)

Provisioning sshd at build time cannot fix networking and would bake shared host keys into every unit. So the bring-up is moved to BOOT via a small, idempotent, mode-agnostic script (`bare-metal-bringup.sh`) delivered by additionalFiles:

- **Networking**: write a systemd-networkd `.network` that DHCPs every wired NIC (`Name=en*`). It sets `[DHCPv4] ClientIdentifier=mac` and `IPv6AcceptRA=no` — required for bare metal: networkd defaults to sending an RFC-4361 DUID as the DHCP client id, but many bare-metal DHCP servers lease by MAC and ignore the DUID, so the unit otherwise gets no IPv4 (or an unexpected one). systemd-networkd ships with systemd, so this needs no ifupdown/netplan/NetworkManager.
- **SSH**: `ssh-keygen -A` generates PER-DEVICE host keys (not shared across the fleet), ensure `/run/sshd`, force password auth via a `00-` `sshd_config.d` drop-in, enable and start `ssh` (Debian's unit is `ssh`, not `sshd`).

The script never touches cloud-init; the cloud-init policy is the template's, exposed as a single-line MODE toggle in `configurations`:

- **MODE A (bare metal, default)**: disable cloud-init at build (so it cannot stall even the first boot) and run the script from a systemd oneshot (`bare-metal-bringup.service`), enabled via a `multi-user.target.wants` symlink.
- **MODE B (cloud)**: leave cloud-init ENABLED so it provisions networking/SSH from the cloud datasource; the bring-up script/unit are shipped but stay unenabled. No local NoCloud seed is baked in — it would shadow the real cloud datasource.

Add `openssh-server` to the overlaid package set so sshd exists.

Accepted trade-offs for this insecure bring-up image: password SSH auth is on (harden to key-based auth and drop `00-baremetal.conf` for real use); MODE A forfeits cloud-init's first-boot rootfs growpart.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Enable networking + SSH on a Debian 13 BB overlay image flashed to bare metal, where cloud-init has no datasource. A boot-time script brings up DHCP (MAC-based client id) and sshd; a single-line template MODE toggle selects the systemd path (bare metal) or leaves cloud-init to provision from a cloud datasource.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

Built the raw image and flashed to bare metal: the NIC obtains its expected DHCP lease via MAC-based client identification and sshd starts with per-device host keys. Also verified under QEMU (where the default DUID client id had masked the MAC-lease issue).
