### PR TITLE
feat(templates): bare-metal bring-up (DHCP + SSH) for the Ubuntu 24 robotics HW overlay, cloud-init optional

### DIFF
--- a/image-templates/additionalfiles/ubuntu24-robotics-baremetal/etc/systemd/system/bare-metal-bringup.service
+++ b/image-templates/additionalfiles/ubuntu24-robotics-baremetal/etc/systemd/system/bare-metal-bringup.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bare-metal bring-up: DHCP networking + SSH (no cloud-init datasource)
+Documentation=file:/usr/local/sbin/bare-metal-bringup.sh
+# Order our config work before networking comes up; we (re)start networkd and ssh
+# from inside the script. We deliberately do NOT order Before=ssh.service: the
+# script runs `systemctl restart ssh` synchronously, so ordering this oneshot
+# before ssh.service would form a cycle and stall until TimeoutStartSec.
+Wants=network.target
+Before=network.target
+ConditionPathExists=/usr/local/sbin/bare-metal-bringup.sh
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/bare-metal-bringup.sh
+StandardOutput=journal+console
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/image-templates/additionalfiles/ubuntu24-robotics-baremetal/usr/local/sbin/bare-metal-bringup.sh
+++ b/image-templates/additionalfiles/ubuntu24-robotics-baremetal/usr/local/sbin/bare-metal-bringup.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# bare-metal-bringup.sh — first-/every-boot bring-up for an Ubuntu cloud image
+# flashed to bare metal, where there is NO cloud-init datasource.
+#
+# The Ubuntu generic cloud image expects cloud-init to configure networking and
+# SSH from a metadata datasource at first boot. On bare metal there is no
+# datasource, so networking and sshd never come up — the device gets no IP and
+# SSH never starts. This script performs that bring-up directly:
+#
+#   1. DHCP every wired NIC via systemd-networkd (always present with systemd),
+#   2. generate PER-DEVICE SSH host keys, enable password auth, start sshd.
+#
+# It is idempotent — safe to run repeatedly (the MODE A oneshot runs it on every
+# boot, and it is safe to re-run by hand). Only MODE A actually runs it (see the
+# image template's MODE toggle):
+#   * MODE A (no cloud-init): run by the bare-metal-bringup.service systemd oneshot.
+#   * MODE B (cloud-init):    shipped but left inert; cloud-init provisions
+#                             networking/SSH from the datasource instead (no local
+#                             NoCloud seed is baked — it would shadow that datasource).
+#
+# This script is deliberately MODE-AGNOSTIC: it does NOT touch cloud-init. Whether
+# cloud-init is disabled is the template's decision (MODE A disables it at build;
+# MODE B keeps it enabled), so the same script is correct under both invokers.
+# Run it by hand for recovery:  sudo bare-metal-bringup.sh
+#
+# INSECURE BRING-UP: this enables PASSWORD SSH auth. Before any real deployment,
+# switch to key-based auth and remove /etc/ssh/sshd_config.d/00-baremetal.conf.
+#
+# It also does NOT create a login user — the login account is provisioned by the
+# image template (systemConfig.users). Without a user, password SSH has nothing
+# to log into.
+
+# Keep going if an individual step fails (no `set -e`), but REMEMBER failures of
+# required steps in `rc` so the oneshot still exits nonzero — otherwise a broken
+# bring-up (no IP / no SSH) would report success under RemainAfterExit=yes.
+# Optional steps (systemd-resolved, unit enablement) stay best-effort.
+set -uo pipefail
+
+rc=0
+log()  { echo "bare-metal-bringup: $*"; }
+fail() { log "ERROR: $*"; rc=1; }
+
+# --- 1. Networking: DHCP on every wired interface ----------------------------
+# systemd-networkd ships with systemd, so this works without ifupdown / netplan /
+# NetworkManager being installed. Match every wired NIC by DEVICE TYPE (Type=ether)
+# rather than by name prefix: predictable names are not guaranteed to start with
+# `en` (e.g. `eth0` under net.ifnames=0, or vendor/board names), and Type=ether
+# still excludes loopback and WiFi (Type=wlan).
+#
+# ClientIdentifier=mac is REQUIRED for bare metal: by default networkd sends an
+# RFC-4361 DUID as the DHCP client id, but many bare-metal DHCP servers lease by
+# MAC (reservations / per-MAC pools) and ignore the DUID — so you get no lease or
+# a different address than expected. Sending the raw MAC matches those servers.
+# IPv6AcceptRA=no stops the NIC coming "up" with only an RA-derived IPv6 address
+# and no usable IPv4. (QEMU's slirp DHCP leases regardless, which masked this.)
+#
+# Caveat (MODE B): if cloud-init is left enabled and also renders a network
+# config (Ubuntu's default netplan → systemd-networkd), both request DHCP on the
+# same NIC — harmless (they converge on the same lease), but for a real
+# deployment pick ONE network manager.
+mkdir -p /etc/systemd/network || fail "could not create /etc/systemd/network"
+cat > /etc/systemd/network/20-baremetal-dhcp.network <<'EOF' || fail "could not write DHCP .network drop-in"
+# Bare-metal bring-up: DHCP every wired NIC. Replace with a static or otherwise
+# managed configuration for a real deployment.
+[Match]
+Type=ether
+
+[Network]
+DHCP=yes
+IPv6AcceptRA=no
+
+[DHCPv4]
+SendRelease=false
+ClientIdentifier=mac
+EOF
+
+systemctl enable systemd-networkd >/dev/null 2>&1 || true
+# Restart (not just start) so a config rewritten on a later boot is re-read.
+# REQUIRED: without networkd running there is no DHCP, so a failure fails the unit.
+systemctl restart systemd-networkd 2>/dev/null || systemctl start systemd-networkd 2>/dev/null || fail "systemd-networkd did not (re)start"
+# DNS resolution — OPTIONAL and harmless if the unit is absent (best-effort).
+systemctl enable systemd-resolved >/dev/null 2>&1 || true
+systemctl start systemd-resolved 2>/dev/null || true
+log "systemd-networkd configured for DHCP"
+
+# --- 2. SSH: per-device host keys + password auth + service ------------------
+# /run is a fresh tmpfs each boot; sshd's privilege-separation dir must exist.
+mkdir -p /run/sshd || fail "could not create /run/sshd"
+
+# ssh-keygen -A generates any MISSING host keys under /etc/ssh — it does NOT
+# overwrite existing ones. Keys are UNIQUE per unit only if the build shipped
+# none: the MODE A configurations step removes any host keys baked by the
+# openssh-server install (otherwise every flashed unit would share them — a
+# fleet-wide MITM risk). First boot regenerates them here; later boots find them
+# present and leave the device identity unchanged (idempotent).
+ssh-keygen -A || fail "ssh-keygen -A failed to generate host keys"
+log "host keys ensured"
+
+# Force password auth on for bring-up. A 00- drop-in wins over the baseline's
+# "PasswordAuthentication no" (the Include sits above that line and sshd takes
+# the first value it sees per option); we also rewrite the main line to remove
+# any ambiguity.
+mkdir -p /etc/ssh/sshd_config.d || fail "could not create /etc/ssh/sshd_config.d"
+cat > /etc/ssh/sshd_config.d/00-baremetal.conf <<'EOF' || fail "could not write sshd_config.d drop-in"
+PasswordAuthentication yes
+PermitRootLogin no
+EOF
+if [ -f /etc/ssh/sshd_config ]; then
+	sed -i 's/^[#[:space:]]*PasswordAuthentication[[:space:]].*/PasswordAuthentication yes/' /etc/ssh/sshd_config || true
+fi
+log "password SSH auth enabled"
+
+# Ubuntu's unit is named "ssh" (not "sshd"). Enable for future boots (best-effort;
+# the oneshot restarts ssh every boot anyway), start now.
+systemctl enable ssh >/dev/null 2>&1 || true
+# REQUIRED: without sshd running there is no login, so a failure fails the unit.
+systemctl restart ssh 2>/dev/null || systemctl start ssh 2>/dev/null || fail "ssh did not (re)start"
+log "sshd enabled and started"
+
+if [ "$rc" -ne 0 ]; then
+	log "bring-up completed WITH ERRORS — see the ERROR lines above"
+else
+	log "bring-up complete"
+fi
+exit "$rc"

--- a/image-templates/ubuntu24/ubuntu24-x86_64-robotics-hw-overlay-qcow2.yml
+++ b/image-templates/ubuntu24/ubuntu24-x86_64-robotics-hw-overlay-qcow2.yml
@@ -197,6 +197,19 @@ disk:
 systemConfig:
   name: robotics-hw
   description: Ubuntu 24.04 robotics base — Intel hardware enablement overlaid on the Canonical cloud image
+  # ---------------------------------------------------------------------------
+  # Login account. This BASE bakes NO credential of its own. In MODE A the
+  # bring-up script turns ON password SSH, but sshd has nothing to log into until
+  # an account exists — and MODE A disables cloud-init, so cloud-init will not
+  # create one either. Provide a login here (or in a child/user template) so MODE
+  # A yields a usable shell; under MODE B, cloud-init provisions the user instead.
+  # Uncomment and set a password HASH, or leave the password unset and drop an
+  # authorized_keys via additionalFiles for key-only auth. Do NOT commit a real
+  # plaintext password.
+  # users:
+  #   - name: user
+  #     password: "<SHA512-CRYPT HASH>"   # e.g. `mkpasswd -m sha512crypt`; NOT plaintext
+  #     groups: ["sudo"]
 
   # ---------------------------------------------------------------------------
   # Intel hardware enablement, overlaid onto the cloud image. Additive-only: a
@@ -232,7 +245,35 @@ systemConfig:
     - linux-firmware
 
     # ── SSH server access ────────────────────────────────────────────
-    - openssh-server
+    - openssh-server   # SSH login on bare metal (started by bare-metal-bringup.sh at boot)
+
+    # ── EFI boot order support ───────────────────────────────────────
+    - efibootmgr   # hardware cleanup: revert EFI boot order back to the host disk
+
+  # ---------------------------------------------------------------------------
+  # Bare-metal bring-up (DHCP networking + SSH) — runs at BOOT, not build.
+  #
+  # The Ubuntu cloud baseline leans on cloud-init to configure networking and
+  # SSH from a datasource at first boot. On bare metal there is no datasource,
+  # so networking and sshd never come up. Rather than provisioning sshd at build
+  # time (which bakes shared host keys and does nothing for networking), the
+  # bring-up runs at BOOT via the shared script bare-metal-bringup.sh: DHCP every
+  # wired NIC via systemd-networkd, generate PER-DEVICE host keys, start sshd.
+  #
+  # The script and its systemd unit are delivered regardless of mode; the MODE
+  # toggle in configurations (below) decides whether they are activated. In
+  # MODE B (cloud) they are shipped but left inert, and cloud-init provisions
+  # networking/SSH from the cloud datasource instead. (No cloud-init seed is
+  # baked in: a local NoCloud seed would shadow the real cloud datasource.)
+  #
+  # The script is 0755 in the repo and additionalFiles preserves mode (cp -p),
+  # so it lands executable.
+  # ---------------------------------------------------------------------------
+  additionalFiles:
+    - local: additionalfiles/ubuntu24-robotics-baremetal/usr/local/sbin/bare-metal-bringup.sh
+      final: /usr/local/sbin/bare-metal-bringup.sh
+    - local: additionalfiles/ubuntu24-robotics-baremetal/etc/systemd/system/bare-metal-bringup.service
+      final: /etc/systemd/system/bare-metal-bringup.service
 
   # ---------------------------------------------------------------------------
   # Hardware-side configuration. These apt pins are post-deployment upgrade
@@ -255,8 +296,48 @@ systemConfig:
     # Intel NPU udev rules (render group access to /dev/accel/*)
     - cmd: "printf 'SUBSYSTEM==\"accel\", KERNEL==\"accel*\", GROUP=\"render\", MODE=\"0660\"\\n' > /etc/udev/rules.d/10-intel-vpu.rules"
 
-    # Enable the ssh service
-    - cmd: "systemctl enable ssh"
+    # ==========================================================================
+    # BARE-METAL vs CLOUD MODE — THE SWITCH. Exactly ONE of the two `- cmd:` lines
+    # below is uncommented. To change mode, move the `#`: comment the active line
+    # and uncomment the other. Nothing else in this template changes.
+    #
+    #   MODE A (bare metal) : disable cloud-init, drop baked SSH host keys, enable
+    #                         our systemd bring-up.
+    #   MODE B (cloud)      : leave cloud-init enabled so it provisions from the
+    #                         cloud datasource; our script/unit stay shipped-inert.
+    #
+    - cmd: mkdir -p /etc/cloud && touch /etc/cloud/cloud-init.disabled && rm -f /etc/ssh/ssh_host_* && mkdir -p /etc/systemd/system/multi-user.target.wants && ln -sf /etc/systemd/system/bare-metal-bringup.service /etc/systemd/system/multi-user.target.wants/bare-metal-bringup.service   # MODE A (default)
+    # - cmd: rm -f /etc/cloud/cloud-init.disabled                                                                                                                                                                                            # MODE B
+    #
+    # WHY: the Ubuntu cloud baseline relies on cloud-init to bring up networking and
+    # SSH from a datasource at first boot.
+    #
+    #   * MODE A (bare metal): there is NO datasource, so cloud-init stalls boot and
+    #     never brings up DHCP or sshd (QEMU masked this via instant DHCP). We
+    #     DISABLE cloud-init and run bare-metal-bringup.sh from a systemd oneshot
+    #     instead — DHCP every wired NIC via systemd-networkd, PER-DEVICE host keys,
+    #     start sshd. We also `rm -f /etc/ssh/ssh_host_*` at build so first boot
+    #     regenerates keys UNIQUE per unit: ssh-keygen -A only fills in MISSING keys,
+    #     so any keys baked by the openssh-server install would otherwise be shared
+    #     fleet-wide. The steps are chained with `&&` (not `;`) so the build fails
+    #     fast if any of them did not actually happen. We create the wants symlink
+    #     directly because `systemctl enable` cannot run in this stage (it executes
+    #     before additionalFiles are copied in). Trade-off: disabling cloud-init
+    #     forfeits its first-boot rootfs growpart. INSECURE bring-up: password SSH
+    #     auth is on.
+    #
+    #   * MODE B (cloud): there IS a datasource, so leave cloud-init ENABLED and let
+    #     it provision networking/SSH normally from the cloud metadata. The `rm -f`
+    #     just clears any inherited disable flag; our bring-up script/unit remain
+    #     shipped but unenabled, and NO local seed is baked (it would shadow the
+    #     cloud datasource).
+    #
+    # The login account is NOT provisioned by this BASE (see the commented
+    # systemConfig.users example near the top of systemConfig). MODE A turns on
+    # password SSH, but with cloud-init disabled nothing creates a user, so add
+    # one (a password hash or an authorized_keys file) or MODE A starts sshd with
+    # no way to log in.
+    # ==========================================================================
 
 # -----------------------------------------------------------------------------
 # All seven repositories are declared here, in ONE layer, and inherited intact by


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Mirror the Debian 13 BB overlay bring-up (cb138646) onto the Ubuntu 24.04 robotics hardware overlay. The Ubuntu cloud baseline relies on cloud-init to configure networking and SSH from a datasource at first boot; flashed to bare metal there is no datasource, so cloud-init never brings up DHCP or sshd.

Move the bring-up to BOOT via the same idempotent, mode-agnostic script (`bare-metal-bringup.sh`) delivered by `additionalFiles`: DHCP every wired NIC via systemd-networkd (`ClientIdentifier=mac`, `IPv6AcceptRA=no`) and generate PER-DEVICE SSH host keys, force password auth, start ssh.

The cloud-init policy is a single-line MODE toggle in `configurations`, replacing the old `systemctl enable ssh`:

- **MODE A (bare metal, default):** disable cloud-init at build, drop any baked SSH host keys, and enable `bare-metal-bringup.service` via a `multi-user.target.wants` symlink.
- **MODE B (cloud):** leave cloud-init enabled so it provisions from the cloud datasource; the script/unit ship but stay inert.

Also add a commented `systemConfig.users` login example (this BASE bakes no credential), annotate `openssh-server`, and add `efibootmgr` for EFI boot-order cleanup.

#### Any Newly Introduced Dependencies

None. `efibootmgr` is a standard distro package added for EFI boot-order cleanup.

#### How Has This Been Tested? <!-- REQUIRED -->

- **Build:** overlay builds clean; `additionalFiles` land at the expected paths and the MODE-A `configurations` steps run (cloud-init disabled, baked host keys dropped, `bare-metal-bringup.service` symlinked into `multi-user.target.wants`).
- **Bare metal:** flashed and confirmed MODE A is applied — `bare-metal-bringup.service` runs `status=0`, `20-baremetal-dhcp.network` is present, cloud-init is disabled. On a board whose NIC driver is in the base kernel, the NIC gets an IP and DHCP + SSH come up as expected.
