### PR TITLE
fix: use GA kernel in DKMS template to avoid kernel 7.x incompatibility

### DIFF
--- a/image-templates/ubuntu24/ubuntu24-x86_64-dkms-demo.yml
+++ b/image-templates/ubuntu24/ubuntu24-x86_64-dkms-demo.yml
@@ -97,5 +97,5 @@ systemConfig:
   kernel:
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
-      - linux-image-generic-hwe-24.04
-      - linux-headers-generic-hwe-24.04
+      - linux-image-generic
+      - linux-headers-generic


### PR DESCRIPTION
Updates the DKMS `ubuntu24-x86_64-dkms-demo.yml`
to use `linux-image-generic` (GA kernel, 6.8.x on Ubuntu 24.04 noble) instead of `linux-image-generic-hwe-24.04`.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [ ] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->