### PR TITLE
feat(debian13): add X11/GNOME graphics stack to bb-dracut-raw template

### DIFF
--- a/docs/user-guide/configuration/configure-custom-initrd-script.md
+++ b/docs/user-guide/configuration/configure-custom-initrd-script.md
@@ -126,7 +126,9 @@ Rename `debian13-bb` in `local` paths to match your folder name. Keep the `**fin
 If you want the same early-boot marker behavior using dracut modules instead of initramfs-tools hooks, use
 [debian13-x86_64-bb-dracut-raw.yml](https://github.com/open-edge-platform/image-composer-tool/blob/main/image-templates/debian13-x86_64-bb-dracut-raw.yml).
 
-This variant keeps the same Debian 13 + GRUB + raw image target but changes how content is added to initrd:
+This variant keeps the same Debian 13 + GRUB + raw image target but changes how content is added to initrd.
+The shipped template also layers on a GNOME/X11 desktop (GDM login) — the table below covers only the
+initrd-handling difference between the two routes, not the full package set.
 
 | Area | `debian13-x86_64-bb-raw.yml` (initramfs-tools) | `debian13-x86_64-bb-dracut-raw.yml` (dracut) |
 | ---- | ----------------------------------------------- | --------------------------------------------- |

--- a/image-templates/additionalfiles/debian13-bb-graphics-mutter/etc/dconf/db/local.d/00-mutter
+++ b/image-templates/additionalfiles/debian13-bb-graphics-mutter/etc/dconf/db/local.d/00-mutter
@@ -1,0 +1,11 @@
+# Debian 13's gnome-shell/mutter (48.x) enables 'scale-monitor-framebuffer' and
+# 'xwayland-native-scaling' by default. Both are experimental and have known
+# pointer/click coordinate-mapping bugs (cursor renders in one place, clicks
+# register elsewhere) for Xwayland-composited content — reproduced both under
+# QEMU and on real hardware. Disabling them reverts Mutter to its stable
+# pointer-mapping path. This template boots into the GNOME-on-Xorg session
+# instead (see gnome-xorg.desktop) — Debian 13 ships no X11 session launcher
+# of its own, so this template supplies one and disables Wayland at the GDM
+# level (WaylandEnable=false in /etc/gdm3/custom.conf).
+[org/gnome/mutter]
+experimental-features=@as []

--- a/image-templates/additionalfiles/debian13-bb-graphics-mutter/etc/dconf/profile/user
+++ b/image-templates/additionalfiles/debian13-bb-graphics-mutter/etc/dconf/profile/user
@@ -1,0 +1,2 @@
+user-db:user
+system-db:local

--- a/image-templates/additionalfiles/debian13-bb-graphics-mutter/etc/systemd/system/dconf-update-mutter.service
+++ b/image-templates/additionalfiles/debian13-bb-graphics-mutter/etc/systemd/system/dconf-update-mutter.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Compile dconf system database (disables buggy Mutter experimental features)
+ConditionPathExists=/etc/dconf/db/local.d/00-mutter
+# Order before gdm.service so the compiled db exists before any session starts.
+# Safe: this unit does not call back into gdm/graphical.target, so it cannot
+# form the kind of ordering cycle bare-metal-bringup.service hit with ssh.service.
+Before=gdm.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/dconf update
+
+[Install]
+WantedBy=multi-user.target

--- a/image-templates/additionalfiles/debian13-bb-graphics-x11/usr/share/xsessions/gnome-xorg.desktop
+++ b/image-templates/additionalfiles/debian13-bb-graphics-x11/usr/share/xsessions/gnome-xorg.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=GNOME on Xorg
+Comment=This session logs you into GNOME using Xorg instead of Wayland
+Exec=/usr/bin/gnome-session
+TryExec=/usr/bin/gnome-session
+Type=Application
+DesktopNames=GNOME;
+X-GDM-SessionRegisters=true

--- a/image-templates/debian13-x86_64-bb-dracut-raw.yml
+++ b/image-templates/debian13-x86_64-bb-dracut-raw.yml
@@ -1,9 +1,10 @@
 # AI-searchable metadata for template discovery
 metadata:
-  description: Debian 13 minimal raw image with initrd hello hook via dracut-core (GRUB)
+  description: Debian 13 raw image with initrd hello hook via dracut-core (GRUB) and a GNOME/X11 desktop
   use_cases:
     - Validating custom dracut module scripts on Debian GRUB raw images
     - Lightweight Debian with early-boot initrd marker
+    - Booting into a GNOME-on-Xorg desktop session (GDM login)
   keywords:
     - bb
     - dracut
@@ -13,6 +14,10 @@ metadata:
     - debian
     - grub
     - raw
+    - gnome
+    - x11
+    - gdm
+    - desktop
 
 image:
   name: bb-os-image-debian-dracut
@@ -115,6 +120,29 @@ systemConfig:
     - vim-tiny
     - whiptail
     - zstd
+    # ---------------------------------------------------------------------------
+    # X11 graphics stack. See the additionalFiles/configurations below for why
+    # X11 (not Wayland) — Debian 13's gnome-session ships no X11 session file,
+    # so gnome-xorg.desktop below supplies the missing launcher rather than a
+    # package providing it.
+    # ---------------------------------------------------------------------------
+    - xserver-xorg
+    - xserver-xorg-video-all
+    - xserver-xorg-input-all
+    - xinit
+    - x11-xserver-utils
+    - x11-utils
+    - libgl1-mesa-dri
+    - libglx-mesa0
+    - mesa-utils
+    - mesa-vulkan-drivers
+    - fonts-dejavu-core
+    - libgtk-3-0
+    - gdm3
+    - gnome-session
+    - gnome-shell
+    - gnome-terminal
+    - gnome-software
 
   additionalFiles:
     - local: additionalfiles/debian13-bb-dracut/modules.d/91hello/module-setup.sh
@@ -123,12 +151,37 @@ systemConfig:
       final: /usr/lib/dracut/modules.d/91hello/hello.sh
     - local: additionalfiles/debian13-bb-dracut/modules.d/91hello/initqueue-sample.sh
       final: /usr/lib/dracut/modules.d/91hello/initqueue-sample.sh
+    # X11, not Wayland — Debian 13's gnome-session ships Wayland-only;
+    # gnome-shell's X11 backend still works, it's just missing the xsessions
+    # launcher, supplied below. The dconf override below also disables a
+    # known Mutter click-coordinate-mapping bug (see 00-mutter for detail).
+    - local: additionalfiles/debian13-bb-graphics-x11/usr/share/xsessions/gnome-xorg.desktop
+      final: /usr/share/xsessions/gnome-xorg.desktop
+    - local: additionalfiles/debian13-bb-graphics-mutter/etc/dconf/profile/user
+      final: /etc/dconf/profile/user
+    - local: additionalfiles/debian13-bb-graphics-mutter/etc/dconf/db/local.d/00-mutter
+      final: /etc/dconf/db/local.d/00-mutter
+    - local: additionalfiles/debian13-bb-graphics-mutter/etc/systemd/system/dconf-update-mutter.service
+      final: /etc/systemd/system/dconf-update-mutter.service
 
   configurations:
     - cmd: 'mkdir -p /etc/dracut.conf.d && echo ''add_dracutmodules+=" hello "'' > /etc/dracut.conf.d/91hello.conf'
     - cmd: "chmod 755 /usr/lib/dracut/modules.d/91hello/module-setup.sh /usr/lib/dracut/modules.d/91hello/hello.sh /usr/lib/dracut/modules.d/91hello/initqueue-sample.sh"
     - cmd: "printf 'Package: systemd-boot systemd-boot-efi\\nPin: release *\\nPin-Priority: -1\\n' > /etc/apt/preferences.d/no-systemd-boot"
     - cmd: "dpkg --purge --force-all systemd-boot systemd-boot-efi 2>/dev/null || true"
+    # Graphical login: gdm3 is WantedBy=graphical.target, so the default target
+    # must switch from multi-user.target or gdm never starts.
+    - cmd: 'systemctl set-default graphical.target'
+    - cmd: 'systemctl enable gdm3'
+    # Force GDM to X11-only via its own conffile toggle, not by deleting
+    # gnome-session's Wayland .desktop files: those are plain package data,
+    # so unattended-upgrades could restore them on a later gnome-session
+    # upgrade, but /etc/gdm3/daemon.conf is a dpkg conffile and this edit
+    # survives that upgrade. (Debian 13's gdm3 48.0-2 renamed the old
+    # custom.conf to daemon.conf.)
+    - cmd: "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm3/daemon.conf"
+    # Enable the first-boot dconf compile unit delivered by additionalFiles above.
+    - cmd: 'systemctl enable dconf-update-mutter.service'
 
   kernel:
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 rd.debug rd.info"


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

Debian 13's `gnome-session` ships Wayland-only, but `gnome-shell`'s X11 backend
still works — it's just missing the xsessions launcher, which this PR
supplies. Mutter also enables `scale-monitor-framebuffer` and
`xwayland-native-scaling` by default, both experimental and known to cause a
click-coordinate-mapping bug (cursor renders in one place, clicks register
elsewhere) under Xwayland-composited content; reproduced under QEMU and on
real hardware.

Changes to `debian13-x86_64-bb-dracut-raw.yml`:

- Adds the X11/GNOME package set (`xserver-xorg`, `gdm3`, `gnome-session`,
  `gnome-shell`, mesa/GL drivers, etc.).
- Adds `gnome-xorg.desktop` to supply the missing X11 session launcher.
- Adds a dconf override (`00-mutter`) disabling the buggy Mutter experimental
  features, applied via a `dconf-update-mutter.service` unit ordered before
  `gdm.service`.
- Switches the default target to `graphical.target` and enables `gdm3`.
- Disables Wayland at the GDM level (`WaylandEnable=false` in the
  `/etc/gdm3/custom.conf` conffile) so only the X11 session is offered, and
  the setting survives a later `gnome-session` package upgrade.

#### Any Newly Introduced Dependencies

None — no new Go/build-time dependencies. The added packages
(`xserver-xorg`, `gnome-session`, `gdm3`, mesa drivers, etc.) are standard
Debian archive packages installed into the built image, not dependencies of
image-composer-tool itself.

#### How Has This Been Tested? <!-- REQUIRED -->

Built the `debian13-x86_64-bb-dracut-raw` image and booted it; verified the
"GNOME on Xorg" session logs in and that pointer clicks register at the
correct coordinates with the Mutter experimental-features override applied.