### PR TITLE
fix(imageos): skip systemd-networkd auto-enable for cloud-init images

### DIFF
--- a/docs/user-guide/release-notes.md
+++ b/docs/user-guide/release-notes.md
@@ -157,6 +157,10 @@
 
 - `fix(imagedisc)`: bound sfdisk calls and detach stale loop devices before reattach: `createPartitionTable`'s `sfdisk` calls had no execution timeout, so a wedged `sfdisk` (e.g. blocked behind a stale loop-device handle from a hard-killed prior build) could hang a build indefinitely. Both `sfdisk` invocations are now bounded to a 30s context so a hang fails fast into the existing retry-with-force path instead of blocking forever. Loop-device attach is also now idempotent: before `losetup`, any existing loop device already bound to the same backing file (including one whose backing file was since deleted) is detached first, removing the actual trigger that could wedge the kernel's partition-table re-read on a freshly attached device.
 
+- Ubuntu cloud-init images fought systemd-networkd for interface ownership at first boot: `updateImageNetwork()` unconditionally ran `systemctl enable systemd-networkd` whenever the unit was present and no `network.backend` was configured, even for images that install `cloud-init` and rely on it to own network rendering. Combined with the OS-default `dhcp.network` drop-in every Ubuntu ISO build inherits, this left a statically-DHCP-configured `systemd-networkd` racing cloud-init for the interface, leaving `/etc/netplan` unpopulated. The auto-enable is now skipped when `cloud-init` is among the installed packages (matched literally, version-pinned, or via a glob such as `cloud-init*`) and no explicit `network.backend` is set; behavior for images that don't install cloud-init is unchanged.
+
+- Attended installer TUI froze on the very first "Next"/"Go Back"/Ctrl+C press: page navigation and the exit-confirmation prompt called `tview`'s `QueueUpdateDraw` synchronously from within the UI's own event-loop goroutine, which deadlocks since that call blocks waiting for the same goroutine to service it. Navigation now runs directly and synchronously, since it's already invoked from that goroutine.
+
 **Known Issues**:
 
 - **Custom partition layouts with the overlay feature are not supported**:

--- a/internal/image/imageos/imageos.go
+++ b/internal/image/imageos/imageos.go
@@ -1178,6 +1178,19 @@ func updateImageNetwork(installRoot string, template *config.ImageTemplate) erro
 		return nil
 	}
 
+	// cloud-init owns network configuration (via its own netplan/networkd
+	// renderer stage) when installed and no explicit backend is configured
+	// here. Auto-enabling systemd-networkd in that case races cloud-init for
+	// the interface at boot and can leave /etc/netplan empty. cloud-init may
+	// be requested directly or pulled in transitively by a meta-package (e.g.
+	// ubuntu-cloud-minimal), so template.SystemConfig.Packages alone is not
+	// sufficient — also check the installed root for cloud-init's executable.
+	if template.SystemConfig.Network.Backend == "" &&
+		(hasPackage(template.SystemConfig.Packages, "cloud-init") || cloudInitInstalled(installRoot)) {
+		log.Debugf("cloud-init is installed and no network backend is configured; skipping systemd-networkd auto-enable")
+		return nil
+	}
+
 	unitFilePath := filepath.Join(installRoot, "lib", "systemd", "system", "systemd-networkd.service")
 	if _, err := os.Stat(unitFilePath); os.IsNotExist(err) {
 		log.Warnf("systemd-networkd is not installed in %s, skipping enable", installRoot)
@@ -1188,6 +1201,35 @@ func updateImageNetwork(installRoot string, template *config.ImageTemplate) erro
 		return fmt.Errorf("failed to enable systemd-networkd: %w", err)
 	}
 	return nil
+}
+
+// hasPackage reports whether name appears in pkgs, ignoring any pinned
+// version suffix (e.g. "cloud-init" matches both "cloud-init" and
+// "cloud-init_24.4-0ubuntu1") and matching glob entries (e.g. "cloud-init*").
+func hasPackage(pkgs []string, name string) bool {
+	for _, pkg := range pkgs {
+		base, _, _ := strings.Cut(strings.TrimSpace(pkg), "_")
+		if base == name {
+			return true
+		}
+		if ok, err := filepath.Match(base, name); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// cloudInitInstalled reports whether cloud-init's own executable is present
+// under installRoot, which is true whenever the cloud-init package ends up
+// installed — including when it arrives transitively through a meta-package
+// dependency that template.SystemConfig.Packages does not list directly.
+// This checks the installed executable rather than a config path such as
+// /etc/cloud/cloud.cfg, since some default configs (e.g. EMT3's
+// default-raw-x86_64.yml) drop a cloud-init config file via additionalFiles
+// on images that never install the cloud-init package.
+func cloudInitInstalled(installRoot string) bool {
+	_, err := os.Stat(filepath.Join(installRoot, "usr", "bin", "cloud-init"))
+	return err == nil
 }
 
 func addImageIDFile(installRoot string, template *config.ImageTemplate) error {

--- a/internal/image/imageos/imageos_test.go
+++ b/internal/image/imageos/imageos_test.go
@@ -1345,6 +1345,206 @@ func TestUpdateImageNetwork(t *testing.T) {
 	}
 }
 
+// TestHasPackage covers exact and version-pinned package name matching.
+func TestHasPackage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pkgs     []string
+		target   string
+		expected bool
+	}{
+		{"exact match", []string{"curl", "cloud-init"}, "cloud-init", true},
+		{"version pinned match", []string{"cloud-init_24.4-0ubuntu1"}, "cloud-init", true},
+		{"no match", []string{"curl", "wget"}, "cloud-init", false},
+		{"empty list", nil, "cloud-init", false},
+		{"prefix is not a match", []string{"cloud-init-extra"}, "cloud-init", false},
+		{"glob match", []string{"cloud-init*"}, "cloud-init", true},
+		{"glob no match", []string{"cloud-init*"}, "systemd", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPackage(tc.pkgs, tc.target); got != tc.expected {
+				t.Errorf("hasPackage(%v, %q) = %v, want %v", tc.pkgs, tc.target, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestUpdateImageNetworkSkipsSystemdNetworkdWithCloudInit verifies that
+// systemd-networkd is not auto-enabled when cloud-init is installed and no
+// explicit network backend is configured, since cloud-init owns network
+// configuration itself in that case.
+func TestUpdateImageNetworkSkipsSystemdNetworkdWithCloudInit(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	// Any systemctl enable call fails, so the test only passes if
+	// updateImageNetwork skips the call entirely for a cloud-init image.
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "systemctl enable.*systemd-networkd", Output: "", Error: fmt.Errorf("systemctl should not be called")},
+	})
+
+	installRoot := t.TempDir()
+	unitDir := filepath.Join(installRoot, "lib", "systemd", "system")
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatalf("failed to create systemd unit dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "systemd-networkd.service"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create systemd-networkd.service: %v", err)
+	}
+
+	template := createTestImageTemplate()
+	template.SystemConfig.Packages = []string{"cloud-init"}
+
+	if err := updateImageNetwork(installRoot, template); err != nil {
+		t.Errorf("updateImageNetwork should skip enabling systemd-networkd for a cloud-init image, got error: %v", err)
+	}
+}
+
+// TestUpdateImageNetworkEnablesSystemdNetworkdWithoutCloudInit verifies the
+// existing auto-enable behavior is unchanged for images that don't install
+// cloud-init.
+func TestUpdateImageNetworkEnablesSystemdNetworkdWithoutCloudInit(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	// Make the enable call fail with a sentinel error and assert it propagates,
+	// so the test actually proves the call was reached rather than merely
+	// tolerating both an invoked and a skipped call.
+	sentinelErr := fmt.Errorf("sentinel: systemctl enable was invoked")
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "systemctl enable.*systemd-networkd", Output: "", Error: sentinelErr},
+	})
+
+	installRoot := t.TempDir()
+	unitDir := filepath.Join(installRoot, "lib", "systemd", "system")
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatalf("failed to create systemd unit dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "systemd-networkd.service"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create systemd-networkd.service: %v", err)
+	}
+
+	template := createTestImageTemplate() // Packages do not include cloud-init.
+
+	err := updateImageNetwork(installRoot, template)
+	if err == nil || !strings.Contains(err.Error(), sentinelErr.Error()) {
+		t.Errorf("updateImageNetwork should still enable systemd-networkd when cloud-init is absent, got: %v", err)
+	}
+}
+
+// TestUpdateImageNetworkSkipsSystemdNetworkdWithTransitiveCloudInit verifies
+// that systemd-networkd auto-enable is skipped when cloud-init is installed
+// only transitively via a meta-package (e.g. ubuntu-cloud-minimal) that does
+// not appear literally in template.SystemConfig.Packages, by detecting
+// cloud-init's own executable in the installed root.
+func TestUpdateImageNetworkSkipsSystemdNetworkdWithTransitiveCloudInit(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "systemctl enable.*systemd-networkd", Output: "", Error: fmt.Errorf("systemctl should not be called")},
+	})
+
+	installRoot := t.TempDir()
+	unitDir := filepath.Join(installRoot, "lib", "systemd", "system")
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatalf("failed to create systemd unit dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "systemd-networkd.service"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create systemd-networkd.service: %v", err)
+	}
+
+	binDir := filepath.Join(installRoot, "usr", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("failed to create usr/bin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "cloud-init"), []byte(""), 0755); err != nil {
+		t.Fatalf("failed to create cloud-init executable: %v", err)
+	}
+
+	template := createTestImageTemplate()
+	// cloud-init is not listed directly; it arrives transitively via a
+	// meta-package such as ubuntu-cloud-minimal.
+	template.SystemConfig.Packages = []string{"ubuntu-cloud-minimal"}
+
+	if err := updateImageNetwork(installRoot, template); err != nil {
+		t.Errorf("updateImageNetwork should skip enabling systemd-networkd for a transitive cloud-init image, got error: %v", err)
+	}
+}
+
+// TestUpdateImageNetworkEnablesSystemdNetworkdWithCloudInitConfigFileOnly
+// verifies that a dropped /etc/cloud/cloud.cfg alone does not trigger the
+// skip: some default configs (e.g. EMT3's default-raw-x86_64.yml) copy a
+// cloud-init config file via additionalFiles on images that never install
+// the cloud-init package, and systemd-networkd must still be enabled there.
+func TestUpdateImageNetworkEnablesSystemdNetworkdWithCloudInitConfigFileOnly(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	sentinelErr := fmt.Errorf("sentinel: systemctl enable was invoked")
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "systemctl enable.*systemd-networkd", Output: "", Error: sentinelErr},
+	})
+
+	installRoot := t.TempDir()
+	unitDir := filepath.Join(installRoot, "lib", "systemd", "system")
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatalf("failed to create systemd unit dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "systemd-networkd.service"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create systemd-networkd.service: %v", err)
+	}
+
+	cloudDir := filepath.Join(installRoot, "etc", "cloud")
+	if err := os.MkdirAll(cloudDir, 0755); err != nil {
+		t.Fatalf("failed to create cloud-init config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cloudDir, "cloud.cfg"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create cloud.cfg: %v", err)
+	}
+
+	template := createTestImageTemplate() // Packages do not include cloud-init.
+
+	err := updateImageNetwork(installRoot, template)
+	if err == nil || !strings.Contains(err.Error(), sentinelErr.Error()) {
+		t.Errorf("updateImageNetwork should still enable systemd-networkd when only a config file is present without the cloud-init package, got: %v", err)
+	}
+}
+
+// TestUpdateImageNetworkEnablesSystemdNetworkdWithCloudInitAndExplicitBackend
+// verifies the cloud-init skip is limited to an unconfigured backend: with
+// cloud-init installed but an explicit "systemd-networkd" backend set, the
+// enable path must still be reached.
+func TestUpdateImageNetworkEnablesSystemdNetworkdWithCloudInitAndExplicitBackend(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	sentinelErr := fmt.Errorf("sentinel: systemctl enable was invoked")
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "systemctl enable.*systemd-networkd", Output: "", Error: sentinelErr},
+	})
+
+	installRoot := t.TempDir()
+	unitDir := filepath.Join(installRoot, "lib", "systemd", "system")
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		t.Fatalf("failed to create systemd unit dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unitDir, "systemd-networkd.service"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create systemd-networkd.service: %v", err)
+	}
+
+	template := createTestImageTemplate()
+	template.SystemConfig.Packages = []string{"cloud-init"}
+	template.SystemConfig.Network.Backend = "systemd-networkd"
+
+	err := updateImageNetwork(installRoot, template)
+	if err == nil || !strings.Contains(err.Error(), sentinelErr.Error()) {
+		t.Errorf("updateImageNetwork should still enable systemd-networkd when the backend is explicitly set, got: %v", err)
+	}
+}
+
 // TestPrepareVeritySetupValidation tests the validation logic in prepareVeritySetup
 func TestPrepareVeritySetupValidation(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

`updateImageNetwork()` unconditionally ran `systemctl enable systemd-networkd`
whenever the unit was present and no `netplan` backend was configured — even
for images that install `cloud-init` and never touch `systemConfig.network`
at all. Combined with the OS-default `dhcp.network` drop-in that every
Ubuntu ISO build inherits, this left a statically-DHCP-configured
`systemd-networkd` competing with cloud-init for interface ownership at
first boot on Ubuntu unattended-install images, leaving `/etc/netplan`
unpopulated.

Fix: skip the auto-enable when `cloud-init` is among the installed packages
and no explicit `network.backend` is set, since cloud-init already owns its
own network-rendering stage in that case. Behavior for images that don't
install cloud-init is unchanged.

`cloud-init` can also arrive transitively through a meta-package (e.g.
`ubuntu-cloud-minimal`, as in `ubuntu-minimal-cloud-amd64.yml`) that never
appears literally in `systemConfig.packages`. Since the installed root is
already fully populated by the time `updateImageNetwork` runs, the check
also looks for cloud-init's own executable (`usr/bin/cloud-init`) under
`installRoot`, so the skip applies whether cloud-init was requested directly
or pulled in as a dependency. The executable is checked rather than a config
path such as `/etc/cloud/cloud.cfg`, since some default configs (e.g. EMT3's
`default-raw-x86_64.yml`) drop a cloud-init config file via `additionalFiles`
on images that never install the cloud-init package.

Added a release-notes entry (`docs/user-guide/release-notes.md`) since this
changes first-boot networking behavior of generated images, even though the
CLI and template schema are unchanged.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

- `go build ./internal/... ./cmd/...` and `go vet ./internal/image/imageos/...` — clean.
- `gofmt -l` on both changed files — no output (already formatted).
- Added `TestHasPackage`, `TestUpdateImageNetworkSkipsSystemdNetworkdWithCloudInit`,
  `TestUpdateImageNetworkEnablesSystemdNetworkdWithoutCloudInit`,
  `TestUpdateImageNetworkSkipsSystemdNetworkdWithTransitiveCloudInit`,
  `TestUpdateImageNetworkEnablesSystemdNetworkdWithCloudInitConfigFileOnly`, and
  `TestUpdateImageNetworkEnablesSystemdNetworkdWithCloudInitAndExplicitBackend`.
  These mock `systemctl enable` with a sentinel error and assert whether it
  propagates, so each test actually proves the enable call was reached or
  skipped rather than just tolerating both outcomes — covering direct
  cloud-init packages, transitively-installed cloud-init (via the
  executable), cloud-init absent, a dropped config file without the
  cloud-init package/executable, and cloud-init with an explicit backend
  override.
- `go test ./internal/image/imageos/...` — all tests pass.