### PR TITLE
fix(web): bump postcss and nanoid to address known CVEs

### DIFF
--- a/internal/webui/dist/index.html
+++ b/internal/webui/dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Image Composer Tool</title>
-    <script type="module" crossorigin src="/assets/index-BKvsTCfU.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BlCAWY-a.css">
+    <script type="module" crossorigin src="/assets/index-D490fHBD.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-VeNX-KOQ.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2158,9 +2158,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2207,9 +2207,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2227,7 +2227,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
#### Merge Checklist

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description

Manually bumps two transitive npm dependencies in `web/` to fix known CVEs, since the repository's Dependabot config only covers `gomod` and `github-actions` ecosystems (no `npm` entry exists yet for `web/`).

| Package | Before | After | Advisories fixed |
|---|---|---|---|
| `postcss` | 8.5.16 | 8.5.26 | GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp |
| `nanoid` | 3.3.15 | 3.3.18 | GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 |

Changes:
- `web/package-lock.json`: updated via `npm audit fix` (0 vulnerabilities remaining per `npm audit`)
- `internal/webui/dist/index.html`: regenerated placeholder reflecting the new build hashes (per `internal/webui/.gitignore`, only this file is tracked; `dist/assets/` remains gitignored build output)

No user-facing behavior changed; no docs updates needed beyond this description. Follow-up (tracked separately, not in this PR): add an `npm` ecosystem block to `.github/dependabot.yml` for `web/` so future frontend CVEs are caught automatically.

#### Any Newly Introduced Dependencies

None. Both `postcss` and `nanoid` are pre-existing transitive dependencies (pulled in via Vite/Tailwind tooling); this PR only bumps their pinned versions in `web/package-lock.json`.

#### How Has This Been Tested?

- `npm audit` in `web/` reports 0 vulnerabilities after the bump (previously 2 high severity)
- `npx tsc --noEmit` -  clean
- `npm run build` - succeeds
- Rebuilt the embedded UI bundle (`internal/webui/dist`) and the `image-composer-tool` binary, ran `serve`, and verified in a browser that the web UI loads and the Basic config flow renders and works correctly
