### PR TITLE
Use wildcard kernel packages in handheld template

### DIFF
--- a/image-templates/ubuntu24/generic-handheld-os-template.yml
+++ b/image-templates/ubuntu24/generic-handheld-os-template.yml
@@ -214,6 +214,7 @@ packageRepositories:
       - lbzip2
       - libglew-dev
       - libglm-dev
+      - libsdl2-dev
       - mc
       - openssl
       - pciutils
@@ -260,6 +261,8 @@ packageRepositories:
       - libswresample6
       - libswscale9
       - libweston-10-0
+      - xnest
+      - xvfb
       - dnsmasq-base
       # additional PTL packages
       - xdp-tools
@@ -510,6 +513,7 @@ systemConfig:
     - lbzip2
     - libglew-dev
     - libglm-dev
+    - libsdl2-dev
     - mc
     - openssl
     - pciutils
@@ -542,6 +546,8 @@ systemConfig:
     - usb-modeswitch
     - fwupd
     - clinfo
+    - xvfb
+    - xnest
     - mesa-vulkan-drivers
     - xdp-tools
     - rpc-go
@@ -596,12 +602,11 @@ systemConfig:
       final: /etc/netplan/01-network-manager-all.yaml
 
   kernel:
-    version: "260713t060441z-r2"
     cmdline: "xe.max_vfs=7 xe.force_probe=* modprobe.blacklist=i915 udmabuf.list_limit=8192 console=tty0 console=ttyS0,115200n8"
     enableExtraModules: "intel_vpu uas"
     packages:
-      - linux-image-6.18-intel*
-      - linux-headers-6.18-intel*
+        - linux-image-6.18-intel*
+        - linux-headers-6.18-intel*
 
   users:
     - name: user

--- a/image-templates/ubuntu24/generic-handheld-os-template.yml
+++ b/image-templates/ubuntu24/generic-handheld-os-template.yml
@@ -214,7 +214,6 @@ packageRepositories:
       - lbzip2
       - libglew-dev
       - libglm-dev
-      - libsdl2-dev
       - mc
       - openssl
       - pciutils
@@ -261,8 +260,6 @@ packageRepositories:
       - libswresample6
       - libswscale9
       - libweston-10-0
-      - xnest
-      - xvfb
       - dnsmasq-base
       # additional PTL packages
       - xdp-tools
@@ -513,7 +510,6 @@ systemConfig:
     - lbzip2
     - libglew-dev
     - libglm-dev
-    - libsdl2-dev
     - mc
     - openssl
     - pciutils
@@ -546,8 +542,6 @@ systemConfig:
     - usb-modeswitch
     - fwupd
     - clinfo
-    - xvfb
-    - xnest
     - mesa-vulkan-drivers
     - xdp-tools
     - rpc-go
@@ -602,12 +596,12 @@ systemConfig:
       final: /etc/netplan/01-network-manager-all.yaml
 
   kernel:
-    version: "260427t075939z-r2"
+    version: "260713t060441z-r2"
     cmdline: "xe.max_vfs=7 xe.force_probe=* modprobe.blacklist=i915 udmabuf.list_limit=8192 console=tty0 console=ttyS0,115200n8"
     enableExtraModules: "intel_vpu uas"
     packages:
-        - linux-image-6.18-intel_260427t075939z-r2
-        - linux-headers-6.18-intel_260427t075939z-r2
+      - linux-image-6.18-intel*
+      - linux-headers-6.18-intel*
 
   users:
     - name: user


### PR DESCRIPTION
## Change

Update `image-templates/ubuntu24/generic-handheld-os-template.yml` to use wildcard kernel package requests:

- Replace `linux-image-6.18-intel_260427t075939z-r2` with `linux-image-6.18-intel*`.
- Replace `linux-headers-6.18-intel_260427t075939z-r2` with `linux-headers-6.18-intel*`.
- Remove the fixed `kernel.version` value.

This allows the template to select the matching current kernel package revision from the configured repository. No other files are changed.