### PR TITLE
fix(image-templates): use split Intel firmware packages for debian13 graphics

### DIFF
--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -14,6 +14,8 @@
 
 **Fixed**
 
+- Debian 13 Bayonne Bridge templates shipped the old monolithic `firmware-linux(-free)`/`firmware-misc-nonfree` packages, so real hardware failed to load the iGPU's GuC firmware at boot (`i915: GuC firmware ... fetch failed -ENOENT`, wedging the GPU) and the graphics child template was missing `firmware-sof-signed`, so SOF audio DSP firmware also failed to load (`failed to load intel/sof-ipc4/arl/sof-arl.ri`, no audio). The overlay base now installs Trixie's split Intel firmware packages (`firmware-intel-graphics`, `firmware-intel-misc`, `firmware-iwlwifi`) matching every other debian13 template, and the graphics child adds `firmware-sof-signed`.
+
 - Attended installer TUI froze on the very first "Next"/"Go Back"/Ctrl+C press: page navigation and the exit-confirmation prompt called `tview`'s `QueueUpdateDraw` synchronously from within the UI's own event-loop goroutine, which deadlocks since that call blocks waiting for the same goroutine to service it. Navigation now runs directly and synchronously, since it's already invoked from that goroutine.
 
 ## Version 2026.1

--- a/image-templates/debian13/debian13-x86_64-bb-graphics-raw.yml
+++ b/image-templates/debian13/debian13-x86_64-bb-graphics-raw.yml
@@ -52,7 +52,7 @@ extends: "debian13-x86_64-bb-overlay-initrd-raw.yml"
 
 image:
   name: debian13-bb-graphics
-  version: "13.0.1"
+  version: "13.0.2"
 
 target:                 # must match the parent template's target
   os: debian
@@ -67,8 +67,9 @@ systemConfig:
   # ---------------------------------------------------------------------------
   # Graphics packages — merged ADDITIVELY on top of the base. Enough of an
   # X/Mesa stack to run GUI desktop apps: xserver-xorg pulls the video drivers,
-  # Mesa provides GL/Vulkan, fonts + GTK cover rendering, and firmware-* covers
-  # common GPUs (loaded by the base's custom initrd, which is regenerated there).
+  # Mesa provides GL/Vulkan, fonts + GTK cover rendering, and firmware-sof-signed
+  # covers the audio DSP firmware the base's Intel GPU firmware packages don't
+  # include (GPU firmware itself comes from the base's firmware-intel-graphics).
   #
   # Do NOT add a `baseline:` or `overlayPolicy:` block here — inheriting them
   # from the parent is what keeps these packages ADDITIVE to the base.
@@ -89,9 +90,11 @@ systemConfig:
     # Fonts + rendering so GUI apps display correctly
     - fonts-dejavu-core
     - libgtk-3-0
-    # GPU firmware the graphics stack / initrd may load at boot
-    - firmware-linux
-    - firmware-misc-nonfree
+    # GPU firmware is provided by the base's firmware-intel-graphics /
+    # firmware-intel-misc packages. Audio DSP firmware (e.g. SOF firmware for
+    # Meteor Lake/Arrow Lake, intel/sof-ipc4/arl/sof-arl.ri) ships in a separate
+    # package the base does not need, so add it here for the desktop's audio.
+    - firmware-sof-signed
     # Display manager + GNOME session — turns the backend X/Mesa stack into a
     # graphical login. gdm3 is the GNOME Display Manager; gnome-session provides
     # the session gdm launches; gnome-shell is that session's compositor and is

--- a/image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml
+++ b/image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml
@@ -77,7 +77,7 @@ metadata:
 
 image:
   name: debian13-bb-overlay-base
-  version: "13.0.1"
+  version: "13.0.2"
 
 target:
   os: debian
@@ -221,18 +221,25 @@ systemConfig:
     - lshw
     - lsof
     - strace
-    # Firmware the base / initrd may load at boot
-    - firmware-linux-free
-    - firmware-misc-nonfree
+    # Firmware the base / initrd may load at boot. firmware-linux-free /
+    # firmware-misc-nonfree are the old monolithic packages; trixie splits Intel
+    # firmware out into these dedicated packages (same set the
+    # image-templates/debian13-x86_64-bb-raw.yml / bb-dracut-raw.yml templates use)
+    # — without firmware-intel-graphics the iGPU's GuC/HuC firmware (e.g.
+    # i915/mtl_guc_*.bin on Meteor Lake/Arrow Lake) is missing on real hardware,
+    # wedging the GPU.
+    - firmware-intel-graphics
+    - firmware-intel-misc
+    - firmware-iwlwifi
 
   # ---------------------------------------------------------------------------
   # Custom dracut module (91hello) for Bayonne Bridge early-boot requirements.
   #
-  # These are the SAME module files the create-mode sibling
-  # debian13-x86_64-bb-dracut-raw.yml uses, dropped into the dracut module tree
-  # at /usr/lib/dracut/modules.d/91hello. Overlay now applies additionalFiles, so
-  # the module is delivered declaratively rather than via base64-encoded config
-  # commands as before.
+  # These are the SAME module files the create-mode
+  # image-templates/debian13-x86_64-bb-dracut-raw.yml uses, dropped into the
+  # dracut module tree at /usr/lib/dracut/modules.d/91hello. Overlay now applies
+  # additionalFiles, so the module is delivered declaratively rather than via
+  # base64-encoded config commands as before.
   #
   # stage: pre-initramfs is REQUIRED. It copies these files BEFORE the overlay's
   # Boot Regeneration stage runs, so the module is present in the dracut tree when


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

The Debian 13 Bayonne Bridge overlay base
(`image-templates/debian13/debian13-x86_64-bb-overlay-initrd-raw.yml`) and its
graphics child template (`debian13-x86_64-bb-graphics-raw.yml`) installed the
old monolithic `firmware-linux(-free)`/`firmware-misc-nonfree` packages.
Trixie splits Intel platform firmware into dedicated packages
(`firmware-intel-graphics`, `firmware-intel-misc`, `firmware-iwlwifi`), which
every other debian13 template in this repo already uses. Without
`firmware-intel-graphics`, real hardware failed to load the iGPU's GuC
firmware at boot (`i915: GuC firmware ... fetch failed -ENOENT`), leaving the
GPU wedged.

The graphics child template was also missing `firmware-sof-signed`, the
separate package that ships SOF audio DSP firmware, causing `failed to load
intel/sof-ipc4/arl/sof-arl.ri` and no audio.

This PR switches the base to the split Intel firmware packages and adds
`firmware-sof-signed` to the graphics child, matching the naming convention
already used by the other debian13 templates and the default ISO config. Both
templates' `image.version` is bumped `13.0.1` -> `13.0.2` since this changes
the generated image's package set for downstream consumers, and a
`docs/user-guide/release-notes.md` entry documents the fix.

#### Any Newly Introduced Dependencies

None — `firmware-intel-graphics`, `firmware-intel-misc`, `firmware-iwlwifi`,
and `firmware-sof-signed` are all Debian packages already available from the
`non-free-firmware` component the trixie repo config enables
(`config/osv/debian/debian13/imageconfigs/additionalfiles/debian-trixie.list`).

#### How Has This Been Tested? <!-- REQUIRED -->

- `./image-composer-tool validate` on both edited templates — passes.
- `./image-composer-tool resolve image-templates/debian13/debian13-x86_64-bb-graphics-raw.yml`
  — confirms the merged package list contains `firmware-intel-graphics`,
  `firmware-intel-misc`, `firmware-iwlwifi`, `firmware-sof-signed` and no
  leftover `firmware-linux`/`firmware-misc-nonfree` entries, and that
  `image.version` resolves to `13.0.2`.
- Root-caused against a real boot log from hardware built with the previous
  template, which showed the exact `mtl_guc_70.bin fetch failed -ENOENT` and
  `sof-arl.ri (-2)` failures this change fixes.

